### PR TITLE
Updated single patch file for binutils 2.40 AmigaOS4

### DIFF
--- a/binutils/2.40/patches/0001-Changes-for-compiling-for-AmigaOS-4-using-clib4.patch
+++ b/binutils/2.40/patches/0001-Changes-for-compiling-for-AmigaOS-4-using-clib4.patch
@@ -1,253 +1,248 @@
-From 063184c10762d5b798671bb49a55cf2308b3c134 Mon Sep 17 00:00:00 2001
-From: Georgios Sokianos <walkero@gmail.com>
-Date: Fri, 29 Nov 2024 19:58:52 +0000
-Subject: [PATCH] Changes for compiling for AmigaOS 4 using clib4
+From 34db58af31ba7bbf20f765341fe6c7a53a5aff91 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Tue, 10 Jan 2023 11:44:25 +0100
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 01/61] 
+ Update VS Code devcontainer files
 
 ---
- .gitignore                            |   10 +
- bfd/Makefile.am                       |    4 +-
- bfd/Makefile.in                       |    5 +-
- bfd/bfd-in2.h                         |    6 +
- bfd/config.bfd                        |    4 +
- bfd/configure                         |    3 +-
- bfd/configure.ac                      |    1 +
- bfd/{cpu-bfin.c => elf-amigaos.c}     |   44 +-
- bfd/{elf-nacl.h => elf-amigaos.h}     |   11 +-
- bfd/elf-bfd.h                         |    3 +-
- bfd/elf32-ppc.c                       |  247 +++++-
- bfd/elflink.c                         |    2 +
- bfd/libbfd.h                          |    4 +
- bfd/po/SRC-POTFILES.in                |    2 +
- bfd/reloc.c                           |   10 +-
- bfd/targets.c                         |    2 +
- binutils/elfcomm.c                    |   12 +
- binutils/objcopy.c                    |   79 +-
- binutils/readelf.c                    |    4 +
- binutils/version.c                    |   13 +
- config.sub                            |   10 +-
- elfcpp/powerpc.h                      |    6 +
- gas/Makefile.am                       |    1 +
- gas/Makefile.in                       |    1 +
- gas/config/tc-ppc.c                   |   26 +-
- gas/config/te-amigaos.h               |   14 +
- gas/configure.tgt                     |    1 +
- gas/doc/.dirstamp                     |    0
- gas/po/POTFILES.in                    |    1 +
- gdb/Makefile.in                       |    2 +
- gdb/auto-load.c                       |    5 +
- gdb/configure.host                    |    1 +
- gdb/configure.nat                     |    8 +
- gdb/configure.tgt                     |    7 +
- gdb/defs.h                            |    3 +
- gdb/dwarf2/read.c                     |   16 +-
- gdb/filesystem.c                      |   11 +-
- gdb/filesystem.h                      |    4 +
- gdb/gdbarch-gen.h                     |    7 +
- gdb/gdbarch.c                         |   26 +
- gdb/osabi.c                           |   21 +
- gdb/osabi.h                           |    1 +
- gdb/ppc-amigaos-nat.c                 | 1122 +++++++++++++++++++++++++
- gdb/ppc-amigaos-nat.h                 |   81 ++
- gdb/ppc-amigaos-tdep.c                |  153 ++++
- gdb/source.c                          |    6 +-
- gdbsupport/common-defs.h              |    1 +
- gdbsupport/common-inferior.cc         |    5 +
- gdbsupport/host-defs.h                |    7 +
- gdbsupport/pathstuff.cc               |   19 +-
- gnulib/configure                      |    4 +
- gnulib/import/m4/getcwd-path-max.m4   |    2 +
- gnulib/import/m4/getcwd.m4            |    2 +
- gnulib/import/sys_time.in.h           |    2 +
- include/elf/amigaos.h                 |   27 +
- include/elf/ppc.h                     |    6 +
- include/filenames.h                   |   18 +
- include/libiberty.h                   |    5 +
- ld/Makefile.am                        |    2 +
- ld/Makefile.in                        |    2 +
- ld/configure.tgt                      |    8 +
- ld/emulparams/amigaos.sh              |   31 +
- ld/ldctor.c                           |   23 +-
- ld/ldlang.c                           |    7 +
- ld/ldmain.c                           |    7 +-
- ld/po/BLD-POTFILES.in                 |    2 +
- ld/scripttempl/{elf.sc => amigaos.sc} |    4 +-
- libiberty/Makefile.in                 |   14 +-
- libiberty/configure                   |    1 +
- libiberty/configure.ac                |    1 +
- libiberty/fnmatch.c                   |    6 +-
- libiberty/lbasename.c                 |   20 +
- libiberty/make-temp-file.c            |    2 +
- libiberty/pex-amigaos.c               |  325 +++++++
- readline/readline/bind.c              |   10 +-
- readline/readline/input.c             |    6 +-
- readline/readline/readline.c          |   11 +
- readline/readline/rldefs.h            |    9 +-
- readline/readline/rltty.h             |    7 +-
- readline/readline/shell.c             |   13 +-
- readline/readline/terminal.c          |   10 +-
- readline/readline/text.c              |    6 +-
- 82 files changed, 2536 insertions(+), 89 deletions(-)
- copy bfd/{cpu-bfin.c => elf-amigaos.c} (51%)
- copy bfd/{elf-nacl.h => elf-amigaos.h} (73%)
- create mode 100644 gas/config/te-amigaos.h
- delete mode 100644 gas/doc/.dirstamp
- create mode 100644 gdb/ppc-amigaos-nat.c
- create mode 100644 gdb/ppc-amigaos-nat.h
- create mode 100644 gdb/ppc-amigaos-tdep.c
- create mode 100644 include/elf/amigaos.h
- create mode 100644 ld/emulparams/amigaos.sh
- copy ld/scripttempl/{elf.sc => amigaos.sc} (99%)
- create mode 100644 libiberty/pex-amigaos.c
+ .devcontainer/Dockerfile         | 46 +++++++++++++++++++++++++
+ .devcontainer/devcontainer.json  | 39 +++++++++++++++++++++
+ .devcontainer/reinstall-cmake.sh | 59 ++++++++++++++++++++++++++++++++
+ .gitignore                       |  1 +
+ 4 files changed, 145 insertions(+)
+ create mode 100644 .devcontainer/Dockerfile
+ create mode 100644 .devcontainer/devcontainer.json
+ create mode 100644 .devcontainer/reinstall-cmake.sh
 
+diff --git a/.devcontainer/Dockerfile b/.devcontainer/Dockerfile
+new file mode 100644
+index 00000000000..d1537d3313d
+--- /dev/null
++++ b/.devcontainer/Dockerfile
+@@ -0,0 +1,46 @@
++# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.0/containers/cpp/.devcontainer/base.Dockerfile
++
++# [Choice] Debian / Ubuntu version (use Debian 11, Ubuntu 18.04/22.04 on local arm64/Apple Silicon): debian-11, debian-10, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
++ARG VARIANT="bullseye"
++FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
++
++# [Optional] Install CMake version different from what base image has already installed. 
++# CMake reinstall choices: none, 3.21.5, 3.22.2, or versions from https://cmake.org/download/
++ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="none"
++
++# Optionally install the cmake for vcpkg
++COPY ./reinstall-cmake.sh /tmp/
++RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
++        chmod +x /tmp/reinstall-cmake.sh && /tmp/reinstall-cmake.sh ${REINSTALL_CMAKE_VERSION_FROM_SOURCE}; \
++    fi \
++    && rm -f /tmp/reinstall-cmake.sh
++
++# [Optional] Uncomment this section to install additional vcpkg ports.
++# RUN su vscode -c "${VCPKG_ROOT}/vcpkg install <your-port-name-here>"
++
++# [Optional] Uncomment this section to install additional packages.
++RUN dpkg --add-architecture i386 && apt-get update && apt-get -y --no-install-recommends install \
++    ca-certificates \
++    curl \
++    python2.7 \
++    bison;
++
++RUN ln -s /usr/bin/python2.7 /usr/bin/python; \
++    curl -fsSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o /tmp/get-pip.py && \
++    python get-pip.py && \
++    pip2 install --no-cache-dir argcomplete==1.12.3; \
++    rm -rf /tmp/* /var/tmp/*;
++
++RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
++    && apt-get -y install --no-install-recommends autoconf automake texinfo libgmp-dev libmpfr-dev libmpc-dev libisl-dev flex
++
++WORKDIR /tmp
++
++RUN git clone https://github.com/jca02266/lha.git && \
++    mkdir build && \
++    cd lha || exit && \
++    autoreconf -vfi && \
++    cd ../build && \
++    ../lha/configure --prefix=/usr && \
++    make && \
++    make install;
+\ No newline at end of file
+diff --git a/.devcontainer/devcontainer.json b/.devcontainer/devcontainer.json
+new file mode 100644
+index 00000000000..f1fcdc9776c
+--- /dev/null
++++ b/.devcontainer/devcontainer.json
+@@ -0,0 +1,39 @@
++// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
++// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.0/containers/cpp
++{
++	"name": "C++",
++	"build": {
++		"dockerfile": "Dockerfile",
++		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
++		// Use Debian 11, Ubuntu 18.04 or Ubuntu 22.04 on local arm64/Apple Silicon
++		"args": { "VARIANT": "debian-11" }
++	},
++	"runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
++
++	// Configure tool-specific properties.
++	"customizations": {
++		// Configure properties specific to VS Code.
++		"vscode": {
++			// Add the IDs of extensions you want installed when the container is created.
++			"extensions": [
++				"ms-vscode.cpptools",
++				"ms-vscode.cmake-tools",
++				"davidanson.vscode-markdownlint",
++				"caponetto.vscode-diff-viewer"
++			]
++		}
++	},
++
++	// Use 'forwardPorts' to make a list of ports inside the container available locally.
++	// "forwardPorts": [],
++
++	// Use 'postCreateCommand' to run commands after the container is created.
++	// "postCreateCommand": "gcc -v",
++
++	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
++	"remoteUser": "vscode",
++	"features": {
++		"git": "latest",
++		"git-lfs": "latest"
++	}
++}
+diff --git a/.devcontainer/reinstall-cmake.sh b/.devcontainer/reinstall-cmake.sh
+new file mode 100644
+index 00000000000..51cd9371296
+--- /dev/null
++++ b/.devcontainer/reinstall-cmake.sh
+@@ -0,0 +1,59 @@
++#!/usr/bin/env bash
++#-------------------------------------------------------------------------------------------------------------
++# Copyright (c) Microsoft Corporation. All rights reserved.
++# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
++#-------------------------------------------------------------------------------------------------------------
++#
++set -e
++
++CMAKE_VERSION=${1:-"none"}
++
++if [ "${CMAKE_VERSION}" = "none" ]; then
++    echo "No CMake version specified, skipping CMake reinstallation"
++    exit 0
++fi
++
++# Cleanup temporary directory and associated files when exiting the script.
++cleanup() {
++    EXIT_CODE=$?
++    set +e
++    if [[ -n "${TMP_DIR}" ]]; then
++        echo "Executing cleanup of tmp files"
++        rm -Rf "${TMP_DIR}"
++    fi
++    exit $EXIT_CODE
++}
++trap cleanup EXIT
++
++
++echo "Installing CMake..."
++apt-get -y purge --auto-remove cmake
++mkdir -p /opt/cmake
++
++architecture=$(dpkg --print-architecture)
++case "${architecture}" in
++    arm64)
++        ARCH=aarch64 ;;
++    amd64)
++        ARCH=x86_64 ;;
++    *)
++        echo "Unsupported architecture ${architecture}."
++        exit 1
++        ;;
++esac
++
++CMAKE_BINARY_NAME="cmake-${CMAKE_VERSION}-linux-${ARCH}.sh"
++CMAKE_CHECKSUM_NAME="cmake-${CMAKE_VERSION}-SHA-256.txt"
++TMP_DIR=$(mktemp -d -t cmake-XXXXXXXXXX)
++
++echo "${TMP_DIR}"
++cd "${TMP_DIR}"
++
++curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_BINARY_NAME}" -O
++curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_CHECKSUM_NAME}" -O
++
++sha256sum -c --ignore-missing "${CMAKE_CHECKSUM_NAME}"
++sh "${TMP_DIR}/${CMAKE_BINARY_NAME}" --prefix=/opt/cmake --skip-license
++
++ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
++
 diff --git a/.gitignore b/.gitignore
-index d44f60295d079e2481c5949aeede221f5c731ccd..d1fafcda72d24b7ae658866cae8ff4689bba224d 100644
+index d44f60295d0..719c72e2d10 100644
 --- a/.gitignore
 +++ b/.gitignore
-@@ -1,11 +1,18 @@
+@@ -1,3 +1,4 @@
 +**/.DS_Store
  *.diff
  *.patch
  *.orig
- *.rej
- 
-+cross-build/
-+native-build/
-+dist/
-+dist-newlib/
-+dist-clib4/
-+
- *~
- .#*
- *#
- 
- *.flt
- *.gmo
-@@ -69,6 +76,9 @@ stamp-*
- 
- # ignore in-tree prerequisites
- /mpfr*
- /mpc*
- /gmp*
- /isl*
-+
-+.vscode
-+.idea
-diff --git a/bfd/Makefile.am b/bfd/Makefile.am
-index e1692e7f8aa8475c8d9fb41f5b35a342752c3987..a884108ff983528b8d3f13f440b3b1e04cb9e260 100644
---- a/bfd/Makefile.am
-+++ b/bfd/Makefile.am
-@@ -289,12 +289,13 @@ BFD32_BACKENDS = \
- 	elf-sframe.lo \
- 	elf-ifunc.lo \
- 	elf-m10200.lo \
- 	elf-m10300.lo \
- 	elf-nacl.lo \
- 	elf-strtab.lo \
-+	elf-amigaos.lo \
- 	elf-vxworks.lo \
- 	elf.lo \
- 	elf32-am33lin.lo \
- 	elf32-arc.lo \
- 	elf32-arm.lo \
- 	elf32-avr.lo \
-@@ -424,12 +425,13 @@ BFD32_BACKENDS_CFILES = \
- 	elf-sframe.c \
- 	elf-ifunc.c \
- 	elf-m10200.c \
- 	elf-m10300.c \
- 	elf-nacl.c \
- 	elf-strtab.c \
-+	elf-amigaos.c \
- 	elf-vxworks.c \
- 	elf.c \
- 	elf32-am33lin.c \
- 	elf32-arc.c \
- 	elf32-arm.c \
- 	elf32-avr.c \
-@@ -703,13 +705,13 @@ SOURCE_HFILES = \
- 	elf32-dlx.h elf32-hppa.h elf32-m68hc1x.h elf32-m68k.h \
- 	elf32-metag.h elf32-nds32.h elf32-nios2.h elf32-ppc.h \
- 	elf32-rx.h elf32-score.h elf32-sh-relocs.h elf32-spu.h \
- 	elf32-tic6x.h elf32-tilegx.h elf32-tilepro.h elf32-v850.h \
- 	elf64-hppa.h elf64-ppc.h elf64-tilegx.h \
- 	elf-bfd.h elfcode.h elfcore.h elf-hppa.h elf-linker-x86.h \
--	elf-linux-core.h elf-nacl.h elf-s390.h elf-vxworks.h \
-+	elf-linux-core.h elf-nacl.h elf-s390.h elf-amigaos.h elf-vxworks.h \
- 	elfxx-aarch64.h elfxx-ia64.h elfxx-mips.h elfxx-riscv.h \
- 	elfxx-sparc.h elfxx-tilegx.h elfxx-x86.h elfxx-loongarch.h \
- 	genlink.h go32stub.h \
- 	libaout.h libbfd.h libcoff.h libecoff.h libhppa.h \
- 	libpei.h libxcoff.h \
- 	mach-o.h \
-diff --git a/bfd/Makefile.in b/bfd/Makefile.in
-index 80aed6576435a4ce295db37c155928349fa8a9a7..ff4d61b7a3a096611d24edcc8ce2d8712703bdb0 100644
---- a/bfd/Makefile.in
-+++ b/bfd/Makefile.in
-@@ -758,12 +758,13 @@ BFD32_BACKENDS = \
- 	elf-sframe.lo \
- 	elf-ifunc.lo \
- 	elf-m10200.lo \
- 	elf-m10300.lo \
- 	elf-nacl.lo \
- 	elf-strtab.lo \
-+	elf-amigaos.lo \
- 	elf-vxworks.lo \
- 	elf.lo \
- 	elf32-am33lin.lo \
- 	elf32-arc.lo \
- 	elf32-arm.lo \
- 	elf32-avr.lo \
-@@ -893,12 +894,13 @@ BFD32_BACKENDS_CFILES = \
- 	elf-sframe.c \
- 	elf-ifunc.c \
- 	elf-m10200.c \
- 	elf-m10300.c \
- 	elf-nacl.c \
- 	elf-strtab.c \
-+	elf-amigaos.c \
- 	elf-vxworks.c \
- 	elf.c \
- 	elf32-am33lin.c \
- 	elf32-arc.c \
- 	elf32-arm.c \
- 	elf32-avr.c \
-@@ -1169,13 +1171,13 @@ SOURCE_HFILES = \
- 	elf32-dlx.h elf32-hppa.h elf32-m68hc1x.h elf32-m68k.h \
- 	elf32-metag.h elf32-nds32.h elf32-nios2.h elf32-ppc.h \
- 	elf32-rx.h elf32-score.h elf32-sh-relocs.h elf32-spu.h \
- 	elf32-tic6x.h elf32-tilegx.h elf32-tilepro.h elf32-v850.h \
- 	elf64-hppa.h elf64-ppc.h elf64-tilegx.h \
- 	elf-bfd.h elfcode.h elfcore.h elf-hppa.h elf-linker-x86.h \
--	elf-linux-core.h elf-nacl.h elf-s390.h elf-vxworks.h \
-+	elf-linux-core.h elf-nacl.h elf-s390.h elf-amigaos.h  elf-vxworks.h \
- 	elfxx-aarch64.h elfxx-ia64.h elfxx-mips.h elfxx-riscv.h \
- 	elfxx-sparc.h elfxx-tilegx.h elfxx-x86.h elfxx-loongarch.h \
- 	genlink.h go32stub.h \
- 	libaout.h libbfd.h libcoff.h libecoff.h libhppa.h \
- 	libpei.h libxcoff.h \
- 	mach-o.h \
-@@ -1577,12 +1579,13 @@ distclean-compile:
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-m10200.Plo@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-m10300.Plo@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-nacl.Plo@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-properties.Plo@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-sframe.Plo@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-strtab.Plo@am__quote@
-+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-amigaos.Plo@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-vxworks.Plo@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf.Plo@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf32-aarch64.Plo@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf32-am33lin.Plo@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf32-arc.Plo@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf32-arm.Plo@am__quote@
+-- 
+2.43.0
+
+
+From 00687b204550af9a68ddbdf6f557369982b6cfff Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Tue, 10 Jan 2023 11:51:55 +0100
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 02/61] 
+ Initial appling adtools binutils patches with focus on AmigaOS ELF only
+ support
+
+---
+ bfd/bfd-in2.h             |    6 +
+ bfd/config.bfd            |    4 +
+ bfd/configure             |    3 +-
+ bfd/configure.ac          |    1 +
+ bfd/elf-bfd.h             |    3 +-
+ bfd/elf32-ppc.c           |  155 ++-
+ bfd/elf32-ppc.h           |    3 +-
+ bfd/elflink.c             |    2 +
+ bfd/libbfd.h              |    4 +
+ bfd/reloc.c               |   10 +-
+ bfd/targets.c             |    2 +
+ binutils/objcopy.c        |   68 +-
+ binutils/readelf.c        |    4 +
+ config.sub                |   10 +-
+ elfcpp/powerpc.h          |    6 +
+ gas/Makefile.am           |    1 +
+ gas/Makefile.in           |    1 +
+ gas/config/tc-ppc.c       |   22 +-
+ gas/config/te-amigaos.h   |   14 +
+ gas/configure.tgt         |    1 +
+ gas/po/POTFILES.in        |    1 +
+ include/elf/amigaos.h     |   27 +
+ include/elf/ppc.h         |    6 +
+ ld/Makefile.am            |    4 +
+ ld/Makefile.in            |    6 +
+ ld/configure.tgt          |    8 +
+ ld/emulparams/amigaos.sh  |   28 +
+ ld/emultempl/amigaos.em   | 2544 +++++++++++++++++++++++++++++++++++++
+ ld/ldctor.c               |   20 +-
+ ld/ldlang.c               |    7 +
+ ld/ldmain.c               |    9 +-
+ ld/po/BLD-POTFILES.in     |    2 +
+ ld/scripttempl/amigaos.sc |  501 ++++++++
+ 33 files changed, 3455 insertions(+), 28 deletions(-)
+ create mode 100644 gas/config/te-amigaos.h
+ create mode 100644 include/elf/amigaos.h
+ create mode 100644 ld/emulparams/amigaos.sh
+ create mode 100644 ld/emultempl/amigaos.em
+ create mode 100644 ld/scripttempl/amigaos.sc
+
 diff --git a/bfd/bfd-in2.h b/bfd/bfd-in2.h
-index eddfb31b6d51c42c970919534af0f05b65f67604..984865277d6acabc543af5693a6afb31a2560cc5 100644
+index eddfb31b6d5..984865277d6 100644
 --- a/bfd/bfd-in2.h
 +++ b/bfd/bfd-in2.h
-@@ -2974,12 +2974,18 @@ instruction.  */
-   BFD_RELOC_PPC64_GOT_TLSGD_PCREL34,
-   BFD_RELOC_PPC64_GOT_TLSLD_PCREL34,
-   BFD_RELOC_PPC64_GOT_TPREL_PCREL34,
+@@ -2977,6 +2977,12 @@ instruction.  */
    BFD_RELOC_PPC64_GOT_DTPREL_PCREL34,
    BFD_RELOC_PPC64_TLS_PCREL,
  
@@ -260,17 +255,11 @@ index eddfb31b6d51c42c970919534af0f05b65f67604..984865277d6acabc543af5693a6afb31
  /* IBM 370/390 relocations  */
    BFD_RELOC_I370_D12,
  
- /* The type of reloc used to build a constructor table - at the moment
- probably a 32 bit wide absolute relocation, but the target can choose.
- It generally does map to one of the other relocation types.  */
 diff --git a/bfd/config.bfd b/bfd/config.bfd
-index 1b0111fd410dcef529bc4d94e2c314678cdd4a2b..8b191314d4653996823189fade3d30a9ecca009a 100644
+index 1b0111fd410..8b191314d46 100644
 --- a/bfd/config.bfd
 +++ b/bfd/config.bfd
-@@ -1124,12 +1124,16 @@ case "${targ}" in
- 	*-*-aix4.[3456789]* | *-*-aix[56789]*)
- 	want64=true;;
- 	*)
+@@ -1127,6 +1127,10 @@ case "${targ}" in
  	targ_cflags=-DSMALL_ARCHIVE;;
      esac
      ;;
@@ -281,158 +270,37 @@ index 1b0111fd410dcef529bc4d94e2c314678cdd4a2b..8b191314d4653996823189fade3d30a9
  #ifdef BFD64
    powerpc64-*-aix*)
      targ_defvec=rs6000_xcoff64_vec
-     targ_selvecs=rs6000_xcoff_vec
-     want64=true
-     ;;
 diff --git a/bfd/configure b/bfd/configure
-index e5d464378f872ab643679197f18a2209b7bc4631..a5754abfb0dfe3f238da79d6421c0ab5a1ee5c8e 100755
+index e5d464378f8..0bc4ba1b28e 100755
 --- a/bfd/configure
 +++ b/bfd/configure
-@@ -13777,13 +13777,14 @@ do
-     pdp11_aout_vec)		 tb="$tb pdp11.lo" ;;
-     pef_vec)			 tb="$tb pef.lo" ;;
-     pef_xlib_vec)		 tb="$tb pef.lo" ;;
+@@ -13780,7 +13780,8 @@ do
      pj_elf32_vec)		 tb="$tb elf32-pj.lo elf32.lo $elf" ;;
      pj_elf32_le_vec)		 tb="$tb elf32-pj.lo elf32.lo $elf" ;;
      powerpc_boot_vec)		 tb="$tb ppcboot.lo" ;;
 -    powerpc_elf32_vec)		 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
-+    powerpc_elf32_amigaos_vec)	tb="$tb elf32-ppc.lo elf-amigaos.lo elf32.lo $elf" ;;
++    powerpc_elf32_amigaos_vec)	tb="$tb elf32-ppc.lo elf32.lo $elf" ;;
 +	powerpc_elf32_vec)		 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
      powerpc_elf32_le_vec)	 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
      powerpc_elf32_fbsd_vec)	 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
      powerpc_elf32_vxworks_vec)	 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
-     powerpc_elf64_vec)		 tb="$tb elf64-ppc.lo elf64-gen.lo elf64.lo $elf"; target_size=64 ;;
-     powerpc_elf64_le_vec)	 tb="$tb elf64-ppc.lo elf64-gen.lo elf64.lo $elf" target_size=64 ;;
-     powerpc_elf64_fbsd_vec)	 tb="$tb elf64-ppc.lo elf64-gen.lo elf64.lo $elf" target_size=64 ;;
 diff --git a/bfd/configure.ac b/bfd/configure.ac
-index 015fd01189321b862b5c2b7777344fb20ead67fe..352be794f65cbc75ce625c2a3d9de4cad302e124 100644
+index 015fd011893..8f59f6484e0 100644
 --- a/bfd/configure.ac
 +++ b/bfd/configure.ac
-@@ -567,12 +567,13 @@ do
-     pdp11_aout_vec)		 tb="$tb pdp11.lo" ;;
-     pef_vec)			 tb="$tb pef.lo" ;;
-     pef_xlib_vec)		 tb="$tb pef.lo" ;;
+@@ -570,6 +570,7 @@ do
      pj_elf32_vec)		 tb="$tb elf32-pj.lo elf32.lo $elf" ;;
      pj_elf32_le_vec)		 tb="$tb elf32-pj.lo elf32.lo $elf" ;;
      powerpc_boot_vec)		 tb="$tb ppcboot.lo" ;;
-+    powerpc_elf32_amigaos_vec)	tb="$tb elf32-ppc.lo elf-amigaos.lo elf32.lo $elf" ;;
++    powerpc_elf32_amigaos_vec)	tb="$tb elf32-ppc.lo elf32.lo $elf" ;;
      powerpc_elf32_vec)		 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
      powerpc_elf32_le_vec)	 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
      powerpc_elf32_fbsd_vec)	 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
-     powerpc_elf32_vxworks_vec)	 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
-     powerpc_elf64_vec)		 tb="$tb elf64-ppc.lo elf64-gen.lo elf64.lo $elf"; target_size=64 ;;
-     powerpc_elf64_le_vec)	 tb="$tb elf64-ppc.lo elf64-gen.lo elf64.lo $elf" target_size=64 ;;
-diff --git a/bfd/cpu-bfin.c b/bfd/elf-amigaos.c
-similarity index 51%
-copy from bfd/cpu-bfin.c
-copy to bfd/elf-amigaos.c
-index 4d3c1804536147ab0365a6f1167c5a87cc8edac8..06771ecc3121b1f96f0a96437dd7dd2bc7e649f9 100644
---- a/bfd/cpu-bfin.c
-+++ b/bfd/elf-amigaos.c
-@@ -1,8 +1,7 @@
--/* BFD Support for the ADI Blackfin processor.
--
-+/* VxWorks support for ELF
-    Copyright (C) 2005-2023 Free Software Foundation, Inc.
- 
-    This file is part of BFD, the Binary File Descriptor library.
- 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-@@ -12,31 +11,32 @@
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
- 
-    You should have received a copy of the GNU General Public License
--   along with this program; if not, write to the Free Software
--   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
--   MA 02110-1301, USA.  */
-+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
-+
-+/* This file provides routines used by all VxWorks targets.  */
- 
- #include "sysdep.h"
- #include "bfd.h"
- #include "libbfd.h"
-+#include "elf-bfd.h"
-+#include "elf-amigaos.h"
-+#include "elf/amigaos.h"
-+
-+/* Add dynamic tags
-+   AmigaOS: Flag it as a version 2 dynamic binary */  
-+
-+bool
-+_bfd_elf_amigaos_add_dynamic_tags (struct bfd_link_info *info)
-+{
-+#ifdef DEBUG
-+		printf ("Target amigaos-pcc needs addtional marker symbol DT_AMIGAOS_DYNVERSION to mark version used.\n"); 
-+#endif
- 
--const bfd_arch_info_type bfd_bfin_arch =
--  {
--    16,			/* Bits in a word.  */
--    32,			/* Bits in an address.  */
--    8,			/* Bits in a byte.  */
--    bfd_arch_bfin,
--    0,			/* Only one machine.  */
--    "bfin",		/* Arch name.  */
--    "bfin",		/* Arch printable name.  */
--    4,			/* Section align power.  */
--    true,		/* The one and only.  */
--    bfd_default_compatible,
--    bfd_default_scan,
--    bfd_arch_default_fill,
--    NULL,
--    0 /* Maximum offset of a reloc from the start of an insn.  */
--  };
-+	struct elf_link_hash_table *htab = elf_hash_table (info);
-+	
-+	return  htab->target_os != is_amigaos || _bfd_elf_add_dynamic_entry (info,DT_AMIGAOS_DYNVERSION, 2);
-+}
-+ 
-\ No newline at end of file
-diff --git a/bfd/elf-nacl.h b/bfd/elf-amigaos.h
-similarity index 73%
-copy from bfd/elf-nacl.h
-copy to bfd/elf-amigaos.h
-index e921c64589c111bfebe31f61c0d0a982e6479ba6..f7770b1d669e39f2b9fc139471fb6dfac1c1beb5 100644
---- a/bfd/elf-nacl.h
-+++ b/bfd/elf-amigaos.h
-@@ -1,8 +1,8 @@
--/* Native Client support for ELF
--   Copyright (C) 2012-2023 Free Software Foundation, Inc.
-+/* VxWorks support for ELF
-+   Copyright (C) 2005-2023 Free Software Foundation, Inc.
- 
-    This file is part of BFD, the Binary File Descriptor library.
- 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-@@ -13,9 +13,10 @@
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
- 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
- 
--bool nacl_modify_segment_map (bfd *, struct bfd_link_info *);
--bool nacl_modify_headers (bfd *, struct bfd_link_info *);
--bool nacl_final_write_processing (bfd *);
-+#include "elf/common.h"
-+#include "elf/internal.h"
-+
-+bool _bfd_elf_amigaos_add_dynamic_tags(struct bfd_link_info *);
 diff --git a/bfd/elf-bfd.h b/bfd/elf-bfd.h
-index 2b7c574f540b55bbc8cccb22f5b60b96f730307d..6ee3ba456a209933b317f6ab726171da3926f7ad 100644
+index 2b7c574f540..6ee3ba456a2 100644
 --- a/bfd/elf-bfd.h
 +++ b/bfd/elf-bfd.h
-@@ -588,13 +588,14 @@ struct bfd_link_needed_list
- 
- enum elf_target_os
- {
+@@ -591,7 +591,8 @@ enum elf_target_os
    is_normal,
    is_solaris,	/* Solaris.  */
    is_vxworks,	/* VxWorks.  */
@@ -442,17 +310,11 @@ index 2b7c574f540b55bbc8cccb22f5b60b96f730307d..6ee3ba456a209933b317f6ab726171da
  };
  
  /* Used by bfd_sym_from_r_symndx to cache a small number of local
-    symbols.  */
- #define LOCAL_SYM_CACHE_SIZE 32
- struct sym_cache
 diff --git a/bfd/elf32-ppc.c b/bfd/elf32-ppc.c
-index a8234f27a8a437b2503cd55c971d5d3acbbf6222..2077aaab94e68bb29bce78598ec82c7e38dba2fe 100644
+index a8234f27a8a..00854bcb4f8 100644
 --- a/bfd/elf32-ppc.c
 +++ b/bfd/elf32-ppc.c
-@@ -19,27 +19,31 @@
-    Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
-    Boston, MA 02110-1301, USA.  */
- 
+@@ -22,6 +22,7 @@
  /* The assembler should generate a full set of section symbols even
     when they appear unused.  The linux kernel build tool recordmcount
     needs them.  */
@@ -460,15 +322,12 @@ index a8234f27a8a437b2503cd55c971d5d3acbbf6222..2077aaab94e68bb29bce78598ec82c7e
  #define TARGET_KEEP_UNUSED_SECTION_SYMBOLS true
  
  #include "sysdep.h"
- #include <stdarg.h>
- #include "bfd.h"
- #include "bfdlink.h"
+@@ -31,12 +32,14 @@
  #include "libbfd.h"
  #include "elf-bfd.h"
  #include "elf/ppc.h"
 +#include "elf/amigaos.h"
  #include "elf32-ppc.h"
-+#include "elf-amigaos.h"
  #include "elf-vxworks.h"
  #include "dwarf2.h"
  #include "opcode/ppc.h"
@@ -478,13 +337,7 @@ index a8234f27a8a437b2503cd55c971d5d3acbbf6222..2077aaab94e68bb29bce78598ec82c7e
  #define OCTETS_PER_BYTE(ABFD, SEC) 1
  
  typedef enum split16_format_type
- {
-   split16a_type = 0,
-   split16d_type
-@@ -571,12 +575,29 @@ static reloc_howto_type ppc_elf_howto_raw[] = {
-   /* Relocation not handled: R_PPC_EMB_RELSEC16 */
-   /* Relocation not handled: R_PPC_EMB_RELST_LO */
-   /* Relocation not handled: R_PPC_EMB_RELST_HI */
+@@ -574,6 +577,23 @@ static reloc_howto_type ppc_elf_howto_raw[] = {
    /* Relocation not handled: R_PPC_EMB_RELST_HA */
    /* Relocation not handled: R_PPC_EMB_BIT_FLD */
  
@@ -508,13 +361,7 @@ index a8234f27a8a437b2503cd55c971d5d3acbbf6222..2077aaab94e68bb29bce78598ec82c7e
    /* PC relative relocation against either _SDA_BASE_ or _SDA2_BASE_, filling
       in the 16 bit signed offset from the appropriate base, and filling in the
       register field with the appropriate register (0, 2, or 13).  */
-   HOW (R_PPC_EMB_RELSDA, 2, 16, 0xffff, 0, false, signed,
-        ppc_elf_unhandled_reloc),
- 
-@@ -819,13 +840,17 @@ ppc_elf_reloc_type_lookup (bfd *abfd ATTRIBUTE_UNUSED,
-     case BFD_RELOC_PPC_EMB_RELSEC16:	r = R_PPC_EMB_RELSEC16;		break;
-     case BFD_RELOC_PPC_EMB_RELST_LO:	r = R_PPC_EMB_RELST_LO;		break;
-     case BFD_RELOC_PPC_EMB_RELST_HI:	r = R_PPC_EMB_RELST_HI;		break;
+@@ -822,7 +842,11 @@ ppc_elf_reloc_type_lookup (bfd *abfd ATTRIBUTE_UNUSED,
      case BFD_RELOC_PPC_EMB_RELST_HA:	r = R_PPC_EMB_RELST_HA;		break;
      case BFD_RELOC_PPC_EMB_BIT_FLD:	r = R_PPC_EMB_BIT_FLD;		break;
      case BFD_RELOC_PPC_EMB_RELSDA:	r = R_PPC_EMB_RELSDA;		break;
@@ -527,13 +374,7 @@ index a8234f27a8a437b2503cd55c971d5d3acbbf6222..2077aaab94e68bb29bce78598ec82c7e
      case BFD_RELOC_PPC_VLE_REL15:	r = R_PPC_VLE_REL15;		break;
      case BFD_RELOC_PPC_VLE_REL24:	r = R_PPC_VLE_REL24;		break;
      case BFD_RELOC_PPC_VLE_LO16A:	r = R_PPC_VLE_LO16A;		break;
-     case BFD_RELOC_PPC_VLE_LO16D:	r = R_PPC_VLE_LO16D;		break;
-     case BFD_RELOC_PPC_VLE_HI16A:	r = R_PPC_VLE_HI16A;		break;
-     case BFD_RELOC_PPC_VLE_HI16D:	r = R_PPC_VLE_HI16D;		break;
-@@ -2332,13 +2357,22 @@ ppc_elf_create_got (bfd *abfd, struct bfd_link_info *info)
-   struct ppc_elf_link_hash_table *htab;
- 
-   if (!_bfd_elf_create_got_section (abfd, info))
+@@ -2335,7 +2359,16 @@ ppc_elf_create_got (bfd *abfd, struct bfd_link_info *info)
      return false;
  
    htab = ppc_elf_hash_table (info);
@@ -551,28 +392,16 @@ index a8234f27a8a437b2503cd55c971d5d3acbbf6222..2077aaab94e68bb29bce78598ec82c7e
      {
        /* The powerpc .got has a blrl instruction in it.  Mark it
  	 executable.  */
-       flagword flags = (SEC_ALLOC | SEC_LOAD | SEC_CODE | SEC_HAS_CONTENTS
- 			| SEC_IN_MEMORY | SEC_LINKER_CREATED);
-       if (!bfd_set_section_flags (htab->elf.sgot, flags))
-@@ -2498,12 +2532,14 @@ ppc_elf_create_dynamic_sections (bfd *abfd, struct bfd_link_info *info)
-   if (htab->elf.target_os == is_vxworks
-       && !elf_vxworks_create_dynamic_sections (abfd, info, &htab->srelplt2))
-     return false;
+@@ -2501,6 +2534,8 @@ ppc_elf_create_dynamic_sections (bfd *abfd, struct bfd_link_info *info)
  
    s = htab->elf.splt;
    flags = SEC_ALLOC | SEC_CODE | SEC_LINKER_CREATED;
-+  if (htab->elf.target_os == is_amigaos )
++  if (htab->plt_type == PLT_AMIGAOS)
 +     flags |= SEC_READONLY;
    if (htab->plt_type == PLT_VXWORKS)
      /* The VxWorks PLT is a loaded section with contents.  */
      flags |= SEC_HAS_CONTENTS | SEC_LOAD | SEC_READONLY;
-   return bfd_set_section_flags (s, flags);
- }
- 
-@@ -3153,12 +3189,19 @@ ppc_elf_check_relocs (bfd *abfd,
- 	    {
- 	      ppc_elf_hash_entry (h)->has_sda_refs = true;
- 	      h->non_got_ref = true;
+@@ -3156,6 +3191,13 @@ ppc_elf_check_relocs (bfd *abfd,
  	    }
  	  break;
  
@@ -586,13 +415,7 @@ index a8234f27a8a437b2503cd55c971d5d3acbbf6222..2077aaab94e68bb29bce78598ec82c7e
  	case R_PPC_VLE_REL8:
  	case R_PPC_VLE_REL15:
  	case R_PPC_VLE_REL24:
- 	case R_PPC_VLE_LO16A:
- 	case R_PPC_VLE_LO16D:
- 	case R_PPC_VLE_HI16A:
-@@ -4907,12 +4950,13 @@ ppc_elf_adjust_dynamic_symbol (struct bfd_link_info *info,
-       doesn't work on VxWorks, where we can not have dynamic
-       relocations (other than copy and jump slot relocations) in an
-       executable.  */
+@@ -4910,6 +4952,7 @@ ppc_elf_adjust_dynamic_symbol (struct bfd_link_info *info,
    if (ELIMINATE_COPY_RELOCS
        && !ppc_elf_hash_entry (h)->has_sda_refs
        && htab->elf.target_os != is_vxworks
@@ -600,29 +423,19 @@ index a8234f27a8a437b2503cd55c971d5d3acbbf6222..2077aaab94e68bb29bce78598ec82c7e
        && !h->def_regular
        && !alias_readonly_dynrelocs (h))
      return true;
- 
-   /* We must allocate the symbol in our .dynbss section, which will
-      become part of the .bss section of the executable.  There will be
-@@ -5894,12 +5938,15 @@ ppc_elf_size_dynamic_sections (bfd *output_bfd,
-   _bfd_elf_add_dynamic_entry (info, TAG, VAL)
- 
-       if (!_bfd_elf_maybe_vxworks_add_dynamic_tags (output_bfd, info,
+@@ -5897,6 +5940,11 @@ ppc_elf_size_dynamic_sections (bfd *output_bfd,
  						    relocs))
  	return false;
  
-+      if (!_bfd_elf_amigaos_add_dynamic_tags (info))
-+		return false;
++	  /* AmigaOS: Flag it as a version 2 dynamic binary */
++      if ( htab->plt_type == PLT_AMIGAOS
++	  && !add_dynamic_entry (DT_AMIGAOS_DYNVERSION, 2) )
++        return false;
 +
        if (htab->plt_type == PLT_NEW
  	  && htab->glink != NULL
  	  && htab->glink->size != 0)
- 	{
- 	  if (!add_dynamic_entry (DT_PPC_GOT, 0))
- 	    return false;
-@@ -6977,12 +7024,13 @@ ppc_elf_relocate_section (bfd *output_bfd,
-   struct ppc_elf_link_hash_table *htab;
-   Elf_Internal_Rela *rel;
-   Elf_Internal_Rela *wrel;
+@@ -6980,6 +7028,7 @@ ppc_elf_relocate_section (bfd *output_bfd,
    Elf_Internal_Rela *relend;
    Elf_Internal_Rela outrel;
    asection *got2;
@@ -630,13 +443,7 @@ index a8234f27a8a437b2503cd55c971d5d3acbbf6222..2077aaab94e68bb29bce78598ec82c7e
    bfd_vma *local_got_offsets;
    bool ret = true;
    bfd_vma d_offset = (bfd_big_endian (input_bfd) ? 2 : 0);
-   bool is_vxworks_tls;
-   unsigned int picfixup_size = 0;
-   struct ppc_elf_relax_info *relax_info = NULL;
-@@ -8048,12 +8096,57 @@ ppc_elf_relocate_section (bfd *output_bfd,
- 	case R_PPC_ADDR16_HI:
- 	case R_PPC_ADDR16_HA:
- 	case R_PPC_UADDR32:
+@@ -8051,6 +8100,51 @@ ppc_elf_relocate_section (bfd *output_bfd,
  	case R_PPC_UADDR16:
  	  goto dodyn;
  
@@ -688,13 +495,7 @@ index a8234f27a8a437b2503cd55c971d5d3acbbf6222..2077aaab94e68bb29bce78598ec82c7e
  	case R_PPC_VLE_REL8:
  	case R_PPC_VLE_REL15:
  	case R_PPC_VLE_REL24:
- 	case R_PPC_REL24:
- 	case R_PPC_REL14:
- 	case R_PPC_REL14_BRTAKEN:
-@@ -10433,12 +10526,162 @@ ppc_elf_finish_dynamic_sections (bfd *output_bfd,
- #define elf_backend_action_discarded		ppc_elf_action_discarded
- #define elf_backend_init_index_section		_bfd_elf_init_1_index_section
- #define elf_backend_lookup_section_flags_hook	ppc_elf_lookup_section_flags
+@@ -10436,6 +10530,63 @@ ppc_elf_finish_dynamic_sections (bfd *output_bfd,
  
  #include "elf32-target.h"
  
@@ -711,20 +512,4789 @@ index a8234f27a8a437b2503cd55c971d5d3acbbf6222..2077aaab94e68bb29bce78598ec82c7e
 +#undef ELF_TARGET_OS
 +#define ELF_TARGET_OS		is_amigaos
 +
++/* Like ppc_elf_link_hash_table_create, but overrides
++   appropriately for AmigaOS.  */
++static struct bfd_link_hash_table *
++ppc_elf_amigaos_link_hash_table_create (bfd *abfd)
++{
++  struct bfd_link_hash_table *ret;
++
++  ret = ppc_elf_link_hash_table_create (abfd);
++  if (ret)
++    {
++      struct ppc_elf_link_hash_table *htab
++	= (struct ppc_elf_link_hash_table *)ret;
++      htab->plt_type = PLT_AMIGAOS;
++    }
++  return ret;
++}
++
++/* If we have .sbss2 or .PPC.EMB.sbss0 output sections, we
++   need to bump up the number of section headers.  */
++
++static int
++ppc_elf_amigaos_additional_program_headers (bfd *abfd,
++				    struct bfd_link_info *info ATTRIBUTE_UNUSED)
++{
++  int ret = 1;
++  ret += ppc_elf_additional_program_headers (abfd,info);
++
++  return ret;
++}
++
++
++#undef bfd_elf32_bfd_link_hash_table_create
++#define bfd_elf32_bfd_link_hash_table_create \
++  ppc_elf_amigaos_link_hash_table_create
++
++#undef elf_backend_additional_program_headers
++#define elf_backend_additional_program_headers \
++  ppc_elf_amigaos_additional_program_headers
++
++#undef elf32_bed
++#define elf32_bed	elf32_powerpc_amigaos_bed
++
++#include "elf32-target.h"
++
+ /* FreeBSD Target */
+ 
+ #undef  TARGET_LITTLE_SYM
+diff --git a/bfd/elf32-ppc.h b/bfd/elf32-ppc.h
+index c1d56bf7197..34939acfcf5 100644
+--- a/bfd/elf32-ppc.h
++++ b/bfd/elf32-ppc.h
+@@ -23,7 +23,8 @@ enum ppc_elf_plt_type
+   PLT_UNSET,
+   PLT_OLD,
+   PLT_NEW,
+-  PLT_VXWORKS
++  PLT_VXWORKS,
++  PLT_AMIGAOS
+ };
+ 
+ /* Various options passed from the linker to bfd backend.  */
+diff --git a/bfd/elflink.c b/bfd/elflink.c
+index 7bf337c7d44..370f4173b22 100644
+--- a/bfd/elflink.c
++++ b/bfd/elflink.c
+@@ -10533,6 +10533,8 @@ elf_link_output_extsym (struct bfd_hash_entry *bh, void *data)
+     default:
+     case bfd_link_hash_new:
+     case bfd_link_hash_warning:
++	  // ML: TODO: really needed, or just  cosmetic?
++	  (*_bfd_error_handler)(_("Unexpected type (%d) of symbol %s"), h->root.type, h->root.root.string);
+       abort ();
+       return false;
+ 
+diff --git a/bfd/libbfd.h b/bfd/libbfd.h
+index e75935133ac..a406a9dc00d 100644
+--- a/bfd/libbfd.h
++++ b/bfd/libbfd.h
+@@ -1651,6 +1651,10 @@ static const char *const bfd_reloc_code_real_names[] = { "@@uninitialized@@",
+   "BFD_RELOC_PPC64_GOT_TPREL_PCREL34",
+   "BFD_RELOC_PPC64_GOT_DTPREL_PCREL34",
+   "BFD_RELOC_PPC64_TLS_PCREL",
++  "BFD_RELOC_PPC_AMIGAOS_BREL",
++  "BFD_RELOC_PPC_AMIGAOS_BREL_LO",
++  "BFD_RELOC_PPC_AMIGAOS_BREL_HI",
++  "BFD_RELOC_PPC_AMIGAOS_BREL_HA",
+   "BFD_RELOC_I370_D12",
+   "BFD_RELOC_CTOR",
+   "BFD_RELOC_ARM_PCREL_BRANCH",
+diff --git a/bfd/reloc.c b/bfd/reloc.c
+index db4f30d36d0..0f4faa0c544 100644
+--- a/bfd/reloc.c
++++ b/bfd/reloc.c
+@@ -3051,9 +3051,15 @@ ENUMDOC
+   PowerPC and PowerPC64 thread-local storage relocations.
+ 
+ ENUM
+-  BFD_RELOC_I370_D12
++  BFD_RELOC_PPC_AMIGAOS_BREL
++ENUMX  
++  BFD_RELOC_PPC_AMIGAOS_BREL_LO
++ENUMX  
++  BFD_RELOC_PPC_AMIGAOS_BREL_HI
++ENUMX
++  BFD_RELOC_PPC_AMIGAOS_BREL_HA
+ ENUMDOC
+-  IBM 370/390 relocations
++  AmigaOS PowerPC r2 base relative addressing into data section.
+ 
+ ENUM
+   BFD_RELOC_CTOR
+diff --git a/bfd/targets.c b/bfd/targets.c
+index 41294ea4d14..f09f2c337a7 100644
+--- a/bfd/targets.c
++++ b/bfd/targets.c
+@@ -850,6 +850,7 @@ extern const bfd_target pj_elf32_vec;
+ extern const bfd_target pj_elf32_le_vec;
+ extern const bfd_target plugin_vec;
+ extern const bfd_target powerpc_boot_vec;
++extern const bfd_target powerpc_elf32_amigaos_vec;
+ extern const bfd_target powerpc_elf32_vec;
+ extern const bfd_target powerpc_elf32_le_vec;
+ extern const bfd_target powerpc_elf32_fbsd_vec;
+@@ -1236,6 +1237,7 @@ static const bfd_target * const _bfd_target_vector[] =
+ 	&pj_elf32_le_vec,
+ 
+ 	&powerpc_boot_vec,
++	&powerpc_elf32_amigaos_vec,
+ 	&powerpc_elf32_vec,
+ 	&powerpc_elf32_le_vec,
+ 	&powerpc_elf32_fbsd_vec,
+diff --git a/binutils/objcopy.c b/binutils/objcopy.c
+index a6182b48b6c..47711c7b42f 100644
+--- a/binutils/objcopy.c
++++ b/binutils/objcopy.c
+@@ -122,6 +122,9 @@ enum strip_action
+ /* Which symbols to remove.  */
+ static enum strip_action strip_symbols = STRIP_UNDEF;
+ 
++/* Shall we strip unneeded relative relocs? */
++static int strip_unneeded_rel_relocs;
++
+ enum locals_action
+ {
+   LOCALS_UNDEF,
+@@ -366,6 +369,7 @@ enum command_line_switch
+   OPTION_SREC_LEN,
+   OPTION_STACK,
+   OPTION_STRIP_DWO,
++  OPTION_STRIP_UNNEEED_REL_RELOCS,
+   OPTION_STRIP_SYMBOLS,
+   OPTION_STRIP_UNNEEDED,
+   OPTION_STRIP_UNNEEDED_SYMBOL,
+@@ -409,6 +413,7 @@ static struct option strip_options[] =
+   {"strip-dwo", no_argument, 0, OPTION_STRIP_DWO},
+   {"strip-symbol", required_argument, 0, 'N'},
+   {"strip-unneeded", no_argument, 0, OPTION_STRIP_UNNEEDED},
++  {"strip-unneeded-rel-relocs", no_argument, 0, OPTION_STRIP_UNNEEED_REL_RELOCS},
+   {"target", required_argument, 0, 'F'},
+   {"verbose", no_argument, 0, 'v'},
+   {"version", no_argument, 0, 'V'},
+@@ -1562,6 +1567,11 @@ filter_symbols (bfd *abfd, bfd *obfd, asymbol **osyms,
+ 
+       undefined = bfd_is_und_section (bfd_asymbol_section (sym));
+ 
++	  if (strip_symbols == STRIP_ALL && undefined)
++        {
++          add_specific_symbol(name, keep_specific_htab);
++        }
++
+       if (add_sym_list)
+ 	{
+ 	  struct addsym_node *ptr;
+@@ -1647,7 +1657,10 @@ filter_symbols (bfd *abfd, bfd *obfd, asymbol **osyms,
+ 	}
+ 
+       if (strip_symbols == STRIP_ALL)
+-	keep = false;
++		if (strcmp(name, "_start") == 0 || strcmp(name, "__amigaos4__") == 0 || strcmp(name, "_SDA_BASE_") == 0)
++          keep = true;
++        else
++          keep = false;
+       else if ((flags & BSF_KEEP) != 0		/* Used in relocation.  */
+ 	       || ((flags & BSF_SECTION_SYM) != 0
+ 		   && ((*bfd_asymbol_section (sym)->symbol_ptr_ptr)->flags
+@@ -1709,7 +1722,17 @@ filter_symbols (bfd *abfd, bfd *obfd, asymbol **osyms,
+ 	keep = true;
+ 
+       if (keep && is_strip_section (abfd, bfd_asymbol_section (sym)))
+-	keep = false;
++	{
++          /* If the symbol refers to a stripped section, we still want to
++           * keep it, e.g., _SDA_BASE_ TODO: We should perhaps output a
++           * warning or add another option to trigger this behaviour.
++           * FIXME: The section to which symbol refers must be adjusted
++           * as well */
++          if (!is_specified_symbol (name, keep_specific_htab))
++            {
++              keep = false;
++            }
++	}
+ 
+       if (keep)
+ 	{
+@@ -3291,6 +3314,7 @@ copy_object (bfd *ibfd, bfd *obfd, const bfd_arch_info_type *input_arch)
+ 	 haven't been set yet.  mark_symbols_used_in_relocations will
+ 	 ignore input sections which have no corresponding output
+ 	 section.  */
++	 // ML: TODO: Really needef for maiga to remove the floowing  fi???
+       if (strip_symbols != STRIP_ALL)
+ 	{
+ 	  bfd_set_error (bfd_error_no_error);
+@@ -4374,7 +4398,9 @@ copy_relocations_in_section (bfd *ibfd, sec_ptr isection, void *obfdarg)
+ 	    }
+ 	}
+ 
+-      if (strip_symbols == STRIP_ALL)
++    /* Never, ever, strip reloc data on the Amiga! */
++    if (strip_symbols == STRIP_ALL &&
++	  bfd_get_flavour(obfd) != bfd_target_amiga_flavour)
+ 	{
+ 	  /* Remove relocations which are not in
+ 	     keep_strip_specific_list.  */
+@@ -4385,10 +4411,28 @@ copy_relocations_in_section (bfd *ibfd, sec_ptr isection, void *obfdarg)
+ 	    /* PR 17512: file: 9e907e0c.  */
+ 	    if (relpp[i]->sym_ptr_ptr
+ 		/* PR 20096 */
+-		&& *relpp[i]->sym_ptr_ptr
+-		&& is_specified_symbol (bfd_asymbol_name (*relpp[i]->sym_ptr_ptr),
++		&& *relpp[i]->sym_ptr_ptr )
++		if( is_specified_symbol (bfd_asymbol_name (*relpp[i]->sym_ptr_ptr),
+ 					keep_specific_htab))
+ 	      *w_relpp++ = relpp[i];
++		else
++		{
++			/* Don't keep the symbol, but keep the reloc unless it is a relative reloc that is
++			* requested by the user to be removed. For now, we also don't discard the reloc if
++			* its targeting a different section. This can happen for relocs in the .rodata
++			* segment that refering to the .text segment. AmigaOS will possibly split these
++			* up.
++			*/
++			if (!strip_unneeded_rel_relocs || !relpp [i]->howto->pc_relative || sec->index != osection->index)
++			{
++			temp_relpp [temp_relcount] = relpp[i];
++			temp_relpp [temp_relcount]->addend = bfd_asymbol_value(*relpp [i]->sym_ptr_ptr)
++								- sec->vma
++								+ relpp[i]->addend;
++			temp_relpp [temp_relcount]->sym_ptr_ptr = sec->symbol_ptr_ptr;
++			temp_relcount++;
++			}
++		}
+ 	  relcount = w_relpp - relpp;
+ 	  *w_relpp = 0;
+ 	}
+@@ -4750,6 +4794,9 @@ strip_main (int argc, char *argv[])
+ 	case OPTION_STRIP_UNNEEDED:
+ 	  strip_symbols = STRIP_UNNEEDED;
+ 	  break;
++	case OPTION_STRIP_UNNEEED_REL_RELOCS:
++	  strip_unneeded_rel_relocs = 1;
++	  break;	  
+ 	case 'K':
+ 	  add_specific_symbol (optarg, keep_specific_htab);
+ 	  break;
+@@ -4835,6 +4882,11 @@ strip_main (int argc, char *argv[])
+ 
+   default_deterministic ();
+ 
++  // ML: TODO: For amiga
++  add_specific_symbol("__amigaos4__", keep_specific_htab);
++  add_specific_symbol("_start", keep_specific_htab);
++  add_specific_symbol("_SDA_BASE_", keep_specific_htab);
++
+   /* Default is to strip all symbols.  */
+   if (strip_symbols == STRIP_UNDEF
+       && discard_locals == LOCALS_UNDEF
+@@ -5909,6 +5961,12 @@ copy_main (int argc, char *argv[])
+   if (interleave && copy_byte == -1)
+     fatal (_("interleave start byte must be set with --byte"));
+ 
++  // ML: TOOD: For akigaSO
++  add_specific_symbol("__amigappc__", keep_specific_htab);
++  add_specific_symbol("__amigaos4__", keep_specific_htab);
++  add_specific_symbol("_start", keep_specific_htab);
++  add_specific_symbol("_SDA_BASE_", keep_specific_htab);
++
+   if (copy_byte >= interleave)
+     fatal (_("byte number must be less than interleave"));
+ 
+diff --git a/binutils/readelf.c b/binutils/readelf.c
+index 3da3db159cc..0439e7af16b 100644
+--- a/binutils/readelf.c
++++ b/binutils/readelf.c
+@@ -97,6 +97,7 @@
+ #include "elf/aarch64.h"
+ #include "elf/alpha.h"
+ #include "elf/amdgpu.h"
++#include "elf/amigaos.h"
+ #include "elf/arc.h"
+ #include "elf/arm.h"
+ #include "elf/avr.h"
+@@ -2223,6 +2224,7 @@ get_ppc_dynamic_type (unsigned long type)
+     {
+     case DT_PPC_GOT:    return "PPC_GOT";
+     case DT_PPC_OPT:    return "PPC_OPT";
++	case DT_AMIGAOS_DYNVERSION: return "AMIGAOS_DYNVERSION";
+     default:
+       return NULL;
+     }
+@@ -2530,6 +2532,8 @@ get_dynamic_type (Filedata * filedata, unsigned long type)
+     case DT_GNU_HASH:	return "GNU_HASH";
+     case DT_GNU_FLAGS_1: return "GNU_FLAGS_1";
+ 
++	case DT_AMIGAOS_DYNVERSION: return get_ppc_dynamic_type (type);
++
+     default:
+       if ((type >= DT_LOPROC) && (type <= DT_HIPROC))
+ 	{
+diff --git a/config.sub b/config.sub
+index dba16e84c77..3913e5de7c1 100755
+--- a/config.sub
++++ b/config.sub
+@@ -12,7 +12,7 @@ timestamp='2022-01-03'
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful, but
+-# WITHOUT ANY WARRANTY; without even the implied warranty of
++# WITHOUT ANY WARRANTY; without even the implied warranty amigaunix
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ # General Public License for more details.
+ #
+@@ -231,12 +231,8 @@ case $1 in
+ 				basic_machine=580-amdahl
+ 				basic_os=sysv
+ 				;;
+-			amiga)
+-				basic_machine=m68k-unknown
+-				basic_os=
+-				;;
+-			amigaos | amigados)
+-				basic_machine=m68k-unknown
++			amigaos | amigados | amiga)
++				basic_machine=powerpc-unknown
+ 				basic_os=amigaos
+ 				;;
+ 			amigaunix | amix)
+diff --git a/elfcpp/powerpc.h b/elfcpp/powerpc.h
+index 9322061daed..375468d984f 100644
+--- a/elfcpp/powerpc.h
++++ b/elfcpp/powerpc.h
+@@ -211,6 +211,12 @@ enum
+   R_PPC64_GOT_TPREL_PCREL34 = 150,
+   R_PPC64_GOT_DTPREL_PCREL34 = 151,
+ 
++  /* ML: TODO: AmigaOS ELF base relative addressing data secion via r2 relocation (compile option -mbaserel)*/
++  R_PPC_AMIGAOS_BREL = 210,
++  R_PPC_AMIGAOS_BREL_LO = 211,
++  R_PPC_AMIGAOS_BREL_HI = 212,
++  R_PPC_AMIGAOS_BREL_HA = 213,
++  
+   R_PPC_VLE_REL8 = 216,
+   R_PPC_VLE_REL15 = 217,
+   R_PPC_VLE_REL24 = 218,
+diff --git a/gas/Makefile.am b/gas/Makefile.am
+index ba2896581b7..b6fbe64a10c 100644
+--- a/gas/Makefile.am
++++ b/gas/Makefile.am
+@@ -317,6 +317,7 @@ OBJ_FORMAT_HFILES = \
+ TARG_ENV_HFILES = \
+ 	config/te-386bsd.h \
+ 	config/te-aix5.h \
++	config/te-amigaos.h \
+ 	config/te-armeabi.h \
+ 	config/te-armfbsdeabi.h \
+ 	config/te-armfbsdvfp.h \
+diff --git a/gas/Makefile.in b/gas/Makefile.in
+index 8319181b472..743c546418d 100644
+--- a/gas/Makefile.in
++++ b/gas/Makefile.in
+@@ -804,6 +804,7 @@ OBJ_FORMAT_HFILES = \
+ TARG_ENV_HFILES = \
+ 	config/te-386bsd.h \
+ 	config/te-aix5.h \
++	config/te-amigaos.h \
+ 	config/te-armeabi.h \
+ 	config/te-armfbsdeabi.h \
+ 	config/te-armfbsdvfp.h \
+diff --git a/gas/config/tc-ppc.c b/gas/config/tc-ppc.c
+index 9450fa74de1..a5da9fc648a 100644
+--- a/gas/config/tc-ppc.c
++++ b/gas/config/tc-ppc.c
+@@ -1547,14 +1547,18 @@ ppc_target_format (void)
+ #endif
+ #endif
+ #ifdef OBJ_ELF
+-# ifdef TE_FreeBSD
++# if TE_AMIGAOS
++  return "elf32-amigaos";
++# else
++#  ifdef TE_FreeBSD
+   return (ppc_obj64 ? "elf64-powerpc-freebsd" : "elf32-powerpc-freebsd");
+-# elif defined (TE_VXWORKS)
++#  elif defined (TE_VXWORKS)
+   return "elf32-powerpc-vxworks";
+-# else
++#  else
+   return (target_big_endian
+ 	  ? (ppc_obj64 ? "elf64-powerpc" : "elf32-powerpc")
+ 	  : (ppc_obj64 ? "elf64-powerpcle" : "elf32-powerpcle"));
++#  endif
+ # endif
+ #endif
+ }
+@@ -2111,6 +2115,10 @@ ppc_elf_suffix (char **str_p, expressionS *exp_p)
+ #define MAP64(str, reloc) { str, sizeof (str) - 1, 0, 1, reloc }
+ 
+   static const struct map_bfd mapping[] = {
++    MAP ("brel",		BFD_RELOC_PPC_AMIGAOS_BREL),
++    MAP ("brel@l",		BFD_RELOC_PPC_AMIGAOS_BREL_LO),
++    MAP ("brel@h",		BFD_RELOC_PPC_AMIGAOS_BREL_HI),
++    MAP ("brel@ha",		BFD_RELOC_PPC_AMIGAOS_BREL_HA),	
+     MAP ("l",			BFD_RELOC_LO16),
+     MAP ("h",			BFD_RELOC_HI16),
+     MAP ("ha",			BFD_RELOC_HI16_S),
+@@ -7507,6 +7515,14 @@ md_apply_fix (fixS *fixP, valueT *valP, segT seg)
+ 	  break;
+ 
+ #ifdef OBJ_ELF
++	case BFD_RELOC_PPC_AMIGAOS_BREL:
++	case BFD_RELOC_PPC_AMIGAOS_BREL_HI:
++	case BFD_RELOC_PPC_AMIGAOS_BREL_LO:
++	case BFD_RELOC_PPC_AMIGAOS_BREL_HA:
++	  md_number_to_chars (fixP->fx_frag->fr_literal + fixP->fx_where,
++			      value, 2);
++	  break;
++
+ 	  /* These can appear with @l etc. in data.  */
+ 	case BFD_RELOC_LO16:
+ 	case BFD_RELOC_LO16_PCREL:
+diff --git a/gas/config/te-amigaos.h b/gas/config/te-amigaos.h
+new file mode 100644
+index 00000000000..56f213ddd38
+--- /dev/null
++++ b/gas/config/te-amigaos.h
+@@ -0,0 +1,14 @@
++/*
++ * te-amigaos.h -- Amiga target environment declarations.
++ */
++
++#define TE_AMIGAOS 1
++
++#define LOCAL_LABELS_DOLLAR 1
++#define LOCAL_LABELS_FB 1
++
++#ifdef OBJ_HEADER
++#include OBJ_HEADER
++#else
++#include "obj-format.h"
++#endif
+\ No newline at end of file
+diff --git a/gas/configure.tgt b/gas/configure.tgt
+index 765ba73633d..6f3f613a1dd 100644
+--- a/gas/configure.tgt
++++ b/gas/configure.tgt
+@@ -361,6 +361,7 @@ case ${generic_target} in
+   ppc-*-beos*)				fmt=coff ;;
+   ppc-*-*n*bsd* | ppc-*-elf*)		fmt=elf ;;
+   ppc-*-eabi* | ppc-*-sysv4*)		fmt=elf ;;
++  ppc-*-amigaos*)         	fmt=elf em=amigaos ;;
+   ppc-*-haiku*)				fmt=elf em=haiku ;;
+   ppc-*-linux-*)			fmt=elf em=linux ;;
+   ppc-*-solaris*)			fmt=elf em=solaris ;;
+diff --git a/gas/po/POTFILES.in b/gas/po/POTFILES.in
+index 8f2efdb8d55..b0d625ffa80 100644
+--- a/gas/po/POTFILES.in
++++ b/gas/po/POTFILES.in
+@@ -185,6 +185,7 @@ config/tc-z8k.c
+ config/tc-z8k.h
+ config/te-386bsd.h
+ config/te-aix5.h
++config/te-amigaos.h
+ config/te-armeabi.h
+ config/te-armfbsdeabi.h
+ config/te-armfbsdvfp.h
+diff --git a/include/elf/amigaos.h b/include/elf/amigaos.h
+new file mode 100644
+index 00000000000..2f12286430f
+--- /dev/null
++++ b/include/elf/amigaos.h
+@@ -0,0 +1,27 @@
++/* AmigaOS ELF support for BFD.
++   Copyright 2001 Free Software Foundation, Inc.
++
++This file is part of BFD, the Binary File Descriptor library.
++
++This program is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 2 of the License, or
++(at your option) any later version.
++
++This program is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with this program; if not, write to the Free Software Foundation, Inc.,
++51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.  */
++
++#ifndef _ELF_AMIGAOS_H
++#define _ELF_AMIGAOS_H
++
++#include "elf/common.h"
++
++#define DT_AMIGAOS_DYNVERSION	(DT_LOOS + 1)
++
++#endif /* _ELF_AMIGAOS_H */
+\ No newline at end of file
+diff --git a/include/elf/ppc.h b/include/elf/ppc.h
+index e0c54a66292..8af55a10a85 100644
+--- a/include/elf/ppc.h
++++ b/include/elf/ppc.h
+@@ -138,6 +138,12 @@ START_RELOC_NUMBERS (elf_ppc_reloc_type)
+   RELOC_NUMBER (R_PPC_PLTSEQ,		119)
+   RELOC_NUMBER (R_PPC_PLTCALL,		120)
+ 
++/* AmigaOS4 relocs */
++  RELOC_NUMBER (R_PPC_AMIGAOS_BREL,	210)
++  RELOC_NUMBER (R_PPC_AMIGAOS_BREL_LO,	211)
++  RELOC_NUMBER (R_PPC_AMIGAOS_BREL_HI,  212)
++  RELOC_NUMBER (R_PPC_AMIGAOS_BREL_HA,  213)
++  
+ /* PowerPC VLE relocations.  */
+   RELOC_NUMBER (R_PPC_VLE_REL8,		216)
+   RELOC_NUMBER (R_PPC_VLE_REL15,	217)
+diff --git a/ld/Makefile.am b/ld/Makefile.am
+index 12b2c3c453f..21c7fb977da 100644
+--- a/ld/Makefile.am
++++ b/ld/Makefile.am
+@@ -336,6 +336,8 @@ ALL_EMULATION_SOURCES = \
+ 	ens32knbsd.c \
+ 	epc532macha.c \
+ 	epdp11.c \
++	eppcamiga.c \
++	eppcamiga_bss.c \
+ 	epjelf.c \
+ 	epjlelf.c \
+ 	eppcmacos.c \
+@@ -833,6 +835,8 @@ $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES): $(GEN_DEPENDS)
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epdp11.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epjelf.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epjlelf.Pc@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcamiga.Pc@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcamiga_bss.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcmacos.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epruelf.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/escore3_elf.Pc@am__quote@
+diff --git a/ld/Makefile.in b/ld/Makefile.in
+index 3d5685d6bae..ad217db2c0b 100644
+--- a/ld/Makefile.in
++++ b/ld/Makefile.in
+@@ -837,6 +837,8 @@ ALL_EMULATION_SOURCES = \
+ 	ens32knbsd.c \
+ 	epc532macha.c \
+ 	epdp11.c \
++	eppcamiga.c \
++	eppcamiga_bss.c \
+ 	epjelf.c \
+ 	epjlelf.c \
+ 	eppcmacos.c \
+@@ -1522,6 +1524,8 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ens32knbsd.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epc532macha.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epdp11.Po@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcamiga.Po@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcamiga_bss.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epjelf.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epjlelf.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcmacos.Po@am__quote@
+@@ -2505,6 +2509,8 @@ $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES): $(GEN_DEPENDS)
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ens32knbsd.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epc532macha.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epdp11.Pc@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcamiga.Pc@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcamiga_bss.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epjelf.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epjlelf.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcmacos.Pc@am__quote@
+diff --git a/ld/configure.tgt b/ld/configure.tgt
+index de04a44b812..a2b3a54a944 100644
+--- a/ld/configure.tgt
++++ b/ld/configure.tgt
+@@ -677,6 +677,10 @@ pjl*-*-*)		targ_emul=pjlelf
+ pj*-*-*)		targ_emul=pjelf
+ 			targ_extra_ofiles=ldelfgen.o
+ 			;;
++powerpc-*-amigaos*)
++			targ_emul=amigaos
++			targ_extra_emuls=elf32ppc
++			;;			
+ powerpc-*-freebsd* | powerpc-*-kfreebsd*-gnu)
+ 			targ_emul=elf32ppc_fbsd
+ 			targ_extra_emuls="elf32ppc elf32ppcsim"
+@@ -1144,6 +1148,10 @@ i[03-9x]86-*-cygwin* | x86_64-*-cygwin*)
+ *-*-netbsd*)
+   ;;
+ 
++powerpc-*-amigaos*)
++  NATIVE_LIB_DIRS='/gcc/local/lib /gcc/lib'
++  ;;
++
+ alpha*-*-*)
+   NATIVE_LIB_DIRS='/usr/local/lib /usr/ccs/lib /lib /usr/lib'
+   ;;
+diff --git a/ld/emulparams/amigaos.sh b/ld/emulparams/amigaos.sh
+new file mode 100644
+index 00000000000..fea98c85061
+--- /dev/null
++++ b/ld/emulparams/amigaos.sh
+@@ -0,0 +1,28 @@
++. ${srcdir}/emulparams/elf32ppccommon.sh
++. ${srcdir}/emulparams/plt_unwind.sh
++
++TEMPLATE_NAME=amigaos
++SCRIPT_NAME=amigaos
++OUTPUT_FORMAT="elf32-amigaos"
++MAXPAGESIZE="CONSTANT (MAXPAGESIZE)"
++COMMONPAGESIZE="CONSTANT (COMMONPAGESIZE)"
++ALIGNMENT=16
++ARCH=powerpc
++MACHINE=
++GENERATE_SHLIB_SCRIPT=yes
++TEXT_START_ADDR=0x01000000
++SHLIB_TEXT_START_ADDR=0x10000000
++unset WRITABLE_RODATA
++DATA_START_SYMBOLS="_DATA_BASE_ = .;"
++SDATA_START_SYMBOLS="_SDA_BASE_ = . + 0x8000;"
++DATA_GOT=
++SDATA_GOT=
++TEXT_PLT=yes
++SEPARATE_GOTPLT=0
++unset BSS_PLT
++unset DATA_PLT
++GOT=".got          ${RELOCATING-0} : SPECIAL { *(.got) }"
++PLT=".plt          ${RELOCATING-0} :  { *(.plt) }"
++# GOTPLT="${PLT}"
++OTHER_TEXT_SECTIONS="*(.glink)"
++EXTRA_EM_FILE=ppc32elf
+\ No newline at end of file
+diff --git a/ld/emultempl/amigaos.em b/ld/emultempl/amigaos.em
+new file mode 100644
+index 00000000000..ecf2fdb40b9
+--- /dev/null
++++ b/ld/emultempl/amigaos.em
+@@ -0,0 +1,2544 @@
++# This shell script emits a C file. -*- C -*-
++# It does some substitutions.
++# This file is now misnamed, because it supports both 32 bit and 64 bit
++# ELF emulations.
++test -z "${ELFSIZE}" && ELFSIZE=32
++if [ -z "$MACHINE" ]; then
++  OUTPUT_ARCH=${ARCH}
++else
++  OUTPUT_ARCH=${ARCH}:${MACHINE}
++fi
++fragment <<EOF
++/* This file is is generated by a shell script.  DO NOT EDIT! */
++
++/* ${ELFSIZE} bit ELF emulation code for ${EMULATION_NAME}
++   Copyright 1991, 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001,
++   2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013
++   Free Software Foundation, Inc.
++   Written by Steve Chamberlain <sac@cygnus.com>
++   ELF support by Ian Lance Taylor <ian@cygnus.com>
++
++   This file is part of the GNU Binutils.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
++   MA 02110-1301, USA.  */
++
++#define TARGET_IS_${EMULATION_NAME}
++
++#include "sysdep.h"
++#include "bfd.h"
++#include "libiberty.h"
++#include "filenames.h"
++#include "safe-ctype.h"
++#include "getopt.h"
++#include "md5.h"
++#include "sha1.h"
++#include <fcntl.h>
++
++#include "bfdlink.h"
++
++#include "ld.h"
++#include "ldmain.h"
++#include "ldmisc.h"
++#include "ldexp.h"
++#include "ldlang.h"
++#include "ldfile.h"
++#include "ldemul.h"
++#include <ldgram.h>
++#include "elf/common.h"
++#include "elf-bfd.h"
++#include "filenames.h"
++
++/* Declare functions used by various EXTRA_EM_FILEs.  */
++static void gld${EMULATION_NAME}_before_parse (void);
++static void gld${EMULATION_NAME}_after_open (void);
++static void gld${EMULATION_NAME}_before_allocation (void);
++static void gld${EMULATION_NAME}_after_allocation (void);
++static lang_output_section_statement_type *gld${EMULATION_NAME}_place_orphan
++  (asection *, const char *, int);
++EOF
++
++if [ "x${USE_LIBPATH}" = xyes ] ; then
++  case ${target} in
++    *-*-linux-* | *-*-k*bsd*-* | *-*-gnu*)
++  fragment <<EOF
++#ifdef HAVE_GLOB
++#include <glob.h>
++#endif
++EOF
++    ;;
++  esac
++fi
++
++# Import any needed special functions and/or overrides.
++#
++source_em ${srcdir}/emultempl/elf-generic.em
++if test -n "$EXTRA_EM_FILE" ; then
++  source_em ${srcdir}/emultempl/${EXTRA_EM_FILE}.em
++fi
++
++# Functions in this file can be overridden by setting the LDEMUL_* shell
++# variables.  If the name of the overriding function is the same as is
++# defined in this file, then don't output this file's version.
++# If a different overriding name is given then output the standard function
++# as presumably it is called from the overriding function.
++#
++if test x"$LDEMUL_BEFORE_PARSE" != xgld"$EMULATION_NAME"_before_parse; then
++fragment <<EOF
++
++static void
++gld${EMULATION_NAME}_before_parse (void)
++{
++  ldfile_set_output_arch ("${OUTPUT_ARCH}", bfd_arch_`echo ${ARCH} | sed -e 's/:.*//'`);
++  input_flags.dynamic = ${DYNAMIC_LINK-TRUE};
++  config.has_shared = `if test -n "$GENERATE_SHLIB_SCRIPT" ; then echo TRUE ; else echo FALSE ; fi`;
++  config.separate_code = `if test "x${SEPARATE_CODE}" = xyes ; then echo TRUE ; else echo FALSE ; fi`;
++}
++
++EOF
++fi
++
++if test x"$LDEMUL_RECOGNIZED_FILE" != xgld"${EMULATION_NAME}"_load_symbols; then
++fragment <<EOF
++/* Handle the generation of DT_NEEDED tags.  */
++
++static bfd_boolean
++gld${EMULATION_NAME}_load_symbols (lang_input_statement_type *entry)
++{
++  int link_class = 0;
++
++  /* Tell the ELF linker that we don't want the output file to have a
++     DT_NEEDED entry for this file, unless it is used to resolve
++     references in a regular object.  */
++  if (entry->flags.add_DT_NEEDED_for_regular)
++    link_class = DYN_AS_NEEDED;
++
++  /* Tell the ELF linker that we don't want the output file to have a
++     DT_NEEDED entry for any dynamic library in DT_NEEDED tags from
++     this file at all.  */
++  if (!entry->flags.add_DT_NEEDED_for_dynamic)
++    link_class |= DYN_NO_ADD_NEEDED;
++
++  if (entry->flags.just_syms
++      && (bfd_get_file_flags (entry->the_bfd) & DYNAMIC) != 0)
++    einfo (_("%P%F: --just-symbols may not be used on DSO: %B\n"),
++	   entry->the_bfd);
++
++  if (link_class == 0
++      || (bfd_get_file_flags (entry->the_bfd) & DYNAMIC) == 0)
++    return FALSE;
++
++  bfd_elf_set_dyn_lib_class (entry->the_bfd,
++			     (enum dynamic_lib_link_class) link_class);
++
++  /* Continue on with normal load_symbols processing.  */
++  return FALSE;
++}
++EOF
++fi
++
++fragment <<EOF
++
++/* These variables are required to pass information back and forth
++   between after_open and check_needed and stat_needed and vercheck.  */
++
++static struct bfd_link_needed_list *global_needed;
++static struct stat global_stat;
++static lang_input_statement_type *global_found;
++static struct bfd_link_needed_list *global_vercheck_needed;
++static bfd_boolean global_vercheck_failed;
++
++/* These variables are used to implement target options */
++
++static char *audit; /* colon (typically) separated list of libs */
++static char *depaudit; /* colon (typically) separated list of libs */
++
++/* Style of .note.gnu.build-id section.  */
++static const char *emit_note_gnu_build_id;
++
++/* On Linux, it's possible to have different versions of the same
++   shared library linked against different versions of libc.  The
++   dynamic linker somehow tags which libc version to use in
++   /etc/ld.so.cache, and, based on the libc that it sees in the
++   executable, chooses which version of the shared library to use.
++
++   We try to do a similar check here by checking whether this shared
++   library needs any other shared libraries which may conflict with
++   libraries we have already included in the link.  If it does, we
++   skip it, and try to find another shared library farther on down the
++   link path.
++
++   This is called via lang_for_each_input_file.
++   GLOBAL_VERCHECK_NEEDED is the list of objects needed by the object
++   which we are checking.  This sets GLOBAL_VERCHECK_FAILED if we find
++   a conflicting version.  */
++
++static void
++gld${EMULATION_NAME}_vercheck (lang_input_statement_type *s)
++{
++  const char *soname;
++  struct bfd_link_needed_list *l;
++
++  if (global_vercheck_failed)
++    return;
++  if (s->the_bfd == NULL
++      || (bfd_get_file_flags (s->the_bfd) & DYNAMIC) == 0)
++    return;
++
++  soname = bfd_elf_get_dt_soname (s->the_bfd);
++  if (soname == NULL)
++    soname = lbasename (bfd_get_filename (s->the_bfd));
++
++  for (l = global_vercheck_needed; l != NULL; l = l->next)
++    {
++      const char *suffix;
++
++      if (filename_cmp (soname, l->name) == 0)
++	{
++	  /* Probably can't happen, but it's an easy check.  */
++	  continue;
++	}
++
++      if (strchr (l->name, '/') != NULL)
++	continue;
++
++      suffix = strstr (l->name, ".so.");
++      if (suffix == NULL)
++	continue;
++
++      suffix += sizeof ".so." - 1;
++
++      if (filename_ncmp (soname, l->name, suffix - l->name) == 0)
++	{
++	  /* Here we know that S is a dynamic object FOO.SO.VER1, and
++	     the object we are considering needs a dynamic object
++	     FOO.SO.VER2, and VER1 and VER2 are different.  This
++	     appears to be a version mismatch, so we tell the caller
++	     to try a different version of this library.  */
++	  global_vercheck_failed = TRUE;
++	  return;
++	}
++    }
++}
++
++
++/* See if an input file matches a DT_NEEDED entry by running stat on
++   the file.  */
++
++static void
++gld${EMULATION_NAME}_stat_needed (lang_input_statement_type *s)
++{
++  struct stat st;
++  const char *suffix;
++  const char *soname;
++
++  if (global_found != NULL)
++    return;
++  if (s->the_bfd == NULL)
++    return;
++
++  /* If this input file was an as-needed entry, and wasn't found to be
++     needed at the stage it was linked, then don't say we have loaded it.  */
++  if ((bfd_elf_get_dyn_lib_class (s->the_bfd) & DYN_AS_NEEDED) != 0)
++    return;
++
++  if (bfd_stat (s->the_bfd, &st) != 0)
++    {
++      einfo ("%P:%B: bfd_stat failed: %E\n", s->the_bfd);
++      return;
++    }
++
++  /* Some operating systems, e.g. Windows, do not provide a meaningful
++     st_ino; they always set it to zero.  (Windows does provide a
++     meaningful st_dev.)  Do not indicate a duplicate library in that
++     case.  While there is no guarantee that a system that provides
++     meaningful inode numbers will never set st_ino to zero, this is
++     merely an optimization, so we do not need to worry about false
++     negatives.  */
++  if (st.st_dev == global_stat.st_dev
++      && st.st_ino == global_stat.st_ino
++      && st.st_ino != 0)
++    {
++      global_found = s;
++      return;
++    }
++
++  /* We issue a warning if it looks like we are including two
++     different versions of the same shared library.  For example,
++     there may be a problem if -lc picks up libc.so.6 but some other
++     shared library has a DT_NEEDED entry of libc.so.5.  This is a
++     heuristic test, and it will only work if the name looks like
++     NAME.so.VERSION.  FIXME: Depending on file names is error-prone.
++     If we really want to issue warnings about mixing version numbers
++     of shared libraries, we need to find a better way.  */
++
++  if (strchr (global_needed->name, '/') != NULL)
++    return;
++  suffix = strstr (global_needed->name, ".so.");
++  if (suffix == NULL)
++    return;
++  suffix += sizeof ".so." - 1;
++
++  soname = bfd_elf_get_dt_soname (s->the_bfd);
++  if (soname == NULL)
++    soname = lbasename (s->filename);
++
++  if (filename_ncmp (soname, global_needed->name, suffix - global_needed->name) == 0)
++    einfo ("%P: warning: %s, needed by %B, may conflict with %s\n",
++	   global_needed->name, global_needed->by, soname);
++}
++
++struct dt_needed
++{
++  bfd *by;
++  const char *name;
++};
++
++/* This function is called for each possible name for a dynamic object
++   named by a DT_NEEDED entry.  The FORCE parameter indicates whether
++   to skip the check for a conflicting version.  */
++
++static bfd_boolean
++gld${EMULATION_NAME}_try_needed (struct dt_needed *needed,
++				 int force)
++{
++  bfd *abfd;
++  const char *name = needed->name;
++  const char *soname;
++  int link_class;
++
++  abfd = bfd_openr (name, bfd_get_target (link_info.output_bfd));
++  if (abfd == NULL)
++    return FALSE;
++
++  /* Linker needs to decompress sections.  */
++  abfd->flags |= BFD_DECOMPRESS;
++
++  if (! bfd_check_format (abfd, bfd_object))
++    {
++      bfd_close (abfd);
++      return FALSE;
++    }
++  if ((bfd_get_file_flags (abfd) & DYNAMIC) == 0)
++    {
++      bfd_close (abfd);
++      return FALSE;
++    }
++
++  /* For DT_NEEDED, they have to match.  */
++  if (abfd->xvec != link_info.output_bfd->xvec)
++    {
++      bfd_close (abfd);
++      return FALSE;
++    }
++
++  /* Check whether this object would include any conflicting library
++     versions.  If FORCE is set, then we skip this check; we use this
++     the second time around, if we couldn't find any compatible
++     instance of the shared library.  */
++
++  if (! force)
++    {
++      struct bfd_link_needed_list *needs;
++
++      if (! bfd_elf_get_bfd_needed_list (abfd, &needs))
++	einfo ("%F%P:%B: bfd_elf_get_bfd_needed_list failed: %E\n", abfd);
++
++      if (needs != NULL)
++	{
++	  global_vercheck_needed = needs;
++	  global_vercheck_failed = FALSE;
++	  lang_for_each_input_file (gld${EMULATION_NAME}_vercheck);
++	  if (global_vercheck_failed)
++	    {
++	      bfd_close (abfd);
++	      /* Return FALSE to force the caller to move on to try
++		 another file on the search path.  */
++	      return FALSE;
++	    }
++
++	  /* But wait!  It gets much worse.  On Linux, if a shared
++	     library does not use libc at all, we are supposed to skip
++	     it the first time around in case we encounter a shared
++	     library later on with the same name which does use the
++	     version of libc that we want.  This is much too horrible
++	     to use on any system other than Linux.  */
++
++EOF
++case ${target} in
++  *-*-linux-* | *-*-k*bsd*-* | *-*-gnu*)
++    fragment <<EOF
++	  {
++	    struct bfd_link_needed_list *l;
++
++	    for (l = needs; l != NULL; l = l->next)
++	      if (CONST_STRNEQ (l->name, "libc.so"))
++		break;
++	    if (l == NULL)
++	      {
++		bfd_close (abfd);
++		return FALSE;
++	      }
++	  }
++
++EOF
++    ;;
++esac
++fragment <<EOF
++	}
++    }
++
++  /* We've found a dynamic object matching the DT_NEEDED entry.  */
++
++  /* We have already checked that there is no other input file of the
++     same name.  We must now check again that we are not including the
++     same file twice.  We need to do this because on many systems
++     libc.so is a symlink to, e.g., libc.so.1.  The SONAME entry will
++     reference libc.so.1.  If we have already included libc.so, we
++     don't want to include libc.so.1 if they are the same file, and we
++     can only check that using stat.  */
++
++  if (bfd_stat (abfd, &global_stat) != 0)
++    einfo ("%F%P:%B: bfd_stat failed: %E\n", abfd);
++
++  /* First strip off everything before the last '/'.  */
++  soname = lbasename (abfd->filename);
++
++  if (verbose)
++    info_msg (_("found %s at %s\n"), soname, name);
++
++  global_found = NULL;
++  lang_for_each_input_file (gld${EMULATION_NAME}_stat_needed);
++  if (global_found != NULL)
++    {
++      /* Return TRUE to indicate that we found the file, even though
++	 we aren't going to do anything with it.  */
++      return TRUE;
++    }
++
++  /* Specify the soname to use.  */
++  bfd_elf_set_dt_needed_name (abfd, soname);
++
++  /* Tell the ELF linker that we don't want the output file to have a
++     DT_NEEDED entry for this file, unless it is used to resolve
++     references in a regular object.  */
++  link_class = DYN_DT_NEEDED;
++
++  /* Tell the ELF linker that we don't want the output file to have a
++     DT_NEEDED entry for this file at all if the entry is from a file
++     with DYN_NO_ADD_NEEDED.  */
++  if (needed->by != NULL
++      && (bfd_elf_get_dyn_lib_class (needed->by) & DYN_NO_ADD_NEEDED) != 0)
++    link_class |= DYN_NO_NEEDED | DYN_NO_ADD_NEEDED;
++
++  bfd_elf_set_dyn_lib_class (abfd, (enum dynamic_lib_link_class) link_class);
++
++  /* Add this file into the symbol table.  */
++  if (! bfd_link_add_symbols (abfd, &link_info))
++    einfo ("%F%B: error adding symbols: %E\n", abfd);
++
++  return TRUE;
++}
++
++
++/* Search for a needed file in a path.  */
++
++static bfd_boolean
++gld${EMULATION_NAME}_search_needed (const char *path,
++				    struct dt_needed *n, int force)
++{
++  const char *s;
++  const char *name = n->name;
++  size_t len;
++  struct dt_needed needed;
++
++  if (name[0] == '/')
++    return gld${EMULATION_NAME}_try_needed (n, force);
++
++  if (path == NULL || *path == '\0')
++    return FALSE;
++
++  needed.by = n->by;
++  needed.name = n->name;
++
++  len = strlen (name);
++  while (1)
++    {
++      char *filename, *sset;
++
++      s = strchr (path, config.rpath_separator);
++      if (s == NULL)
++	s = path + strlen (path);
++
++#if HAVE_DOS_BASED_FILE_SYSTEM
++      /* Assume a match on the second char is part of drive specifier.  */
++      else if (config.rpath_separator == ':'
++	       && s == path + 1
++	       && ISALPHA (*path))
++	{
++	  s = strchr (s + 1, config.rpath_separator);
++	  if (s == NULL)
++	    s = path + strlen (path);
++	}
++#endif
++      filename = (char *) xmalloc (s - path + len + 2);
++      if (s == path)
++	sset = filename;
++      else
++	{
++	  memcpy (filename, path, s - path);
++	  filename[s - path] = '/';
++	  sset = filename + (s - path) + 1;
++	}
++      strcpy (sset, name);
++
++      needed.name = filename;
++      if (gld${EMULATION_NAME}_try_needed (&needed, force))
++	return TRUE;
++
++      free (filename);
++
++      if (*s == '\0')
++	break;
++      path = s + 1;
++    }
++
++  return FALSE;
++}
++
++EOF
++if [ "x${USE_LIBPATH}" = xyes ] ; then
++  fragment <<EOF
++
++/* Add the sysroot to every entry in a path separated by
++   config.rpath_separator.  */
++
++static char *
++gld${EMULATION_NAME}_add_sysroot (const char *path)
++{
++  int len, colons, i;
++  char *ret, *p;
++
++  len = strlen (path);
++  colons = 0;
++  i = 0;
++  while (path[i])
++    if (path[i++] == config.rpath_separator)
++      colons++;
++
++  if (path[i])
++    colons++;
++
++  len = len + (colons + 1) * strlen (ld_sysroot);
++  ret = xmalloc (len + 1);
++  strcpy (ret, ld_sysroot);
++  p = ret + strlen (ret);
++  i = 0;
++  while (path[i])
++    if (path[i] == config.rpath_separator)
++      {
++	*p++ = path[i++];
++	strcpy (p, ld_sysroot);
++	p = p + strlen (p);
++      }
++    else
++      *p++ = path[i++];
++
++  *p = 0;
++  return ret;
++}
++
++EOF
++  case ${target} in
++    *-*-freebsd* | *-*-dragonfly*)
++      fragment <<EOF
++/* Read the system search path the FreeBSD way rather than the Linux way.  */
++#ifdef HAVE_ELF_HINTS_H
++#include <elf-hints.h>
++#else
++#include "elf-hints-local.h"
++#endif
++
++static bfd_boolean
++gld${EMULATION_NAME}_check_ld_elf_hints (const struct bfd_link_needed_list *l,
++					 int force)
++{
++  static bfd_boolean initialized;
++  static char *ld_elf_hints;
++  struct dt_needed needed;
++
++  if (!initialized)
++    {
++      FILE *f;
++      char *tmppath;
++
++      tmppath = concat (ld_sysroot, _PATH_ELF_HINTS, (const char *) NULL);
++      f = fopen (tmppath, FOPEN_RB);
++      free (tmppath);
++      if (f != NULL)
++	{
++	  struct elfhints_hdr hdr;
++
++	  if (fread (&hdr, 1, sizeof (hdr), f) == sizeof (hdr)
++	      && hdr.magic == ELFHINTS_MAGIC
++	      && hdr.version == 1)
++	    {
++	      if (fseek (f, hdr.strtab + hdr.dirlist, SEEK_SET) != -1)
++		{
++		  char *b;
++
++		  b = xmalloc (hdr.dirlistlen + 1);
++		  if (fread (b, 1, hdr.dirlistlen + 1, f) ==
++		      hdr.dirlistlen + 1)
++		    ld_elf_hints = gld${EMULATION_NAME}_add_sysroot (b);
++
++		  free (b);
++		}
++	    }
++	  fclose (f);
++	}
++
++      initialized = TRUE;
++    }
++
++  if (ld_elf_hints == NULL)
++    return FALSE;
++
++  needed.by = l->by;
++  needed.name = l->name;
++  return gld${EMULATION_NAME}_search_needed (ld_elf_hints, &needed, force);
++}
++EOF
++    # FreeBSD
++    ;;
++
++    *-*-linux-* | *-*-k*bsd*-* | *-*-gnu*)
++      fragment <<EOF
++/* For a native linker, check the file /etc/ld.so.conf for directories
++   in which we may find shared libraries.  /etc/ld.so.conf is really
++   only meaningful on Linux.  */
++
++struct gld${EMULATION_NAME}_ld_so_conf
++{
++  char *path;
++  size_t len, alloc;
++};
++
++static bfd_boolean
++gld${EMULATION_NAME}_parse_ld_so_conf
++     (struct gld${EMULATION_NAME}_ld_so_conf *info, const char *filename);
++
++static void
++gld${EMULATION_NAME}_parse_ld_so_conf_include
++     (struct gld${EMULATION_NAME}_ld_so_conf *info, const char *filename,
++      const char *pattern)
++{
++  char *newp = NULL;
++#ifdef HAVE_GLOB
++  glob_t gl;
++#endif
++
++  if (pattern[0] != '/')
++    {
++      char *p = strrchr (filename, '/');
++      size_t patlen = strlen (pattern) + 1;
++
++      newp = xmalloc (p - filename + 1 + patlen);
++      memcpy (newp, filename, p - filename + 1);
++      memcpy (newp + (p - filename + 1), pattern, patlen);
++      pattern = newp;
++    }
++
++#ifdef HAVE_GLOB
++  if (glob (pattern, 0, NULL, &gl) == 0)
++    {
++      size_t i;
++
++      for (i = 0; i < gl.gl_pathc; ++i)
++	gld${EMULATION_NAME}_parse_ld_so_conf (info, gl.gl_pathv[i]);
++      globfree (&gl);
++    }
++#else
++  /* If we do not have glob, treat the pattern as a literal filename.  */
++  gld${EMULATION_NAME}_parse_ld_so_conf (info, pattern);
++#endif
++
++  if (newp)
++    free (newp);
++}
++
++static bfd_boolean
++gld${EMULATION_NAME}_parse_ld_so_conf
++     (struct gld${EMULATION_NAME}_ld_so_conf *info, const char *filename)
++{
++  FILE *f = fopen (filename, FOPEN_RT);
++  char *line;
++  size_t linelen;
++
++  if (f == NULL)
++    return FALSE;
++
++  linelen = 256;
++  line = xmalloc (linelen);
++  do
++    {
++      char *p = line, *q;
++
++      /* Normally this would use getline(3), but we need to be portable.  */
++      while ((q = fgets (p, linelen - (p - line), f)) != NULL
++	     && strlen (q) == linelen - (p - line) - 1
++	     && line[linelen - 2] != '\n')
++	{
++	  line = xrealloc (line, 2 * linelen);
++	  p = line + linelen - 1;
++	  linelen += linelen;
++	}
++
++      if (q == NULL && p == line)
++	break;
++
++      p = strchr (line, '\n');
++      if (p)
++	*p = '\0';
++
++      /* Because the file format does not know any form of quoting we
++	 can search forward for the next '#' character and if found
++	 make it terminating the line.  */
++      p = strchr (line, '#');
++      if (p)
++	*p = '\0';
++
++      /* Remove leading whitespace.  NUL is no whitespace character.  */
++      p = line;
++      while (*p == ' ' || *p == '\f' || *p == '\r' || *p == '\t' || *p == '\v')
++	++p;
++
++      /* If the line is blank it is ignored.  */
++      if (p[0] == '\0')
++	continue;
++
++      if (CONST_STRNEQ (p, "include") && (p[7] == ' ' || p[7] == '\t'))
++	{
++	  char *dir, c;
++	  p += 8;
++	  do
++	    {
++	      while (*p == ' ' || *p == '\t')
++		++p;
++
++	      if (*p == '\0')
++		break;
++
++	      dir = p;
++
++	      while (*p != ' ' && *p != '\t' && *p)
++		++p;
++
++	      c = *p;
++	      *p++ = '\0';
++	      if (dir[0] != '\0')
++		gld${EMULATION_NAME}_parse_ld_so_conf_include (info, filename,
++							       dir);
++	    }
++	  while (c != '\0');
++	}
++      else
++	{
++	  char *dir = p;
++	  while (*p && *p != '=' && *p != ' ' && *p != '\t' && *p != '\f'
++		 && *p != '\r' && *p != '\v')
++	    ++p;
++
++	  while (p != dir && p[-1] == '/')
++	    --p;
++	  if (info->path == NULL)
++	    {
++	      info->alloc = p - dir + 1 + 256;
++	      info->path = xmalloc (info->alloc);
++	      info->len = 0;
++	    }
++	  else
++	    {
++	      if (info->len + 1 + (p - dir) >= info->alloc)
++		{
++		  info->alloc += p - dir + 256;
++		  info->path = xrealloc (info->path, info->alloc);
++		}
++	      info->path[info->len++] = config.rpath_separator;
++	    }
++	  memcpy (info->path + info->len, dir, p - dir);
++	  info->len += p - dir;
++	  info->path[info->len] = '\0';
++	}
++    }
++  while (! feof (f));
++  free (line);
++  fclose (f);
++  return TRUE;
++}
++
++static bfd_boolean
++gld${EMULATION_NAME}_check_ld_so_conf (const struct bfd_link_needed_list *l,
++				       int force)
++{
++  static bfd_boolean initialized;
++  static char *ld_so_conf;
++  struct dt_needed needed;
++
++  if (! initialized)
++    {
++      char *tmppath;
++      struct gld${EMULATION_NAME}_ld_so_conf info;
++
++      info.path = NULL;
++      info.len = info.alloc = 0;
++      tmppath = concat (ld_sysroot, "${prefix}/etc/ld.so.conf",
++			(const char *) NULL);
++      if (!gld${EMULATION_NAME}_parse_ld_so_conf (&info, tmppath))
++	{
++	  free (tmppath);
++	  tmppath = concat (ld_sysroot, "/etc/ld.so.conf",
++			    (const char *) NULL);
++	  gld${EMULATION_NAME}_parse_ld_so_conf (&info, tmppath);
++	}
++      free (tmppath);
++
++      if (info.path)
++	{
++	  char *d = gld${EMULATION_NAME}_add_sysroot (info.path);
++	  free (info.path);
++	  ld_so_conf = d;
++	}
++      initialized = TRUE;
++    }
++
++  if (ld_so_conf == NULL)
++    return FALSE;
++
++
++  needed.by = l->by;
++  needed.name = l->name;
++  return gld${EMULATION_NAME}_search_needed (ld_so_conf, &needed, force);
++}
++
++EOF
++    # Linux
++    ;;
++  esac
++fi
++fragment <<EOF
++
++/* See if an input file matches a DT_NEEDED entry by name.  */
++
++static void
++gld${EMULATION_NAME}_check_needed (lang_input_statement_type *s)
++{
++  const char *soname;
++
++  /* Stop looking if we've found a loaded lib.  */
++  if (global_found != NULL
++      && (bfd_elf_get_dyn_lib_class (global_found->the_bfd)
++	  & DYN_AS_NEEDED) == 0)
++    return;
++
++  if (s->filename == NULL || s->the_bfd == NULL)
++    return;
++
++  /* Don't look for a second non-loaded as-needed lib.  */
++  if (global_found != NULL
++      && (bfd_elf_get_dyn_lib_class (s->the_bfd) & DYN_AS_NEEDED) != 0)
++    return;
++
++  if (filename_cmp (s->filename, global_needed->name) == 0)
++    {
++      global_found = s;
++      return;
++    }
++
++  if (s->flags.search_dirs)
++    {
++      const char *f = strrchr (s->filename, '/');
++      if (f != NULL
++	  && filename_cmp (f + 1, global_needed->name) == 0)
++	{
++	  global_found = s;
++	  return;
++	}
++    }
++
++  soname = bfd_elf_get_dt_soname (s->the_bfd);
++  if (soname != NULL
++      && filename_cmp (soname, global_needed->name) == 0)
++    {
++      global_found = s;
++      return;
++    }
++}
++
++EOF
++
++if test x"$LDEMUL_AFTER_OPEN" != xgld"$EMULATION_NAME"_after_open; then
++fragment <<EOF
++
++static bfd_size_type
++id_note_section_size (bfd *abfd ATTRIBUTE_UNUSED)
++{
++  const char *style = emit_note_gnu_build_id;
++  bfd_size_type size;
++
++  size = offsetof (Elf_External_Note, name[sizeof "GNU"]);
++  size = (size + 3) & -(bfd_size_type) 4;
++
++  if (!strcmp (style, "md5") || !strcmp (style, "uuid"))
++    size += 128 / 8;
++  else if (!strcmp (style, "sha1"))
++    size += 160 / 8;
++  else if (!strncmp (style, "0x", 2))
++    {
++      /* ID is in string form (hex).  Convert to bits.  */
++      const char *id = style + 2;
++      do
++	{
++	  if (ISXDIGIT (id[0]) && ISXDIGIT (id[1]))
++	    {
++	      ++size;
++	      id += 2;
++	    }
++	  else if (*id == '-' || *id == ':')
++	    ++id;
++	  else
++	    {
++	      size = 0;
++	      break;
++	    }
++	} while (*id != '\0');
++    }
++  else
++    size = 0;
++
++  return size;
++}
++
++static unsigned char
++read_hex (const char xdigit)
++{
++  if (ISDIGIT (xdigit))
++    return xdigit - '0';
++  if (ISUPPER (xdigit))
++    return xdigit - 'A' + 0xa;
++  if (ISLOWER (xdigit))
++    return xdigit - 'a' + 0xa;
++  abort ();
++  return 0;
++}
++
++static bfd_boolean
++write_build_id (bfd *abfd)
++{
++  const struct elf_backend_data *bed = get_elf_backend_data (abfd);
++  struct elf_obj_tdata *t = elf_tdata (abfd);
++  const char *style;
++  asection *asec;
++  Elf_Internal_Shdr *i_shdr;
++  unsigned char *contents, *id_bits;
++  bfd_size_type size;
++  file_ptr position;
++  Elf_External_Note *e_note;
++  typedef void (*sum_fn) (const void *, size_t, void *);
++
++  style = t->o->build_id.style;
++  asec = t->o->build_id.sec;
++  if (bfd_is_abs_section (asec->output_section))
++    {
++      einfo (_("%P: warning: .note.gnu.build-id section discarded,"
++	       " --build-id ignored.\n"));
++      return TRUE;
++    }
++  i_shdr = &elf_section_data (asec->output_section)->this_hdr;
++
++  if (i_shdr->contents == NULL)
++    {
++      if (asec->contents == NULL)
++	asec->contents = (unsigned char *) xmalloc (asec->size);
++      contents = asec->contents;
++    }
++  else
++    contents = i_shdr->contents + asec->output_offset;
++
++  e_note = (Elf_External_Note *) contents;
++  size = offsetof (Elf_External_Note, name[sizeof "GNU"]);
++  size = (size + 3) & -(bfd_size_type) 4;
++  id_bits = contents + size;
++  size = asec->size - size;
++
++  bfd_h_put_32 (abfd, sizeof "GNU", &e_note->namesz);
++  bfd_h_put_32 (abfd, size, &e_note->descsz);
++  bfd_h_put_32 (abfd, NT_GNU_BUILD_ID, &e_note->type);
++  memcpy (e_note->name, "GNU", sizeof "GNU");
++
++  if (strcmp (style, "md5") == 0)
++    {
++      struct md5_ctx ctx;
++
++      md5_init_ctx (&ctx);
++      if (!bed->s->checksum_contents (abfd, (sum_fn) &md5_process_bytes, &ctx))
++	return FALSE;
++      md5_finish_ctx (&ctx, id_bits);
++    }
++  else if (strcmp (style, "sha1") == 0)
++    {
++      struct sha1_ctx ctx;
++
++      sha1_init_ctx (&ctx);
++      if (!bed->s->checksum_contents (abfd, (sum_fn) &sha1_process_bytes, &ctx))
++	return FALSE;
++      sha1_finish_ctx (&ctx, id_bits);
++    }
++  else if (strcmp (style, "uuid") == 0)
++    {
++      int n;
++      int fd = open ("/dev/urandom", O_RDONLY);
++      if (fd < 0)
++	return FALSE;
++      n = read (fd, id_bits, size);
++      close (fd);
++      if (n < (int) size)
++	return FALSE;
++    }
++  else if (strncmp (style, "0x", 2) == 0)
++    {
++      /* ID is in string form (hex).  Convert to bits.  */
++      const char *id = style + 2;
++      size_t n = 0;
++      do
++	{
++	  if (ISXDIGIT (id[0]) && ISXDIGIT (id[1]))
++	    {
++	      id_bits[n] = read_hex (*id++) << 4;
++	      id_bits[n++] |= read_hex (*id++);
++	    }
++	  else if (*id == '-' || *id == ':')
++	    ++id;
++	  else
++	    abort ();		/* Should have been validated earlier.  */
++	} while (*id != '\0');
++    }
++  else
++    abort ();			/* Should have been validated earlier.  */
++
++  position = i_shdr->sh_offset + asec->output_offset;
++  size = asec->size;
++  return (bfd_seek (abfd, position, SEEK_SET) == 0
++	  && bfd_bwrite (contents, size, abfd) == size);
++}
++
++/* Make .note.gnu.build-id section, and set up elf_tdata->build_id.  */
++
++static bfd_boolean
++setup_build_id (bfd *ibfd)
++{
++  asection *s;
++  bfd_size_type size;
++  flagword flags;
++
++  size = id_note_section_size (ibfd);
++  if (size == 0)
++    {
++      einfo ("%P: warning: unrecognized --build-id style ignored.\n");
++      return FALSE;
++    }
++
++  flags = (SEC_ALLOC | SEC_LOAD | SEC_IN_MEMORY
++	   | SEC_LINKER_CREATED | SEC_READONLY | SEC_DATA);
++  s = bfd_make_section_with_flags (ibfd, ".note.gnu.build-id", flags);
++  if (s != NULL && bfd_set_section_alignment (ibfd, s, 2))
++    {
++      struct elf_obj_tdata *t = elf_tdata (link_info.output_bfd);
++      t->o->build_id.after_write_object_contents = &write_build_id;
++      t->o->build_id.style = emit_note_gnu_build_id;
++      t->o->build_id.sec = s;
++      elf_section_type (s) = SHT_NOTE;
++      s->size = size;
++      return TRUE;
++    }
++
++  einfo ("%P: warning: Cannot create .note.gnu.build-id section,"
++	 " --build-id ignored.\n");
++  return FALSE;
++}
++
++/* This is called after all the input files have been opened.  */
++
++static void
++gld${EMULATION_NAME}_after_open (void)
++{
++  struct bfd_link_needed_list *needed, *l;
++  struct elf_link_hash_table *htab;
++
++  after_open_default ();
++
++  htab = elf_hash_table (&link_info);
++  if (!is_elf_hash_table (htab))
++    return;
++
++  if (emit_note_gnu_build_id != NULL)
++    {
++      bfd *abfd;
++
++      /* Find an ELF input.  */
++      for (abfd = link_info.input_bfds;
++	   abfd != (bfd *) NULL; abfd = abfd->link_next)
++	if (bfd_get_flavour (abfd) == bfd_target_elf_flavour)
++	  break;
++
++      /* PR 10555: If there are no ELF input files do not try to
++	 create a .note.gnu-build-id section.  */
++      if (abfd == NULL
++	  || !setup_build_id (abfd))
++	{
++	  free ((char *) emit_note_gnu_build_id);
++	  emit_note_gnu_build_id = NULL;
++	}
++    }
++
++  if (link_info.relocatable)
++    return;
++
++  if (link_info.eh_frame_hdr
++      && !link_info.traditional_format)
++    {
++      bfd *abfd, *elfbfd = NULL;
++      bfd_boolean warn_eh_frame = FALSE;
++      asection *s;
++
++      for (abfd = link_info.input_bfds; abfd; abfd = abfd->link_next)
++	{
++	  if (bfd_get_flavour (abfd) == bfd_target_elf_flavour)
++	    elfbfd = abfd;
++	  if (!warn_eh_frame)
++	    {
++	      s = bfd_get_section_by_name (abfd, ".eh_frame");
++	      while (s != NULL
++		     && (s->size <= 8
++			 || bfd_is_abs_section (s->output_section)))
++		s = bfd_get_next_section_by_name (s);
++	      warn_eh_frame = s != NULL;
++	    }
++	  if (elfbfd && warn_eh_frame)
++	    break;
++	}
++      if (elfbfd)
++	{
++	  const struct elf_backend_data *bed;
++
++	  bed = get_elf_backend_data (elfbfd);
++	  s = bfd_make_section_with_flags (elfbfd, ".eh_frame_hdr",
++					   bed->dynamic_sec_flags
++					   | SEC_READONLY);
++	  if (s != NULL
++	      && bfd_set_section_alignment (elfbfd, s, 2))
++	    {
++	      htab->eh_info.hdr_sec = s;
++	      warn_eh_frame = FALSE;
++	    }
++	}
++      if (warn_eh_frame)
++	einfo ("%P: warning: Cannot create .eh_frame_hdr section,"
++	       " --eh-frame-hdr ignored.\n");
++    }
++
++  /* Get the list of files which appear in DT_NEEDED entries in
++     dynamic objects included in the link (often there will be none).
++     For each such file, we want to track down the corresponding
++     library, and include the symbol table in the link.  This is what
++     the runtime dynamic linker will do.  Tracking the files down here
++     permits one dynamic object to include another without requiring
++     special action by the person doing the link.  Note that the
++     needed list can actually grow while we are stepping through this
++     loop.  */
++  needed = bfd_elf_get_needed_list (link_info.output_bfd, &link_info);
++  for (l = needed; l != NULL; l = l->next)
++    {
++      struct bfd_link_needed_list *ll;
++      struct dt_needed n, nn;
++      int force;
++
++      /* If the lib that needs this one was --as-needed and wasn't
++	 found to be needed, then this lib isn't needed either.  */
++      if (l->by != NULL
++	  && (bfd_elf_get_dyn_lib_class (l->by) & DYN_AS_NEEDED) != 0)
++	continue;
++
++      /* Skip the lib if --no-copy-dt-needed-entries and
++	 --allow-shlib-undefined is in effect.  */
++      if (l->by != NULL
++	  && link_info.unresolved_syms_in_shared_libs == RM_IGNORE
++	  && (bfd_elf_get_dyn_lib_class (l->by) & DYN_NO_ADD_NEEDED) != 0)
++	continue;
++
++      /* If we've already seen this file, skip it.  */
++      for (ll = needed; ll != l; ll = ll->next)
++	if ((ll->by == NULL
++	     || (bfd_elf_get_dyn_lib_class (ll->by) & DYN_AS_NEEDED) == 0)
++	    && strcmp (ll->name, l->name) == 0)
++	  break;
++      if (ll != l)
++	continue;
++
++      /* See if this file was included in the link explicitly.  */
++      global_needed = l;
++      global_found = NULL;
++      lang_for_each_input_file (gld${EMULATION_NAME}_check_needed);
++      if (global_found != NULL
++	  && (bfd_elf_get_dyn_lib_class (global_found->the_bfd)
++	      & DYN_AS_NEEDED) == 0)
++	continue;
++
++      n.by = l->by;
++      n.name = l->name;
++      nn.by = l->by;
++      if (verbose)
++	info_msg (_("%s needed by %B\n"), l->name, l->by);
++
++      /* As-needed libs specified on the command line (or linker script)
++	 take priority over libs found in search dirs.  */
++      if (global_found != NULL)
++	{
++	  nn.name = global_found->filename;
++	  if (gld${EMULATION_NAME}_try_needed (&nn, TRUE))
++	    continue;
++	}
++
++      /* We need to find this file and include the symbol table.  We
++	 want to search for the file in the same way that the dynamic
++	 linker will search.  That means that we want to use
++	 rpath_link, rpath, then the environment variable
++	 LD_LIBRARY_PATH (native only), then the DT_RPATH/DT_RUNPATH
++	 entries (native only), then the linker script LIB_SEARCH_DIRS.
++	 We do not search using the -L arguments.
++
++	 We search twice.  The first time, we skip objects which may
++	 introduce version mismatches.  The second time, we force
++	 their use.  See gld${EMULATION_NAME}_vercheck comment.  */
++      for (force = 0; force < 2; force++)
++	{
++	  size_t len;
++	  search_dirs_type *search;
++EOF
++if [ "x${NATIVE}" = xyes ] ; then
++fragment <<EOF
++	  const char *lib_path;
++EOF
++fi
++if [ "x${USE_LIBPATH}" = xyes ] ; then
++fragment <<EOF
++	  struct bfd_link_needed_list *rp;
++	  int found;
++EOF
++fi
++fragment <<EOF
++
++	  if (gld${EMULATION_NAME}_search_needed (command_line.rpath_link,
++						  &n, force))
++	    break;
++EOF
++if [ "x${USE_LIBPATH}" = xyes ] ; then
++fragment <<EOF
++	  if (gld${EMULATION_NAME}_search_needed (command_line.rpath,
++						  &n, force))
++	    break;
++EOF
++fi
++if [ "x${NATIVE}" = xyes ] ; then
++fragment <<EOF
++	  if (command_line.rpath_link == NULL
++	      && command_line.rpath == NULL)
++	    {
++	      lib_path = (const char *) getenv ("LD_RUN_PATH");
++	      if (gld${EMULATION_NAME}_search_needed (lib_path, &n,
++						      force))
++		break;
++	    }
++	  lib_path = (const char *) getenv ("LD_LIBRARY_PATH");
++	  if (gld${EMULATION_NAME}_search_needed (lib_path, &n, force))
++	    break;
++EOF
++fi
++if [ "x${USE_LIBPATH}" = xyes ] ; then
++fragment <<EOF
++	  found = 0;
++	  rp = bfd_elf_get_runpath_list (link_info.output_bfd, &link_info);
++	  for (; !found && rp != NULL; rp = rp->next)
++	    {
++	      char *tmpname = gld${EMULATION_NAME}_add_sysroot (rp->name);
++	      found = (rp->by == l->by
++		       && gld${EMULATION_NAME}_search_needed (tmpname,
++							      &n,
++							      force));
++	      free (tmpname);
++	    }
++	  if (found)
++	    break;
++
++EOF
++fi
++if [ "x${USE_LIBPATH}" = xyes ] ; then
++  case ${target} in
++    *-*-freebsd* | *-*-dragonfly*)
++      fragment <<EOF
++	  if (gld${EMULATION_NAME}_check_ld_elf_hints (l, force))
++	    break;
++EOF
++    # FreeBSD
++    ;;
++
++    *-*-linux-* | *-*-k*bsd*-* | *-*-gnu*)
++      fragment <<EOF
++	  if (gld${EMULATION_NAME}_check_ld_so_conf (l, force))
++	    break;
++
++EOF
++    # Linux
++    ;;
++  esac
++fi
++fragment <<EOF
++	  len = strlen (l->name);
++	  for (search = search_head; search != NULL; search = search->next)
++	    {
++	      char *filename;
++
++	      if (search->cmdline)
++		continue;
++	      filename = (char *) xmalloc (strlen (search->name) + len + 2);
++	      sprintf (filename, "%s/%s", search->name, l->name);
++	      nn.name = filename;
++	      if (gld${EMULATION_NAME}_try_needed (&nn, force))
++		break;
++	      free (filename);
++	    }
++	  if (search != NULL)
++	    break;
++EOF
++fragment <<EOF
++	}
++
++      if (force < 2)
++	continue;
++
++      einfo ("%P: warning: %s, needed by %B, not found (try using -rpath or -rpath-link)\n",
++	     l->name, l->by);
++    }
++}
++
++EOF
++fi
++
++fragment <<EOF
++
++/* Look through an expression for an assignment statement.  */
++
++static void
++gld${EMULATION_NAME}_find_exp_assignment (etree_type *exp)
++{
++  bfd_boolean provide = FALSE;
++
++  switch (exp->type.node_class)
++    {
++    case etree_provide:
++    case etree_provided:
++      provide = TRUE;
++      /* Fall thru */
++    case etree_assign:
++      /* We call record_link_assignment even if the symbol is defined.
++	 This is because if it is defined by a dynamic object, we
++	 actually want to use the value defined by the linker script,
++	 not the value from the dynamic object (because we are setting
++	 symbols like etext).  If the symbol is defined by a regular
++	 object, then, as it happens, calling record_link_assignment
++	 will do no harm.  */
++      if (strcmp (exp->assign.dst, ".") != 0)
++	{
++	  if (!bfd_elf_record_link_assignment (link_info.output_bfd,
++					       &link_info,
++					       exp->assign.dst, provide,
++					       exp->assign.hidden))
++	    einfo ("%P%F: failed to record assignment to %s: %E\n",
++		   exp->assign.dst);
++	}
++      gld${EMULATION_NAME}_find_exp_assignment (exp->assign.src);
++      break;
++
++    case etree_binary:
++      gld${EMULATION_NAME}_find_exp_assignment (exp->binary.lhs);
++      gld${EMULATION_NAME}_find_exp_assignment (exp->binary.rhs);
++      break;
++
++    case etree_trinary:
++      gld${EMULATION_NAME}_find_exp_assignment (exp->trinary.cond);
++      gld${EMULATION_NAME}_find_exp_assignment (exp->trinary.lhs);
++      gld${EMULATION_NAME}_find_exp_assignment (exp->trinary.rhs);
++      break;
++
++    case etree_unary:
++      gld${EMULATION_NAME}_find_exp_assignment (exp->unary.child);
++      break;
++
++    default:
++      break;
++    }
++}
++
++
++/* This is called by the before_allocation routine via
++   lang_for_each_statement.  It locates any assignment statements, and
++   tells the ELF backend about them, in case they are assignments to
++   symbols which are referred to by dynamic objects.  */
++
++static void
++gld${EMULATION_NAME}_find_statement_assignment (lang_statement_union_type *s)
++{
++  if (s->header.type == lang_assignment_statement_enum)
++    gld${EMULATION_NAME}_find_exp_assignment (s->assignment_statement.exp);
++}
++
++EOF
++
++if test x"$LDEMUL_BEFORE_ALLOCATION" != xgld"$EMULATION_NAME"_before_allocation; then
++  if test x"${ELF_INTERPRETER_NAME+set}" = xset; then
++    ELF_INTERPRETER_SET_DEFAULT="
++  if (sinterp != NULL)
++    {
++      sinterp->contents = (unsigned char *) ${ELF_INTERPRETER_NAME};
++      sinterp->size = strlen ((char *) sinterp->contents) + 1;
++    }
++
++"
++  else
++    ELF_INTERPRETER_SET_DEFAULT=
++  fi
++fragment <<EOF
++
++/* used by before_allocation and handle_option. */
++static void
++gld${EMULATION_NAME}_append_to_separated_string (char **to, char *op_arg)
++{
++  if (*to == NULL)
++    *to = xstrdup (op_arg);
++  else
++    {
++      size_t to_len = strlen (*to);
++      size_t op_arg_len = strlen (op_arg);
++      char *buf;
++      char *cp = *to;
++
++      /* First see whether OPTARG is already in the path.  */
++      do
++	{
++	  if (strncmp (op_arg, cp, op_arg_len) == 0
++	      && (cp[op_arg_len] == 0
++		  || cp[op_arg_len] == config.rpath_separator))
++	    /* We found it.  */
++	    break;
++
++	  /* Not yet found.  */
++	  cp = strchr (cp, config.rpath_separator);
++	  if (cp != NULL)
++	    ++cp;
++	}
++      while (cp != NULL);
++
++      if (cp == NULL)
++	{
++	  buf = xmalloc (to_len + op_arg_len + 2);
++	  sprintf (buf, "%s%c%s", *to,
++		   config.rpath_separator, op_arg);
++	  free (*to);
++	  *to = buf;
++	}
++    }
++}
++
++/* This is called after the sections have been attached to output
++   sections, but before any sizes or addresses have been set.  */
++
++static void
++gld${EMULATION_NAME}_before_allocation (void)
++{
++  const char *rpath;
++  asection *sinterp;
++  bfd *abfd;
++
++  if (is_elf_hash_table (link_info.hash))
++    {
++      _bfd_elf_tls_setup (link_info.output_bfd, &link_info);
++
++      /* Make __ehdr_start hidden if it has been referenced, to
++	 prevent the symbol from being dynamic.  */
++      if (!link_info.relocatable)
++       {
++         struct elf_link_hash_entry *h
++           = elf_link_hash_lookup (elf_hash_table (&link_info), "__ehdr_start",
++                                   FALSE, FALSE, TRUE);
++
++         /* Only adjust the export class if the symbol was referenced
++            and not defined, otherwise leave it alone.  */
++         if (h != NULL
++             && (h->root.type == bfd_link_hash_new
++                 || h->root.type == bfd_link_hash_undefined
++                 || h->root.type == bfd_link_hash_undefweak
++                 || h->root.type == bfd_link_hash_common))
++           {
++             _bfd_elf_link_hash_hide_symbol (&link_info, h, TRUE);
++             if (ELF_ST_VISIBILITY (h->other) != STV_INTERNAL)
++               h->other = (h->other & ~ELF_ST_VISIBILITY (-1)) | STV_HIDDEN;
++           }
++       }
++
++      /* If we are going to make any variable assignments, we need to
++	 let the ELF backend know about them in case the variables are
++	 referred to by dynamic objects.  */
++      lang_for_each_statement (gld${EMULATION_NAME}_find_statement_assignment);
++    }
++
++  /* Let the ELF backend work out the sizes of any sections required
++     by dynamic linking.  */
++  rpath = command_line.rpath;
++  if (rpath == NULL)
++    rpath = (const char *) getenv ("LD_RUN_PATH");
++
++  for (abfd = link_info.input_bfds; abfd; abfd = abfd->link_next)
++    if (bfd_get_flavour (abfd) == bfd_target_elf_flavour)
++      {
++	const char *audit_libs = elf_dt_audit (abfd);
++
++	/* If the input bfd contains an audit entry, we need to add it as
++	   a dep audit entry.  */
++	if (audit_libs && *audit_libs != '\0')
++	  {
++	    char *cp = xstrdup (audit_libs);
++	    do
++	      {
++		int more = 0;
++		char *cp2 = strchr (cp, config.rpath_separator);
++
++		if (cp2)
++		  {
++		    *cp2 = '\0';
++		    more = 1;
++		  }
++
++		if (cp != NULL && *cp != '\0')
++		  gld${EMULATION_NAME}_append_to_separated_string (&depaudit, cp);
++
++		cp = more ? ++cp2 : NULL;
++	      }
++	    while (cp != NULL);
++	  }
++      }
++
++  if (! (bfd_elf_size_dynamic_sections
++	 (link_info.output_bfd, command_line.soname, rpath,
++	  command_line.filter_shlib, audit, depaudit,
++	  (const char * const *) command_line.auxiliary_filters,
++	  &link_info, &sinterp)))
++    einfo ("%P%F: failed to set dynamic section sizes: %E\n");
++
++${ELF_INTERPRETER_SET_DEFAULT}
++  /* Let the user override the dynamic linker we are using.  */
++  if (command_line.interpreter != NULL
++      && sinterp != NULL)
++    {
++      sinterp->contents = (bfd_byte *) command_line.interpreter;
++      sinterp->size = strlen (command_line.interpreter) + 1;
++    }
++
++  /* Look for any sections named .gnu.warning.  As a GNU extensions,
++     we treat such sections as containing warning messages.  We print
++     out the warning message, and then zero out the section size so
++     that it does not get copied into the output file.  */
++
++  {
++    LANG_FOR_EACH_INPUT_STATEMENT (is)
++      {
++	asection *s;
++	bfd_size_type sz;
++	char *msg;
++	bfd_boolean ret;
++
++	if (is->flags.just_syms)
++	  continue;
++
++	s = bfd_get_section_by_name (is->the_bfd, ".gnu.warning");
++	if (s == NULL)
++	  continue;
++
++	sz = s->size;
++	msg = (char *) xmalloc ((size_t) (sz + 1));
++	if (! bfd_get_section_contents (is->the_bfd, s,	msg,
++					(file_ptr) 0, sz))
++	  einfo ("%F%B: Can't read contents of section .gnu.warning: %E\n",
++		 is->the_bfd);
++	msg[sz] = '\0';
++	ret = link_info.callbacks->warning (&link_info, msg,
++					    (const char *) NULL,
++					    is->the_bfd, (asection *) NULL,
++					    (bfd_vma) 0);
++	ASSERT (ret);
++	free (msg);
++
++	/* Clobber the section size, so that we don't waste space
++	   copying the warning into the output file.  If we've already
++	   sized the output section, adjust its size.  The adjustment
++	   is on rawsize because targets that size sections early will
++	   have called lang_reset_memory_regions after sizing.  */
++	if (s->output_section != NULL
++	    && s->output_section->rawsize >= s->size)
++	  s->output_section->rawsize -= s->size;
++
++	s->size = 0;
++
++	/* Also set SEC_EXCLUDE, so that local symbols defined in the
++	   warning section don't get copied to the output.  */
++	s->flags |= SEC_EXCLUDE | SEC_KEEP;
++      }
++  }
++
++  before_allocation_default ();
++
++  if (!bfd_elf_size_dynsym_hash_dynstr (link_info.output_bfd, &link_info))
++    einfo ("%P%F: failed to set dynamic section sizes: %E\n");
++}
++
++EOF
++fi
++
++if test x"$LDEMUL_OPEN_DYNAMIC_ARCHIVE" != xgld"$EMULATION_NAME"_open_dynamic_archive; then
++fragment <<EOF
++
++/* Try to open a dynamic archive.  This is where we know that ELF
++   dynamic libraries have an extension of .so (or .sl on oddball systems
++   like hpux).  */
++
++static bfd_boolean
++gld${EMULATION_NAME}_open_dynamic_archive
++  (const char *arch, search_dirs_type *search, lang_input_statement_type *entry)
++{
++  const char *filename;
++  char *string;
++
++  if (! entry->flags.maybe_archive)
++    return FALSE;
++
++  filename = entry->filename;
++
++  /* This allocates a few bytes too many when EXTRA_SHLIB_EXTENSION
++     is defined, but it does not seem worth the headache to optimize
++     away those two bytes of space.  */
++  string = (char *) xmalloc (strlen (search->name)
++			     + strlen (filename)
++			     + strlen (arch)
++#ifdef EXTRA_SHLIB_EXTENSION
++			     + strlen (EXTRA_SHLIB_EXTENSION)
++#endif
++			     + sizeof "/lib.so");
++
++  sprintf (string, "%s/lib%s%s.so", search->name, filename, arch);
++
++#ifdef EXTRA_SHLIB_EXTENSION
++  /* Try the .so extension first.  If that fails build a new filename
++     using EXTRA_SHLIB_EXTENSION.  */
++  if (! ldfile_try_open_bfd (string, entry))
++    {
++      sprintf (string, "%s/lib%s%s%s", search->name,
++	       filename, arch, EXTRA_SHLIB_EXTENSION);
++#endif
++
++  if (! ldfile_try_open_bfd (string, entry))
++    {
++      free (string);
++      return FALSE;
++    }
++#ifdef EXTRA_SHLIB_EXTENSION
++    }
++#endif
++
++  entry->filename = string;
++
++  /* We have found a dynamic object to include in the link.  The ELF
++     backend linker will create a DT_NEEDED entry in the .dynamic
++     section naming this file.  If this file includes a DT_SONAME
++     entry, it will be used.  Otherwise, the ELF linker will just use
++     the name of the file.  For an archive found by searching, like
++     this one, the DT_NEEDED entry should consist of just the name of
++     the file, without the path information used to find it.  Note
++     that we only need to do this if we have a dynamic object; an
++     archive will never be referenced by a DT_NEEDED entry.
++
++     FIXME: This approach--using bfd_elf_set_dt_needed_name--is not
++     very pretty.  I haven't been able to think of anything that is
++     pretty, though.  */
++  if (bfd_check_format (entry->the_bfd, bfd_object)
++      && (entry->the_bfd->flags & DYNAMIC) != 0)
++    {
++      ASSERT (entry->flags.maybe_archive && entry->flags.search_dirs);
++
++      /* Rather than duplicating the logic above.  Just use the
++	 filename we recorded earlier.  */
++
++      filename = lbasename (entry->filename);
++      bfd_elf_set_dt_needed_name (entry->the_bfd, filename);
++    }
++
++  return TRUE;
++}
++
++EOF
++fi
++
++if test x"$LDEMUL_PLACE_ORPHAN" != xgld"$EMULATION_NAME"_place_orphan; then
++fragment <<EOF
++
++/* A variant of lang_output_section_find used by place_orphan.  */
++
++static lang_output_section_statement_type *
++output_rel_find (asection *sec, int isdyn)
++{
++  lang_output_section_statement_type *lookup;
++  lang_output_section_statement_type *last = NULL;
++  lang_output_section_statement_type *last_alloc = NULL;
++  lang_output_section_statement_type *last_ro_alloc = NULL;
++  lang_output_section_statement_type *last_rel = NULL;
++  lang_output_section_statement_type *last_rel_alloc = NULL;
++  int rela = sec->name[4] == 'a';
++
++  for (lookup = &lang_output_section_statement.head->output_section_statement;
++       lookup != NULL;
++       lookup = lookup->next)
++    {
++      if (lookup->constraint >= 0
++	  && CONST_STRNEQ (lookup->name, ".rel"))
++	{
++	  int lookrela = lookup->name[4] == 'a';
++
++	  /* .rel.dyn must come before all other reloc sections, to suit
++	     GNU ld.so.  */
++	  if (isdyn)
++	    break;
++
++	  /* Don't place after .rel.plt as doing so results in wrong
++	     dynamic tags.  */
++	  if (strcmp (".plt", lookup->name + 4 + lookrela) == 0)
++	    break;
++
++	  if (rela == lookrela || last_rel == NULL)
++	    last_rel = lookup;
++	  if ((rela == lookrela || last_rel_alloc == NULL)
++	      && lookup->bfd_section != NULL
++	      && (lookup->bfd_section->flags & SEC_ALLOC) != 0)
++	    last_rel_alloc = lookup;
++	}
++
++      last = lookup;
++      if (lookup->bfd_section != NULL
++	  && (lookup->bfd_section->flags & SEC_ALLOC) != 0)
++	{
++	  last_alloc = lookup;
++	  if ((lookup->bfd_section->flags & SEC_READONLY) != 0)
++	    last_ro_alloc = lookup;
++	}
++    }
++
++  if (last_rel_alloc)
++    return last_rel_alloc;
++
++  if (last_rel)
++    return last_rel;
++
++  if (last_ro_alloc)
++    return last_ro_alloc;
++
++  if (last_alloc)
++    return last_alloc;
++
++  return last;
++}
++
++/* Place an orphan section.  We use this to put random SHF_ALLOC
++   sections in the right segment.  */
++
++static lang_output_section_statement_type *
++gld${EMULATION_NAME}_place_orphan (asection *s,
++				   const char *secname,
++				   int constraint)
++{
++  static struct orphan_save hold[] =
++    {
++      { ".text",
++	SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_READONLY | SEC_CODE,
++	0, 0, 0, 0 },
++      { ".rodata",
++	SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_READONLY | SEC_DATA,
++	0, 0, 0, 0 },
++      { ".data",
++	SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_DATA,
++	0, 0, 0, 0 },
++      { ".bss",
++	SEC_ALLOC,
++	0, 0, 0, 0 },
++      { 0,
++	SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_READONLY | SEC_DATA,
++	0, 0, 0, 0 },
++      { ".interp",
++	SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_READONLY | SEC_DATA,
++	0, 0, 0, 0 },
++      { ".sdata",
++	SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_DATA | SEC_SMALL_DATA,
++	0, 0, 0, 0 },
++      { ".comment",
++	SEC_HAS_CONTENTS,
++	0, 0, 0, 0 },
++    };
++  enum orphan_save_index
++    {
++      orphan_text = 0,
++      orphan_rodata,
++      orphan_data,
++      orphan_bss,
++      orphan_rel,
++      orphan_interp,
++      orphan_sdata,
++      orphan_nonalloc
++    };
++  static int orphan_init_done = 0;
++  struct orphan_save *place;
++  lang_output_section_statement_type *after;
++  lang_output_section_statement_type *os;
++  lang_output_section_statement_type *match_by_name = NULL;
++  int isdyn = 0;
++  int iself = s->owner->xvec->flavour == bfd_target_elf_flavour;
++  unsigned int sh_type = iself ? elf_section_type (s) : SHT_NULL;
++
++  if (! link_info.relocatable
++      && link_info.combreloc
++      && (s->flags & SEC_ALLOC))
++    {
++      if (iself)
++	switch (sh_type)
++	  {
++	  case SHT_RELA:
++	    secname = ".rela.dyn";
++	    isdyn = 1;
++	    break;
++	  case SHT_REL:
++	    secname = ".rel.dyn";
++	    isdyn = 1;
++	    break;
++	  default:
++	    break;
++	  }
++      else if (CONST_STRNEQ (secname, ".rel"))
++	{
++	  secname = secname[4] == 'a' ? ".rela.dyn" : ".rel.dyn";
++	  isdyn = 1;
++	}
++    }
++
++  /* Look through the script to see where to place this section.  */
++  if (constraint == 0)
++    for (os = lang_output_section_find (secname);
++	 os != NULL;
++	 os = next_matching_output_section_statement (os, 0))
++      {
++	/* If we don't match an existing output section, tell
++	   lang_insert_orphan to create a new output section.  */
++	constraint = SPECIAL;
++
++	if (os->bfd_section != NULL
++	    && (os->bfd_section->flags == 0
++		|| (_bfd_elf_match_sections_by_type (link_info.output_bfd,
++						     os->bfd_section,
++						     s->owner, s)
++		    && ((s->flags ^ os->bfd_section->flags)
++			& (SEC_LOAD | SEC_ALLOC)) == 0)))
++	  {
++	    /* We already have an output section statement with this
++	       name, and its bfd section has compatible flags.
++	       If the section already exists but does not have any flags
++	       set, then it has been created by the linker, probably as a
++	       result of a --section-start command line switch.  */
++	    lang_add_section (&os->children, s, NULL, os);
++	    return os;
++	  }
++
++	/* Save unused output sections in case we can match them
++	   against orphans later.  */
++	if (os->bfd_section == NULL)
++	  match_by_name = os;
++      }
++
++  /* If we didn't match an active output section, see if we matched an
++     unused one and use that.  */
++  if (match_by_name)
++    {
++      lang_add_section (&match_by_name->children, s, NULL, match_by_name);
++      return match_by_name;
++    }
++
++  if (!orphan_init_done)
++    {
++      struct orphan_save *ho;
++
++      for (ho = hold; ho < hold + sizeof (hold) / sizeof (hold[0]); ++ho)
++	if (ho->name != NULL)
++	  {
++	    ho->os = lang_output_section_find (ho->name);
++	    if (ho->os != NULL && ho->os->flags == 0)
++	      ho->os->flags = ho->flags;
++	  }
++      orphan_init_done = 1;
++    }
++
++  /* If this is a final link, then always put .gnu.warning.SYMBOL
++     sections into the .text section to get them out of the way.  */
++  if (link_info.executable
++      && ! link_info.relocatable
++      && CONST_STRNEQ (s->name, ".gnu.warning.")
++      && hold[orphan_text].os != NULL)
++    {
++      os = hold[orphan_text].os;
++      lang_add_section (&os->children, s, NULL, os);
++      return os;
++    }
++
++  /* Decide which segment the section should go in based on the
++     section name and section flags.  We put loadable .note sections
++     right after the .interp section, so that the PT_NOTE segment is
++     stored right after the program headers where the OS can read it
++     in the first page.  */
++
++  place = NULL;
++  if ((s->flags & (SEC_ALLOC | SEC_DEBUGGING)) == 0)
++    place = &hold[orphan_nonalloc];
++  else if ((s->flags & SEC_ALLOC) == 0)
++    ;
++  else if ((s->flags & SEC_LOAD) != 0
++	   && ((iself && sh_type == SHT_NOTE)
++	       || (!iself && CONST_STRNEQ (secname, ".note"))))
++    place = &hold[orphan_interp];
++  else if ((s->flags & (SEC_LOAD | SEC_HAS_CONTENTS | SEC_THREAD_LOCAL)) == 0)
++    place = &hold[orphan_bss];
++  else if ((s->flags & SEC_SMALL_DATA) != 0)
++    place = &hold[orphan_sdata];
++  else if ((s->flags & SEC_READONLY) == 0)
++    place = &hold[orphan_data];
++  else if (((iself && (sh_type == SHT_RELA || sh_type == SHT_REL))
++	    || (!iself && CONST_STRNEQ (secname, ".rel")))
++	   && (s->flags & SEC_LOAD) != 0)
++    place = &hold[orphan_rel];
++  else if ((s->flags & SEC_CODE) == 0)
++    place = &hold[orphan_rodata];
++  else
++    place = &hold[orphan_text];
++
++  after = NULL;
++  if (place != NULL)
++    {
++      if (place->os == NULL)
++	{
++	  if (place->name != NULL)
++	    place->os = lang_output_section_find (place->name);
++	  else
++	    place->os = output_rel_find (s, isdyn);
++	}
++      after = place->os;
++      if (after == NULL)
++	after = lang_output_section_find_by_flags
++	  (s, &place->os, _bfd_elf_match_sections_by_type);
++      if (after == NULL)
++	/* *ABS* is always the first output section statement.  */
++	after = &lang_output_section_statement.head->output_section_statement;
++    }
++
++  return lang_insert_orphan (s, secname, constraint, after, place, NULL, NULL);
++}
++EOF
++fi
++
++if test x"$LDEMUL_AFTER_ALLOCATION" != xgld"$EMULATION_NAME"_after_allocation; then
++fragment <<EOF
++
++static void
++gld${EMULATION_NAME}_after_allocation (void)
++{
++  bfd_boolean need_layout = bfd_elf_discard_info (link_info.output_bfd,
++						  &link_info);
++  gld${EMULATION_NAME}_map_segments (need_layout);
++}
++EOF
++fi
++
++if test x"$LDEMUL_GET_SCRIPT" != xgld"$EMULATION_NAME"_get_script; then
++fragment <<EOF
++
++static char *
++gld${EMULATION_NAME}_get_script (int *isfile)
++EOF
++
++if test -n "$COMPILE_IN"
++then
++# Scripts compiled in.
++
++# sed commands to quote an ld script as a C string.
++sc="-f stringify.sed"
++
++fragment <<EOF
++{
++  *isfile = 0;
++
++  if (link_info.relocatable && config.build_constructors)
++    return
++EOF
++sed $sc ldscripts/${EMULATION_NAME}.xu			>> e${EMULATION_NAME}.c
++echo '  ; else if (link_info.relocatable) return'	>> e${EMULATION_NAME}.c
++sed $sc ldscripts/${EMULATION_NAME}.xr			>> e${EMULATION_NAME}.c
++echo '  ; else if (!config.text_read_only) return'	>> e${EMULATION_NAME}.c
++sed $sc ldscripts/${EMULATION_NAME}.xbn			>> e${EMULATION_NAME}.c
++if cmp -s ldscripts/${EMULATION_NAME}.x ldscripts/${EMULATION_NAME}.xn; then : ; else
++echo '  ; else if (!config.magic_demand_paged) return'	>> e${EMULATION_NAME}.c
++sed $sc ldscripts/${EMULATION_NAME}.xn			>> e${EMULATION_NAME}.c
++fi
++if test -n "$GENERATE_PIE_SCRIPT" ; then
++if test -n "$GENERATE_COMBRELOC_SCRIPT" ; then
++echo '  ; else if (link_info.pie && link_info.combreloc' >> e${EMULATION_NAME}.c
++echo '             && link_info.relro' >> e${EMULATION_NAME}.c
++echo '             && (link_info.flags & DF_BIND_NOW)) return' >> e${EMULATION_NAME}.c
++sed $sc ldscripts/${EMULATION_NAME}.xdw			>> e${EMULATION_NAME}.c
++echo '  ; else if (link_info.pie && link_info.combreloc) return' >> e${EMULATION_NAME}.c
++sed $sc ldscripts/${EMULATION_NAME}.xdc			>> e${EMULATION_NAME}.c
++fi
++echo '  ; else if (link_info.pie) return'		>> e${EMULATION_NAME}.c
++sed $sc ldscripts/${EMULATION_NAME}.xd			>> e${EMULATION_NAME}.c
++fi
++if test -n "$GENERATE_SHLIB_SCRIPT" ; then
++if test -n "$GENERATE_COMBRELOC_SCRIPT" ; then
++echo '  ; else if (link_info.shared && link_info.combreloc' >> e${EMULATION_NAME}.c
++echo '             && link_info.relro' >> e${EMULATION_NAME}.c
++echo '             && (link_info.flags & DF_BIND_NOW)) return' >> e${EMULATION_NAME}.c
++sed $sc ldscripts/${EMULATION_NAME}.xsw			>> e${EMULATION_NAME}.c
++echo '  ; else if (link_info.shared && link_info.combreloc) return' >> e${EMULATION_NAME}.c
++sed $sc ldscripts/${EMULATION_NAME}.xsc			>> e${EMULATION_NAME}.c
++fi
++echo '  ; else if (link_info.shared) return'		>> e${EMULATION_NAME}.c
++sed $sc ldscripts/${EMULATION_NAME}.xs			>> e${EMULATION_NAME}.c
++fi
++if test -n "$GENERATE_COMBRELOC_SCRIPT" ; then
++echo '  ; else if (link_info.combreloc && link_info.relro' >> e${EMULATION_NAME}.c
++echo '             && (link_info.flags & DF_BIND_NOW)) return' >> e${EMULATION_NAME}.c
++sed $sc ldscripts/${EMULATION_NAME}.xw			>> e${EMULATION_NAME}.c
++echo '  ; else if (link_info.combreloc) return'		>> e${EMULATION_NAME}.c
++sed $sc ldscripts/${EMULATION_NAME}.xc			>> e${EMULATION_NAME}.c
++fi
++echo '  ; else return'					>> e${EMULATION_NAME}.c
++sed $sc ldscripts/${EMULATION_NAME}.x			>> e${EMULATION_NAME}.c
++echo '; }'						>> e${EMULATION_NAME}.c
++
++else
++# Scripts read from the filesystem.
++
++fragment <<EOF
++{
++  *isfile = 1;
++
++  if (link_info.relocatable && config.build_constructors)
++    return "ldscripts/${EMULATION_NAME}.xu";
++  else if (link_info.relocatable)
++    return "ldscripts/${EMULATION_NAME}.xr";
++  else if (!config.text_read_only)
++    return "ldscripts/${EMULATION_NAME}.xbn";
++EOF
++if cmp -s ldscripts/${EMULATION_NAME}.x ldscripts/${EMULATION_NAME}.xn; then :
++else
++fragment <<EOF
++  else if (!config.magic_demand_paged)
++    return "ldscripts/${EMULATION_NAME}.xn";
++EOF
++fi
++if test -n "$GENERATE_PIE_SCRIPT" ; then
++if test -n "$GENERATE_COMBRELOC_SCRIPT" ; then
++fragment <<EOF
++  else if (link_info.pie && link_info.combreloc
++	   && link_info.relro && (link_info.flags & DF_BIND_NOW))
++    return "ldscripts/${EMULATION_NAME}.xdw";
++  else if (link_info.pie && link_info.combreloc)
++    return "ldscripts/${EMULATION_NAME}.xdc";
++EOF
++fi
++fragment <<EOF
++  else if (link_info.pie)
++    return "ldscripts/${EMULATION_NAME}.xd";
++EOF
++fi
++if test -n "$GENERATE_SHLIB_SCRIPT" ; then
++if test -n "$GENERATE_COMBRELOC_SCRIPT" ; then
++fragment <<EOF
++  else if (link_info.shared && link_info.combreloc
++	   && link_info.relro && (link_info.flags & DF_BIND_NOW))
++    return "ldscripts/${EMULATION_NAME}.xsw";
++  else if (link_info.shared && link_info.combreloc)
++    return "ldscripts/${EMULATION_NAME}.xsc";
++EOF
++fi
++fragment <<EOF
++  else if (link_info.shared)
++    return "ldscripts/${EMULATION_NAME}.xs";
++EOF
++fi
++if test -n "$GENERATE_COMBRELOC_SCRIPT" ; then
++fragment <<EOF
++  else if (link_info.combreloc && link_info.relro
++	   && (link_info.flags & DF_BIND_NOW))
++    return "ldscripts/${EMULATION_NAME}.xw";
++  else if (link_info.combreloc)
++    return "ldscripts/${EMULATION_NAME}.xc";
++EOF
++fi
++fragment <<EOF
++  else
++    return "ldscripts/${EMULATION_NAME}.x";
++}
++
++EOF
++fi
++fi
++
++if test -n "$PARSE_AND_LIST_PROLOGUE" ; then
++fragment <<EOF
++ $PARSE_AND_LIST_PROLOGUE
++EOF
++fi
++
++fragment <<EOF
++
++#define OPTION_DISABLE_NEW_DTAGS	(400)
++#define OPTION_ENABLE_NEW_DTAGS		(OPTION_DISABLE_NEW_DTAGS + 1)
++#define OPTION_GROUP			(OPTION_ENABLE_NEW_DTAGS + 1)
++#define OPTION_EH_FRAME_HDR		(OPTION_GROUP + 1)
++#define OPTION_EXCLUDE_LIBS		(OPTION_EH_FRAME_HDR + 1)
++#define OPTION_HASH_STYLE		(OPTION_EXCLUDE_LIBS + 1)
++#define OPTION_BUILD_ID			(OPTION_HASH_STYLE + 1)
++#define OPTION_AUDIT			(OPTION_BUILD_ID + 1)
++
++static void
++gld${EMULATION_NAME}_add_options
++  (int ns, char **shortopts, int nl, struct option **longopts,
++   int nrl ATTRIBUTE_UNUSED, struct option **really_longopts ATTRIBUTE_UNUSED)
++{
++EOF
++if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
++fragment <<EOF
++  static const char xtra_short[] = "${PARSE_AND_LIST_SHORTOPTS}z:P:";
++EOF
++else
++fragment <<EOF
++  static const char xtra_short[] = "${PARSE_AND_LIST_SHORTOPTS}z:";
++EOF
++fi
++fragment <<EOF
++  static const struct option xtra_long[] = {
++EOF
++if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
++fragment <<EOF
++    {"audit", required_argument, NULL, OPTION_AUDIT},
++    {"Bgroup", no_argument, NULL, OPTION_GROUP},
++EOF
++fi
++fragment <<EOF
++    {"build-id", optional_argument, NULL, OPTION_BUILD_ID},
++EOF
++if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
++fragment <<EOF
++    {"depaudit", required_argument, NULL, 'P'},
++    {"disable-new-dtags", no_argument, NULL, OPTION_DISABLE_NEW_DTAGS},
++    {"enable-new-dtags", no_argument, NULL, OPTION_ENABLE_NEW_DTAGS},
++    {"eh-frame-hdr", no_argument, NULL, OPTION_EH_FRAME_HDR},
++    {"exclude-libs", required_argument, NULL, OPTION_EXCLUDE_LIBS},
++    {"hash-style", required_argument, NULL, OPTION_HASH_STYLE},
++EOF
++fi
++if test -n "$PARSE_AND_LIST_LONGOPTS" ; then
++fragment <<EOF
++    $PARSE_AND_LIST_LONGOPTS
++EOF
++fi
++fragment <<EOF
++    {NULL, no_argument, NULL, 0}
++  };
++
++  *shortopts = (char *) xrealloc (*shortopts, ns + sizeof (xtra_short));
++  memcpy (*shortopts + ns, &xtra_short, sizeof (xtra_short));
++  *longopts = (struct option *)
++    xrealloc (*longopts, nl * sizeof (struct option) + sizeof (xtra_long));
++  memcpy (*longopts + nl, &xtra_long, sizeof (xtra_long));
++}
++
++#define DEFAULT_BUILD_ID_STYLE	"sha1"
++
++static bfd_boolean
++gld${EMULATION_NAME}_handle_option (int optc)
++{
++  switch (optc)
++    {
++    default:
++      return FALSE;
++
++    case OPTION_BUILD_ID:
++      if (emit_note_gnu_build_id != NULL)
++	{
++	  free ((char *) emit_note_gnu_build_id);
++	  emit_note_gnu_build_id = NULL;
++	}
++      if (optarg == NULL)
++	optarg = DEFAULT_BUILD_ID_STYLE;
++      if (strcmp (optarg, "none"))
++	emit_note_gnu_build_id = xstrdup (optarg);
++      break;
++
++EOF
++
++if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
++fragment <<EOF
++    case OPTION_AUDIT:
++	gld${EMULATION_NAME}_append_to_separated_string (&audit, optarg);
++	break;
++
++    case 'P':
++	gld${EMULATION_NAME}_append_to_separated_string (&depaudit, optarg);
++	break;
++
++    case OPTION_DISABLE_NEW_DTAGS:
++      link_info.new_dtags = FALSE;
++      break;
++
++    case OPTION_ENABLE_NEW_DTAGS:
++      link_info.new_dtags = TRUE;
++      break;
++
++    case OPTION_EH_FRAME_HDR:
++      link_info.eh_frame_hdr = TRUE;
++      break;
++
++    case OPTION_GROUP:
++      link_info.flags_1 |= (bfd_vma) DF_1_GROUP;
++      /* Groups must be self-contained.  */
++      link_info.unresolved_syms_in_objects = RM_GENERATE_ERROR;
++      link_info.unresolved_syms_in_shared_libs = RM_GENERATE_ERROR;
++      break;
++
++    case OPTION_EXCLUDE_LIBS:
++      add_excluded_libs (optarg);
++      break;
++
++    case OPTION_HASH_STYLE:
++      link_info.emit_hash = FALSE;
++      link_info.emit_gnu_hash = FALSE;
++      if (strcmp (optarg, "sysv") == 0)
++	link_info.emit_hash = TRUE;
++      else if (strcmp (optarg, "gnu") == 0)
++	link_info.emit_gnu_hash = TRUE;
++      else if (strcmp (optarg, "both") == 0)
++	{
++	  link_info.emit_hash = TRUE;
++	  link_info.emit_gnu_hash = TRUE;
++	}
++      else
++	einfo (_("%P%F: invalid hash style \`%s'\n"), optarg);
++      break;
++
++EOF
++fi
++fragment <<EOF
++    case 'z':
++      if (strcmp (optarg, "defs") == 0)
++	link_info.unresolved_syms_in_objects = RM_GENERATE_ERROR;
++      else if (strcmp (optarg, "muldefs") == 0)
++	link_info.allow_multiple_definition = TRUE;
++      else if (CONST_STRNEQ (optarg, "max-page-size="))
++	{
++	  char *end;
++
++	  config.maxpagesize = strtoul (optarg + 14, &end, 0);
++	  if (*end || (config.maxpagesize & (config.maxpagesize - 1)) != 0)
++	    einfo (_("%P%F: invalid maxium page size \`%s'\n"),
++		   optarg + 14);
++	}
++      else if (CONST_STRNEQ (optarg, "common-page-size="))
++	{
++	  char *end;
++	  config.commonpagesize = strtoul (optarg + 17, &end, 0);
++	  if (*end
++	      || (config.commonpagesize & (config.commonpagesize - 1)) != 0)
++	    einfo (_("%P%F: invalid common page size \`%s'\n"),
++		   optarg + 17);
++	}
++      else if (CONST_STRNEQ (optarg, "stack-size="))
++	{
++	  char *end;
++	  link_info.stacksize = strtoul (optarg + 11, &end, 0);
++	  if (*end || link_info.stacksize < 0)
++	    einfo (_("%P%F: invalid stack size \`%s'\n"), optarg + 11);
++	  if (!link_info.stacksize)
++	    /* Use -1 for explicit no-stack, because zero means
++	       'default'.   */
++	    link_info.stacksize = -1;
++	}
++      else if (strcmp (optarg, "execstack") == 0)
++	{
++	  link_info.execstack = TRUE;
++	  link_info.noexecstack = FALSE;
++	}
++      else if (strcmp (optarg, "noexecstack") == 0)
++	{
++	  link_info.noexecstack = TRUE;
++	  link_info.execstack = FALSE;
++	}
++EOF
++if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
++fragment <<EOF
++      else if (strcmp (optarg, "global") == 0)
++	link_info.flags_1 |= (bfd_vma) DF_1_GLOBAL;
++      else if (strcmp (optarg, "initfirst") == 0)
++	link_info.flags_1 |= (bfd_vma) DF_1_INITFIRST;
++      else if (strcmp (optarg, "interpose") == 0)
++	link_info.flags_1 |= (bfd_vma) DF_1_INTERPOSE;
++      else if (strcmp (optarg, "loadfltr") == 0)
++	link_info.flags_1 |= (bfd_vma) DF_1_LOADFLTR;
++      else if (strcmp (optarg, "nodefaultlib") == 0)
++	link_info.flags_1 |= (bfd_vma) DF_1_NODEFLIB;
++      else if (strcmp (optarg, "nodelete") == 0)
++	link_info.flags_1 |= (bfd_vma) DF_1_NODELETE;
++      else if (strcmp (optarg, "nodlopen") == 0)
++	link_info.flags_1 |= (bfd_vma) DF_1_NOOPEN;
++      else if (strcmp (optarg, "nodump") == 0)
++	link_info.flags_1 |= (bfd_vma) DF_1_NODUMP;
++      else if (strcmp (optarg, "now") == 0)
++	{
++	  link_info.flags |= (bfd_vma) DF_BIND_NOW;
++	  link_info.flags_1 |= (bfd_vma) DF_1_NOW;
++	}
++      else if (strcmp (optarg, "lazy") == 0)
++	{
++	  link_info.flags &= ~(bfd_vma) DF_BIND_NOW;
++	  link_info.flags_1 &= ~(bfd_vma) DF_1_NOW;
++	}
++      else if (strcmp (optarg, "origin") == 0)
++	{
++	  link_info.flags |= (bfd_vma) DF_ORIGIN;
++	  link_info.flags_1 |= (bfd_vma) DF_1_ORIGIN;
++	}
++      else if (strcmp (optarg, "combreloc") == 0)
++	link_info.combreloc = TRUE;
++      else if (strcmp (optarg, "nocombreloc") == 0)
++	link_info.combreloc = FALSE;
++      else if (strcmp (optarg, "nocopyreloc") == 0)
++	link_info.nocopyreloc = TRUE;
++      else if (strcmp (optarg, "relro") == 0)
++	link_info.relro = TRUE;
++      else if (strcmp (optarg, "norelro") == 0)
++	link_info.relro = FALSE;
++      else if (strcmp (optarg, "text") == 0)
++	link_info.error_textrel = TRUE;
++      else if (strcmp (optarg, "notext") == 0)
++	link_info.error_textrel = FALSE;
++      else if (strcmp (optarg, "textoff") == 0)
++	link_info.error_textrel = FALSE;
++EOF
++fi
++
++fragment <<EOF
++      else
++	einfo (_("%P: warning: -z %s ignored.\n"), optarg);
++      break;
++EOF
++
++if test -n "$PARSE_AND_LIST_ARGS_CASES" ; then
++fragment <<EOF
++ $PARSE_AND_LIST_ARGS_CASES
++EOF
++fi
++
++fragment <<EOF
++    }
++
++  return TRUE;
++}
++
++EOF
++
++if test x"$LDEMUL_LIST_OPTIONS" != xgld"$EMULATION_NAME"_list_options; then
++fragment <<EOF
++
++static void
++gld${EMULATION_NAME}_list_options (FILE * file)
++{
++EOF
++if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
++fragment <<EOF
++  fprintf (file, _("\
++  --audit=AUDITLIB            Specify a library to use for auditing\n"));
++  fprintf (file, _("\
++  -Bgroup                     Selects group name lookup rules for DSO\n"));
++EOF
++fi
++fragment <<EOF
++  fprintf (file, _("\
++  --build-id[=STYLE]          Generate build ID note\n"));
++EOF
++if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
++fragment <<EOF
++  fprintf (file, _("\
++  -P AUDITLIB, --depaudit=AUDITLIB\n" "\
++			      Specify a library to use for auditing dependencies\n"));
++  fprintf (file, _("\
++  --disable-new-dtags         Disable new dynamic tags\n"));
++  fprintf (file, _("\
++  --enable-new-dtags          Enable new dynamic tags\n"));
++  fprintf (file, _("\
++  --eh-frame-hdr              Create .eh_frame_hdr section\n"));
++  fprintf (file, _("\
++  --exclude-libs=LIBS         Make all symbols in LIBS hidden\n"));
++  fprintf (file, _("\
++  --hash-style=STYLE          Set hash style to sysv, gnu or both\n"));
++  fprintf (file, _("\
++  -z combreloc                Merge dynamic relocs into one section and sort\n"));
++EOF
++fi
++
++fragment <<EOF
++  fprintf (file, _("\
++  -z common-page-size=SIZE    Set common page size to SIZE\n"));
++  fprintf (file, _("\
++  -z defs                     Report unresolved symbols in object files.\n"));
++  fprintf (file, _("\
++  -z execstack                Mark executable as requiring executable stack\n"));
++EOF
++
++if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
++fragment <<EOF
++  fprintf (file, _("\
++  -z global                   Make symbols in DSO available for subsequently\n\
++			       loaded objects\n"));
++  fprintf (file, _("\
++  -z initfirst                Mark DSO to be initialized first at runtime\n"));
++  fprintf (file, _("\
++  -z interpose                Mark object to interpose all DSOs but executable\n"));
++  fprintf (file, _("\
++  -z lazy                     Mark object lazy runtime binding (default)\n"));
++  fprintf (file, _("\
++  -z loadfltr                 Mark object requiring immediate process\n"));
++EOF
++fi
++
++fragment <<EOF
++  fprintf (file, _("\
++  -z max-page-size=SIZE       Set maximum page size to SIZE\n"));
++  fprintf (file, _("\
++  -z muldefs                  Allow multiple definitions\n"));
++EOF
++
++if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
++fragment <<EOF
++  fprintf (file, _("\
++  -z nocombreloc              Don't merge dynamic relocs into one section\n"));
++  fprintf (file, _("\
++  -z nocopyreloc              Don't create copy relocs\n"));
++  fprintf (file, _("\
++  -z nodefaultlib             Mark object not to use default search paths\n"));
++  fprintf (file, _("\
++  -z nodelete                 Mark DSO non-deletable at runtime\n"));
++  fprintf (file, _("\
++  -z nodlopen                 Mark DSO not available to dlopen\n"));
++  fprintf (file, _("\
++  -z nodump                   Mark DSO not available to dldump\n"));
++EOF
++fi
++fragment <<EOF
++  fprintf (file, _("\
++  -z noexecstack              Mark executable as not requiring executable stack\n"));
++EOF
++if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
++fragment <<EOF
++  fprintf (file, _("\
++  -z norelro                  Don't create RELRO program header\n"));
++  fprintf (file, _("\
++  -z now                      Mark object non-lazy runtime binding\n"));
++  fprintf (file, _("\
++  -z origin                   Mark object requiring immediate \$ORIGIN\n\
++				processing at runtime\n"));
++  fprintf (file, _("\
++  -z relro                    Create RELRO program header\n"));
++  fprintf (file, _("\
++  -z stacksize=SIZE           Set size of stack segment\n"));
++EOF
++fi
++
++if test -n "$PARSE_AND_LIST_OPTIONS" ; then
++fragment <<EOF
++ $PARSE_AND_LIST_OPTIONS
++EOF
++fi
++
++fragment <<EOF
++}
++EOF
++
++if test -n "$PARSE_AND_LIST_EPILOGUE" ; then
++fragment <<EOF
++ $PARSE_AND_LIST_EPILOGUE
++EOF
++fi
++fi
++
++fragment <<EOF
++
++struct ld_emulation_xfer_struct ld_${EMULATION_NAME}_emulation =
++{
++  ${LDEMUL_BEFORE_PARSE-gld${EMULATION_NAME}_before_parse},
++  ${LDEMUL_SYSLIB-syslib_default},
++  ${LDEMUL_HLL-hll_default},
++  ${LDEMUL_AFTER_PARSE-after_parse_default},
++  ${LDEMUL_AFTER_OPEN-gld${EMULATION_NAME}_after_open},
++  ${LDEMUL_AFTER_ALLOCATION-gld${EMULATION_NAME}_after_allocation},
++  ${LDEMUL_SET_OUTPUT_ARCH-set_output_arch_default},
++  ${LDEMUL_CHOOSE_TARGET-ldemul_default_target},
++  ${LDEMUL_BEFORE_ALLOCATION-gld${EMULATION_NAME}_before_allocation},
++  ${LDEMUL_GET_SCRIPT-gld${EMULATION_NAME}_get_script},
++  "${EMULATION_NAME}",
++  "${OUTPUT_FORMAT}",
++  ${LDEMUL_FINISH-finish_default},
++  ${LDEMUL_CREATE_OUTPUT_SECTION_STATEMENTS-NULL},
++  ${LDEMUL_OPEN_DYNAMIC_ARCHIVE-gld${EMULATION_NAME}_open_dynamic_archive},
++  ${LDEMUL_PLACE_ORPHAN-gld${EMULATION_NAME}_place_orphan},
++  ${LDEMUL_SET_SYMBOLS-NULL},
++  ${LDEMUL_PARSE_ARGS-NULL},
++  gld${EMULATION_NAME}_add_options,
++  gld${EMULATION_NAME}_handle_option,
++  ${LDEMUL_UNRECOGNIZED_FILE-NULL},
++  ${LDEMUL_LIST_OPTIONS-gld${EMULATION_NAME}_list_options},
++  ${LDEMUL_RECOGNIZED_FILE-gld${EMULATION_NAME}_load_symbols},
++  ${LDEMUL_FIND_POTENTIAL_LIBRARIES-NULL},
++  ${LDEMUL_NEW_VERS_PATTERN-NULL}
++};
++EOF
+\ No newline at end of file
+diff --git a/ld/ldctor.c b/ld/ldctor.c
+index 2f80aa02df6..841378ed7b1 100644
+--- a/ld/ldctor.c
++++ b/ld/ldctor.c
+@@ -256,8 +256,12 @@ ldctor_build_sets (void)
+       /* If the symbol is defined, we may have been invoked from
+ 	 collect, and the sets may already have been built, so we do
+ 	 not do anything.  */
+-      if (p->h->type == bfd_link_hash_defined
+-	  || p->h->type == bfd_link_hash_defweak)
++	 /* dgv -- libnix v1.1 uses absolute sets that are also explicitly
++	 defined in the library so that the sets need to be build even
++	 if the symbol is defined */
++      if ((bfd_get_flavour (link_info.output_bfd) != bfd_target_amiga_flavour) &&
++        (p->h->type == bfd_link_hash_defined
++	    || p->h->type == bfd_link_hash_defweak))
+ 	continue;
+ 
+       /* For each set we build:
+@@ -356,15 +360,21 @@ ldctor_build_sets (void)
+ 
+ 	      if (e->name != NULL)
+ 		minfo ("%pT\n", e->name);
+-	      else
+-		minfo ("%G\n", e->section->owner, e->section, e->value);
++		  else if (e->section->owner)
++	    minfo ("%G\n", e->section->owner, e->section, e->value);
++		  else
++		minfo ("%s\n", "** ABS **");
+ 	    }
+ 
+ 	  /* Need SEC_KEEP for --gc-sections.  */
+ 	  if (!bfd_is_abs_section (e->section))
+ 	    e->section->flags |= SEC_KEEP;
+ 
+-	  if (bfd_link_relocatable (&link_info))
++	  /* dgv -- on the amiga, we want the constructors to be relocateable
++	     objects. However, this should be arranged somewhere else (FIXME) */
++	  if (bfd_link_relocatable (&link_info) ||
++	      (bfd_get_flavour (link_info.output_bfd) == bfd_target_amiga_flavour &&
++	       e->section != bfd_abs_section_ptr))
+ 	    lang_add_reloc (p->reloc, howto, e->section, e->name,
+ 			    exp_intop (e->value));
+ 	  else
+diff --git a/ld/ldlang.c b/ld/ldlang.c
+index b66d8c6bc1d..2f546239ab0 100644
+--- a/ld/ldlang.c
++++ b/ld/ldlang.c
+@@ -3840,6 +3840,13 @@ typedef struct bfd_sym_chain ldlang_undef_chain_list_type;
+ void
+ ldlang_add_undef (const char *const name, bool cmdline ATTRIBUTE_UNUSED)
+ {
++#if 1
++  /* This is a quick ugly hak of getting around the problem
++   * with -use-dynld being passed to the linker
++   */
++  if (strcmp(name, "se-dynld") == 0)
++    return;
++#endif	
+   ldlang_undef_chain_list_type *new_undef;
+ 
+   new_undef = stat_alloc (sizeof (*new_undef));
+diff --git a/ld/ldmain.c b/ld/ldmain.c
+index 9290a189b0d..1d44dd2c40e 100644
+--- a/ld/ldmain.c
++++ b/ld/ldmain.c
+@@ -496,12 +496,19 @@ main (int argc, char **argv)
+ 
+   lang_process ();
+ 
+-  /* Print error messages for any missing symbols, for any warning
++    /* Print error messages for any missing symbols, for any warning
++     symbols, and possibly multiple definitions.  */
++#ifdef __amigaos4__
++  /* Make all files executable, even relocatable files */
++    link_info.output_bfd->flags |= EXEC_P;
++#else
++	/* Print error messages for any missing symbols, for any warning
+      symbols, and possibly multiple definitions.  */
+   if (bfd_link_relocatable (&link_info))
+     link_info.output_bfd->flags &= ~EXEC_P;
+   else
+     link_info.output_bfd->flags |= EXEC_P;
++#endif
+ 
+   flagword flags = 0;
+   switch (config.compress_debug)
+diff --git a/ld/po/BLD-POTFILES.in b/ld/po/BLD-POTFILES.in
+index ff820172b98..018ac5d6dc7 100644
+--- a/ld/po/BLD-POTFILES.in
++++ b/ld/po/BLD-POTFILES.in
+@@ -268,6 +268,8 @@ enios2linux.c
+ ens32knbsd.c
+ epc532macha.c
+ epdp11.c
++eppcamiga.c
++eppcamiga_bss.c
+ epjelf.c
+ epjlelf.c
+ eppcmacos.c
+diff --git a/ld/scripttempl/amigaos.sc b/ld/scripttempl/amigaos.sc
+new file mode 100644
+index 00000000000..d472d990abc
+--- /dev/null
++++ b/ld/scripttempl/amigaos.sc
+@@ -0,0 +1,501 @@
++#
++# Unusual variables checked by this code:
++#	NOP - four byte opcode for no-op (defaults to 0)
++#	NO_SMALL_DATA - no .sbss/.sbss2/.sdata/.sdata2 sections if not
++#		empty.
++#	SMALL_DATA_CTOR - .ctors contains small data.
++#	SMALL_DATA_DTOR - .dtors contains small data.
++#	DATA_ADDR - if end-of-text-plus-one-page isn't right for data start
++#	INITIAL_READONLY_SECTIONS - at start of text segment
++#	OTHER_READONLY_SECTIONS - other than .text .init .rodata ...
++#		(e.g., .PARISC.milli)
++#	OTHER_TEXT_SECTIONS - these get put in .text when relocating
++#	OTHER_READWRITE_SECTIONS - other than .data .bss .ctors .sdata ...
++#		(e.g., .PARISC.global)
++#	OTHER_RELRO_SECTIONS - other than .data.rel.ro ...
++#		(e.g. PPC32 .fixup, .got[12])
++#	OTHER_BSS_SECTIONS - other than .bss .sbss ...
++#	ATTRS_SECTIONS - at the end
++#	OTHER_SECTIONS - at the end
++#	EXECUTABLE_SYMBOLS - symbols that must be defined for an
++#		executable (e.g., _DYNAMIC_LINK)
++#       TEXT_START_ADDR - the first byte of the text segment, after any
++#               headers.
++#       TEXT_BASE_ADDRESS - the first byte of the text segment.
++#	TEXT_START_SYMBOLS - symbols that appear at the start of the
++#		.text section.
++#	DATA_START_SYMBOLS - symbols that appear at the start of the
++#		.data section.
++#	DATA_END_SYMBOLS - symbols that appear at the end of the
++#		writeable data sections.
++#	OTHER_GOT_SYMBOLS - symbols defined just before .got.
++#	OTHER_GOT_SECTIONS - sections just after .got.
++#	OTHER_SDATA_SECTIONS - sections just after .sdata.
++#	OTHER_BSS_SYMBOLS - symbols that appear at the start of the
++#		.bss section besides __bss_start.
++#	DATA_PLT - .plt should be in data segment, not text segment.
++#	PLT_BEFORE_GOT - .plt just before .got when .plt is in data segement.
++#	BSS_PLT - .plt should be in bss segment
++#	TEXT_DYNAMIC - .dynamic in text segment, not data segment.
++#	EMBEDDED - whether this is for an embedded system.
++#	SHLIB_TEXT_START_ADDR - if set, add to SIZEOF_HEADERS to set
++#		start address of shared library.
++#	INPUT_FILES - INPUT command of files to always include
++#	WRITABLE_RODATA - if set, the .rodata section should be writable
++#	INIT_START, INIT_END -  statements just before and just after
++# 	combination of .init sections.
++#	FINI_START, FINI_END - statements just before and just after
++# 	combination of .fini sections.
++#	STACK_ADDR - start of a .stack section.
++#	OTHER_SYMBOLS - symbols to place right at the end of the script.
++#	ETEXT_NAME - name of a symbol for the end of the text section,
++#		normally etext.
++#	SEPARATE_GOTPLT - if set, .got.plt should be separate output section,
++#		so that .got can be in the RELRO area.  It should be set to
++#		the number of bytes in the beginning of .got.plt which can be
++#		in the RELRO area as well.
++#	USER_LABEL_PREFIX - prefix to add to user-visible symbols.
++#
++# When adding sections, do note that the names of some sections are used
++# when specifying the start address of the next.
++#
++
++#  Many sections come in three flavours.  There is the 'real' section,
++#  like ".data".  Then there are the per-procedure or per-variable
++#  sections, generated by -ffunction-sections and -fdata-sections in GCC,
++#  and useful for --gc-sections, which for a variable "foo" might be
++#  ".data.foo".  Then there are the linkonce sections, for which the linker
++#  eliminates duplicates, which are named like ".gnu.linkonce.d.foo".
++#  The exact correspondences are:
++#
++#  Section	Linkonce section
++#  .text	.gnu.linkonce.t.foo
++#  .rodata	.gnu.linkonce.r.foo
++#  .data	.gnu.linkonce.d.foo
++#  .bss		.gnu.linkonce.b.foo
++#  .sdata	.gnu.linkonce.s.foo
++#  .sbss	.gnu.linkonce.sb.foo
++#  .sdata2	.gnu.linkonce.s2.foo
++#  .sbss2	.gnu.linkonce.sb2.foo
++#  .debug_info	.gnu.linkonce.wi.foo
++#  .tdata	.gnu.linkonce.td.foo
++#  .tbss	.gnu.linkonce.tb.foo
++#  .lrodata	.gnu.linkonce.lr.foo
++#  .ldata	.gnu.linkonce.l.foo
++#  .lbss	.gnu.linkonce.lb.foo
++#
++#  Each of these can also have corresponding .rel.* and .rela.* sections.
++
++test -z "$ENTRY" && ENTRY=_start
++test -z "${BIG_OUTPUT_FORMAT}" && BIG_OUTPUT_FORMAT=${OUTPUT_FORMAT}
++test -z "${LITTLE_OUTPUT_FORMAT}" && LITTLE_OUTPUT_FORMAT=${OUTPUT_FORMAT}
++if [ -z "$MACHINE" ]; then OUTPUT_ARCH=${ARCH}; else OUTPUT_ARCH=${ARCH}:${MACHINE}; fi
++test -z "${ELFSIZE}" && ELFSIZE=32
++test -z "${ALIGNMENT}" && ALIGNMENT="${ELFSIZE} / 8"
++test "$LD_FLAG" = "N" && DATA_ADDR=.
++test -z "${ETEXT_NAME}" && ETEXT_NAME=etext
++test -n "$CREATE_SHLIB$CREATE_PIE" && test -n "$SHLIB_DATA_ADDR" && COMMONPAGESIZE=""
++test -z "$CREATE_SHLIB$CREATE_PIE" && test -n "$DATA_ADDR" && COMMONPAGESIZE=""
++test -n "$RELRO_NOW" && unset SEPARATE_GOTPLT
++test -z "$ATTRS_SECTIONS" && ATTRS_SECTIONS=".gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }"
++DATA_SEGMENT_ALIGN="ALIGN(${SEGMENT_SIZE})"
++#DATA_SEGMENT_ALIGN="ALIGN(${SEGMENT_SIZE}) + (. & (${MAXPAGESIZE} - 1))"
++DATA_SEGMENT_RELRO_END=""
++DATA_SEGMENT_END=""
++if test -n "${COMMONPAGESIZE}"; then
++  DATA_SEGMENT_ALIGN="ALIGN (${SEGMENT_SIZE}) - ((${MAXPAGESIZE} - .) & (${MAXPAGESIZE} - 1)); . = DATA_SEGMENT_ALIGN (${MAXPAGESIZE}, ${COMMONPAGESIZE})"
++  DATA_SEGMENT_END=". = DATA_SEGMENT_END (.);"
++  DATA_SEGMENT_RELRO_END=". = DATA_SEGMENT_RELRO_END (${SEPARATE_GOTPLT-0}, .);"
++fi
++if test -z "${INITIAL_READONLY_SECTIONS}${CREATE_SHLIB}"; then
++  INITIAL_READONLY_SECTIONS=".interp       ${RELOCATING-0} : { *(.interp) }"
++fi
++if test -z "$PLT"; then
++  PLT=".plt          ${RELOCATING-0} : { *(.plt) }"
++fi
++test -n "${DATA_PLT-${BSS_PLT-text}}" && TEXT_PLT=yes
++if test -z "$GOT"; then
++  if test -z "$SEPARATE_GOTPLT"; then
++    GOT=".got          ${RELOCATING-0} : { *(.got.plt) *(.got) }"
++  else
++    GOT=".got          ${RELOCATING-0} : { *(.got) }"
++    GOTPLT=".got.plt      ${RELOCATING-0} : { *(.got.plt) }"
++  fi
++fi
++DYNAMIC=".dynamic      ${RELOCATING-0} : { *(.dynamic) }"
++RODATA=".rodata       ${RELOCATING-0} : { *(.rodata${RELOCATING+ .rodata.* .gnu.linkonce.r.*}) }"
++DATARELRO=".data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro* .gnu.linkonce.d.rel.ro.*) }"
++DISCARDED="/DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) }"
++if test -z "${NO_SMALL_DATA}"; then
++  SBSS=".sbss         ${RELOCATING-0} :
++  {
++    ${RELOCATING+${SBSS_START_SYMBOLS}}
++    ${CREATE_SHLIB+*(.sbss2 .sbss2.* .gnu.linkonce.sb2.*)}
++    *(.dynsbss)
++    *(.sbss${RELOCATING+ .sbss.* .gnu.linkonce.sb.*})
++    *(.scommon)
++    ${RELOCATING+${SBSS_END_SYMBOLS}}
++  }"
++  SBSS2=".sbss2        ${RELOCATING-0} : { *(.sbss2${RELOCATING+ .sbss2.* .gnu.linkonce.sb2.*}) }"
++  SDATA="/* We want the small data sections together, so single-instruction offsets
++     can access them all, and initialized data all before uninitialized, so
++     we can shorten the on-disk segment size.  */
++  .sdata        ${RELOCATING-0} : 
++  {
++    ${RELOCATING+${SDATA_START_SYMBOLS}}
++    ${CREATE_SHLIB+*(.sdata2 .sdata2.* .gnu.linkonce.s2.*)}
++    *(.sdata${RELOCATING+ .sdata.* .gnu.linkonce.s.*})
++  }"
++  SDATA2=".sdata2       ${RELOCATING-0} :
++  {
++    ${RELOCATING+${SDATA2_START_SYMBOLS}}
++    *(.sdata2${RELOCATING+ .sdata2.* .gnu.linkonce.s2.*})
++  }"
++  REL_SDATA=".rel.sdata    ${RELOCATING-0} : { *(.rel.sdata${RELOCATING+ .rel.sdata.* .rel.gnu.linkonce.s.*}) }
++  .rela.sdata   ${RELOCATING-0} : { *(.rela.sdata${RELOCATING+ .rela.sdata.* .rela.gnu.linkonce.s.*}) }"
++  REL_SBSS=".rel.sbss     ${RELOCATING-0} : { *(.rel.sbss${RELOCATING+ .rel.sbss.* .rel.gnu.linkonce.sb.*}) }
++  .rela.sbss    ${RELOCATING-0} : { *(.rela.sbss${RELOCATING+ .rela.sbss.* .rela.gnu.linkonce.sb.*}) }"
++  REL_SDATA2=".rel.sdata2   ${RELOCATING-0} : { *(.rel.sdata2${RELOCATING+ .rel.sdata2.* .rel.gnu.linkonce.s2.*}) }
++  .rela.sdata2  ${RELOCATING-0} : { *(.rela.sdata2${RELOCATING+ .rela.sdata2.* .rela.gnu.linkonce.s2.*}) }"
++  REL_SBSS2=".rel.sbss2    ${RELOCATING-0} : { *(.rel.sbss2${RELOCATING+ .rel.sbss2.* .rel.gnu.linkonce.sb2.*}) }
++  .rela.sbss2   ${RELOCATING-0} : { *(.rela.sbss2${RELOCATING+ .rela.sbss2.* .rela.gnu.linkonce.sb2.*}) }"
++else
++  NO_SMALL_DATA=" "
++fi
++if test -z "${DATA_GOT}"; then
++  if test -n "${NO_SMALL_DATA}"; then
++    DATA_GOT=" "
++  fi
++fi
++if test -z "${SDATA_GOT}"; then
++  if test -z "${NO_SMALL_DATA}"; then
++    SDATA_GOT=" "
++  fi
++fi
++test -n "$SEPARATE_GOTPLT" && SEPARATE_GOTPLT=" "
++test "${LARGE_SECTIONS}" = "yes" && REL_LARGE="
++  .rel.ldata    ${RELOCATING-0} : { *(.rel.ldata${RELOCATING+ .rel.ldata.* .rel.gnu.linkonce.l.*}) }
++  .rela.ldata   ${RELOCATING-0} : { *(.rela.ldata${RELOCATING+ .rela.ldata.* .rela.gnu.linkonce.l.*}) }
++  .rel.lbss     ${RELOCATING-0} : { *(.rel.lbss${RELOCATING+ .rel.lbss.* .rel.gnu.linkonce.lb.*}) }
++  .rela.lbss    ${RELOCATING-0} : { *(.rela.lbss${RELOCATING+ .rela.lbss.* .rela.gnu.linkonce.lb.*}) }
++  .rel.lrodata  ${RELOCATING-0} : { *(.rel.lrodata${RELOCATING+ .rel.lrodata.* .rel.gnu.linkonce.lr.*}) }
++  .rela.lrodata ${RELOCATING-0} : { *(.rela.lrodata${RELOCATING+ .rela.lrodata.* .rela.gnu.linkonce.lr.*}) }"
++test "${LARGE_SECTIONS}" = "yes" && OTHER_BSS_SECTIONS="
++  ${OTHER_BSS_SECTIONS}
++  .lbss ${RELOCATING-0} :
++  {
++    *(.dynlbss)
++    *(.lbss${RELOCATING+ .lbss.* .gnu.linkonce.lb.*})
++    *(LARGE_COMMON)
++  }"
++test "${LARGE_SECTIONS}" = "yes" && LARGE_SECTIONS="
++  .lrodata ${RELOCATING-0} ${RELOCATING+ALIGN(${MAXPAGESIZE}) + (. & (${MAXPAGESIZE} - 1))} :
++  {
++    *(.lrodata${RELOCATING+ .lrodata.* .gnu.linkonce.lr.*})
++  }
++  .ldata ${RELOCATING-0} ${RELOCATING+ALIGN(${MAXPAGESIZE}) + (. & (${MAXPAGESIZE} - 1))} :
++  {
++    *(.ldata${RELOCATING+ .ldata.* .gnu.linkonce.l.*})
++    ${RELOCATING+. = ALIGN(. != 0 ? ${ALIGNMENT} : 1);}
++  }"
++CTOR=".ctors        ${CONSTRUCTING-0} :
++  {
++    ${CONSTRUCTING+${CTOR_START}}
++    /* gcc uses crtbegin.o to find the start of
++       the constructors, so we make sure it is
++       first.  Because this is a wildcard, it
++       doesn't matter if the user does not
++       actually link against crtbegin.o; the
++       linker won't look for a file to match a
++       wildcard.  The wildcard also means that it
++       doesn't matter which directory crtbegin.o
++       is in.  */
++
++    KEEP (*crtbegin.o(.ctors))
++    KEEP (*crtbegin?.o(.ctors))
++
++    /* We don't want to include the .ctor section from
++       the crtend.o file until after the sorted ctors.
++       The .ctor section from the crtend file contains the
++       end of ctors marker and it must be last */
++
++    KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o $OTHER_EXCLUDE_FILES) .ctors))
++    KEEP (*(SORT(.ctors.*)))
++    KEEP (*(.ctors))
++    ${CONSTRUCTING+${CTOR_END}}
++  }"
++DTOR=".dtors        ${CONSTRUCTING-0} :
++  {
++    ${CONSTRUCTING+${DTOR_START}}
++    KEEP (*crtbegin.o(.dtors))
++    KEEP (*crtbegin?.o(.dtors))
++    KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o $OTHER_EXCLUDE_FILES) .dtors))
++    KEEP (*(SORT(.dtors.*)))
++    KEEP (*(.dtors))
++    ${CONSTRUCTING+${DTOR_END}}
++  }"
++STACK="  .stack        ${RELOCATING-0}${RELOCATING+${STACK_ADDR}} :
++  {
++    ${RELOCATING+_stack = .;}
++    *(.stack)
++  }"
++
++# if this is for an embedded system, don't add SIZEOF_HEADERS.
++if [ -z "$EMBEDDED" ]; then
++   test -z "${TEXT_BASE_ADDRESS}" && TEXT_BASE_ADDRESS="${TEXT_START_ADDR} + SIZEOF_HEADERS"
++else
++   test -z "${TEXT_BASE_ADDRESS}" && TEXT_BASE_ADDRESS="${TEXT_START_ADDR}"
++fi
++
++cat <<EOF
++OUTPUT_FORMAT("${OUTPUT_FORMAT}", "${BIG_OUTPUT_FORMAT}",
++	      "${LITTLE_OUTPUT_FORMAT}")
++OUTPUT_ARCH(${OUTPUT_ARCH})
++ENTRY(${ENTRY})
++
++${RELOCATING+${LIB_SEARCH_DIRS}}
++${RELOCATING+${EXECUTABLE_SYMBOLS}}
++${RELOCATING+${INPUT_FILES}}
++${RELOCATING- /* For some reason, the Solaris linker makes bad executables
++  if gld -r is used and the intermediate file has sections starting
++  at non-zero addresses.  Could be a Solaris ld bug, could be a GNU ld
++  bug.  But for now assigning the zero vmas works.  */}
++
++SECTIONS
++{
++  /* Read-only sections, merged into text segment: */
++  ${CREATE_SHLIB-${CREATE_PIE-${RELOCATING+PROVIDE (__executable_start = ${TEXT_START_ADDR}); . = ${TEXT_BASE_ADDRESS};}}}
++  ${CREATE_SHLIB+${RELOCATING+. = ${SHLIB_TEXT_START_ADDR:-0} + SIZEOF_HEADERS;}}
++  ${CREATE_PIE+${RELOCATING+. = ${SHLIB_TEXT_START_ADDR:-0} + SIZEOF_HEADERS;}}
++  ${INITIAL_READONLY_SECTIONS}
++  .note.gnu.build-id : { *(.note.gnu.build-id) }
++
++  ${TEXT_DYNAMIC+${DYNAMIC}}
++  .hash         ${RELOCATING-0} : { *(.hash) }
++  .gnu.hash     ${RELOCATING-0} : { *(.gnu.hash) }
++  .dynsym       ${RELOCATING-0} : { *(.dynsym) }
++  .dynstr       ${RELOCATING-0} : { *(.dynstr) }
++  .gnu.version  ${RELOCATING-0} : { *(.gnu.version) }
++  .gnu.version_d ${RELOCATING-0}: { *(.gnu.version_d) }
++  .gnu.version_r ${RELOCATING-0}: { *(.gnu.version_r) }
++EOF
++
++if [ "x$COMBRELOC" = x ]; then
++  COMBRELOCCAT=cat
++else
++  COMBRELOCCAT="cat > $COMBRELOC"
++fi
++eval $COMBRELOCCAT <<EOF
++  .rel.init     ${RELOCATING-0} : { *(.rel.init) }
++  .rela.init    ${RELOCATING-0} : { *(.rela.init) }
++  .rel.text     ${RELOCATING-0} : { *(.rel.text${RELOCATING+ .rel.text.* .rel.gnu.linkonce.t.*}) }
++  .rela.text    ${RELOCATING-0} : { *(.rela.text${RELOCATING+ .rela.text.* .rela.gnu.linkonce.t.*}) }
++  .rel.fini     ${RELOCATING-0} : { *(.rel.fini) }
++  .rela.fini    ${RELOCATING-0} : { *(.rela.fini) }
++  .rel.rodata   ${RELOCATING-0} : { *(.rel.rodata${RELOCATING+ .rel.rodata.* .rel.gnu.linkonce.r.*}) }
++  .rela.rodata  ${RELOCATING-0} : { *(.rela.rodata${RELOCATING+ .rela.rodata.* .rela.gnu.linkonce.r.*}) }
++  ${OTHER_READONLY_RELOC_SECTIONS}
++  .rel.data.rel.ro ${RELOCATING-0} : { *(.rel.data.rel.ro${RELOCATING+* .rel.gnu.linkonce.d.rel.ro.*}) }
++  .rela.data.rel.ro ${RELOCATING-0} : { *(.rela.data.rel.ro${RELOCATING+* .rela.gnu.linkonce.d.rel.ro.*}) }
++  .rel.data     ${RELOCATING-0} : { *(.rel.data${RELOCATING+ .rel.data.* .rel.gnu.linkonce.d.*}) }
++  .rela.data    ${RELOCATING-0} : { *(.rela.data${RELOCATING+ .rela.data.* .rela.gnu.linkonce.d.*}) }
++  .rel.tdata	${RELOCATING-0} : { *(.rel.tdata${RELOCATING+ .rel.tdata.* .rel.gnu.linkonce.td.*}) }
++  .rela.tdata	${RELOCATING-0} : { *(.rela.tdata${RELOCATING+ .rela.tdata.* .rela.gnu.linkonce.td.*}) }
++  .rel.tbss	${RELOCATING-0} : { *(.rel.tbss${RELOCATING+ .rel.tbss.* .rel.gnu.linkonce.tb.*}) }
++  .rela.tbss	${RELOCATING-0} : { *(.rela.tbss${RELOCATING+ .rela.tbss.* .rela.gnu.linkonce.tb.*}) }
++  .rel.ctors    ${RELOCATING-0} : { *(.rel.ctors) }
++  .rela.ctors   ${RELOCATING-0} : { *(.rela.ctors) }
++  .rel.dtors    ${RELOCATING-0} : { *(.rel.dtors) }
++  .rela.dtors   ${RELOCATING-0} : { *(.rela.dtors) }
++  .rel.got      ${RELOCATING-0} : { *(.rel.got) }
++  .rela.got     ${RELOCATING-0} : { *(.rela.got) }
++  ${OTHER_GOT_RELOC_SECTIONS}
++  ${REL_SDATA}
++  ${REL_SBSS}
++  ${REL_SDATA2}
++  ${REL_SBSS2}
++  .rel.bss      ${RELOCATING-0} : { *(.rel.bss${RELOCATING+ .rel.bss.* .rel.gnu.linkonce.b.*}) }
++  .rela.bss     ${RELOCATING-0} : { *(.rela.bss${RELOCATING+ .rela.bss.* .rela.gnu.linkonce.b.*}) }
++  ${REL_LARGE}
++EOF
++
++if [ -n "$COMBRELOC" ]; then
++cat <<EOF
++  .rel.dyn      ${RELOCATING-0} :
++    {
++EOF
++sed -e '/^[ 	]*[{}][ 	]*$/d;/:[ 	]*$/d;/\.rela\./d;s/^.*: { *\(.*\)}$/      \1/' $COMBRELOC
++cat <<EOF
++    }
++  .rela.dyn     ${RELOCATING-0} :
++    {
++EOF
++sed -e '/^[ 	]*[{}][ 	]*$/d;/:[ 	]*$/d;/\.rel\./d;s/^.*: { *\(.*\)}/      \1/' $COMBRELOC
++cat <<EOF
++    }
++EOF
++fi
++
++cat <<EOF
++  .rel.plt      ${RELOCATING-0} : { *(.rel.plt) }
++  .rela.plt     ${RELOCATING-0} : { *(.rela.plt) }
++  ${OTHER_PLT_RELOC_SECTIONS}
++
++
++  .init         ${RELOCATING-0} : 
++  { 
++    ${RELOCATING+${INIT_START}}
++    KEEP (*(.init))
++    ${RELOCATING+${INIT_END}}
++  } =${NOP-0}
++
++  ${TINY_READONLY_SECTION}
++  .text         ${RELOCATING-0} :
++  {
++    ${RELOCATING+${TEXT_START_SYMBOLS}}
++    *(.text .stub${RELOCATING+ .text.* .gnu.linkonce.t.*})
++	KEEP (*(.text.*personality*))
++    /* .gnu.warning sections are handled specially by elf32.em.  */
++    *(.gnu.warning)
++    ${RELOCATING+${OTHER_TEXT_SECTIONS}}
++  } =${NOP-0}
++  . = ALIGN(4096);
++  ${TEXT_PLT+${PLT}}
++  . = ALIGN(4096);
++  .fini         ${RELOCATING-0} :
++  {
++    ${RELOCATING+${FINI_START}}
++    KEEP (*(.fini))
++    ${RELOCATING+${FINI_END}}
++  } =${NOP-0}
++  ${RELOCATING+PROVIDE (__${ETEXT_NAME} = .);}
++  ${RELOCATING+PROVIDE (_${ETEXT_NAME} = .);}
++  ${RELOCATING+PROVIDE (${ETEXT_NAME} = .);}
++  ${WRITABLE_RODATA-${RODATA}}
++  .rodata1      ${RELOCATING-0} : { *(.rodata1) }
++  ${CREATE_SHLIB-${SDATA2}}
++  ${CREATE_SHLIB-${SBSS2}}
++  ${OTHER_READONLY_SECTIONS}
++  .eh_frame_hdr : { *(.eh_frame_hdr) }
++  .eh_frame     ${RELOCATING-0} : ONLY_IF_RO { KEEP (*(.eh_frame)) }
++  .gcc_except_table ${RELOCATING-0} : ONLY_IF_RO { *(.gcc_except_table .gcc_except_table.*) }
++
++  /* Adjust the address for the data segment.  We want to adjust up to
++     the same address within the page on the next page up.  */
++  ${CREATE_SHLIB-${CREATE_PIE-${RELOCATING+. = ${DATA_ADDR-${DATA_SEGMENT_ALIGN}};}}}
++  ${CREATE_SHLIB+${RELOCATING+. = ${SHLIB_DATA_ADDR-${DATA_SEGMENT_ALIGN}};}}
++  ${CREATE_PIE+${RELOCATING+. = ${SHLIB_DATA_ADDR-${DATA_SEGMENT_ALIGN}};}}
++
++  /* Exception handling  */
++  .eh_frame     ${RELOCATING-0} : ONLY_IF_RW { KEEP (*(.eh_frame)) }
++  .gcc_except_table ${RELOCATING-0} : ONLY_IF_RW { *(.gcc_except_table .gcc_except_table.*) }
++
++  /* Thread Local Storage sections  */
++  .tdata	${RELOCATING-0} : { *(.tdata${RELOCATING+ .tdata.* .gnu.linkonce.td.*}) }
++  .tbss		${RELOCATING-0} : { *(.tbss${RELOCATING+ .tbss.* .gnu.linkonce.tb.*})${RELOCATING+ *(.tcommon)} }
++
++  .preinit_array   ${RELOCATING-0} :
++  {
++    ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__preinit_array_start = .);}}
++    KEEP (*(.preinit_array))
++    ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__preinit_array_end = .);}}
++  }
++  .init_array   ${RELOCATING-0} :
++  {
++     ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__init_array_start = .);}}
++     KEEP (*(SORT(.init_array.*)))
++     KEEP (*(.init_array))
++     ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__init_array_end = .);}}
++  }
++  .fini_array   ${RELOCATING-0} :
++  {
++    ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__fini_array_start = .);}}
++    KEEP (*(.fini_array))
++    KEEP (*(SORT(.fini_array.*)))
++    ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__fini_array_end = .);}}
++  }
++  ${SMALL_DATA_CTOR-${RELOCATING+${CTOR}}}
++  ${SMALL_DATA_DTOR-${RELOCATING+${DTOR}}}
++  .jcr          ${RELOCATING-0} : { KEEP (*(.jcr)) }
++
++  ${RELOCATING+${DATARELRO}}
++  ${OTHER_RELRO_SECTIONS}
++  ${TEXT_DYNAMIC-${DYNAMIC}}
++  ${DATA_GOT+${RELRO_NOW+${GOT}}}
++  ${DATA_GOT+${RELRO_NOW+${GOTPLT}}}
++  ${DATA_GOT+${RELRO_NOW-${SEPARATE_GOTPLT+${GOT}}}}
++  ${RELOCATING+${DATA_SEGMENT_RELRO_END}}
++  ${DATA_GOT+${RELRO_NOW-${SEPARATE_GOTPLT-${GOT}}}}
++  ${DATA_GOT+${RELRO_NOW-${GOTPLT}}}
++
++  ${DATA_PLT+${PLT_BEFORE_GOT-${PLT}}}
++
++  .data         ${RELOCATING-0} :
++  {
++    ${RELOCATING+${DATA_START_SYMBOLS}}
++    *(.data${RELOCATING+ .data.* .gnu.linkonce.d.*})
++    ${RELOCATING+KEEP (*(.gnu.linkonce.d.*personality*))}
++    ${CONSTRUCTING+SORT(CONSTRUCTORS)}
++  }
++  .data1        ${RELOCATING-0} : { *(.data1) }
++  ${WRITABLE_RODATA+${RODATA}}
++  ${OTHER_READWRITE_SECTIONS}
++  ${SMALL_DATA_CTOR+${RELOCATING+${CTOR}}}
++  ${SMALL_DATA_DTOR+${RELOCATING+${DTOR}}}
++  ${DATA_PLT+${PLT_BEFORE_GOT+${PLT}}}
++  ${SDATA_GOT+${RELOCATING+${OTHER_GOT_SYMBOLS}}}
++  ${SDATA_GOT+${GOT}}
++  ${SDATA_GOT+${OTHER_GOT_SECTIONS}}
++  ${SDATA}
++  ${OTHER_SDATA_SECTIONS}
++  ${RELOCATING+${DATA_END_SYMBOLS-${USER_LABEL_PREFIX}_edata = .; PROVIDE (${USER_LABEL_PREFIX}edata = .);}}
++  ${RELOCATING+__bss_start = .;}
++  ${RELOCATING+${OTHER_BSS_SYMBOLS}}
++  ${SBSS}
++  ${BSS_PLT+${PLT}}
++  .bss          ${RELOCATING-0} :
++  {
++   *(.dynbss)
++   *(.bss${RELOCATING+ .bss.* .gnu.linkonce.b.*})
++   *(COMMON)
++   /* Align here to ensure that the .bss section occupies space up to
++      _end.  Align after .bss to ensure correct alignment even if the
++      .bss section disappears because there are no input sections.
++      FIXME: Why do we need it? When there is no .bss section, we don't
++      pad the .data section.  */
++   ${RELOCATING+. = ALIGN(. != 0 ? ${ALIGNMENT} : 1);}
++  }
++  ${OTHER_BSS_SECTIONS}
++  ${RELOCATING+${OTHER_BSS_END_SYMBOLS}}
++  ${RELOCATING+. = ALIGN(${ALIGNMENT});}
++  ${LARGE_SECTIONS}
++  ${RELOCATING+. = ALIGN(${ALIGNMENT});}
++  ${RELOCATING+${OTHER_END_SYMBOLS}}
++  ${RELOCATING+${END_SYMBOLS-${USER_LABEL_PREFIX}_end = .; PROVIDE (${USER_LABEL_PREFIX}end = .);}}
++  ${RELOCATING+${DATA_SEGMENT_END}}
++
++  /* Stabs debugging sections.  */
++  .stab          0 : { *(.stab) }
++  .stabstr       0 : { *(.stabstr) }
++  .stab.excl     0 : { *(.stab.excl) }
++  .stab.exclstr  0 : { *(.stab.exclstr) }
++  .stab.index    0 : { *(.stab.index) }
++  .stab.indexstr 0 : { *(.stab.indexstr) }
++
++  .comment       0 : { *(.comment) }
++
++EOF
++
++. $srcdir/scripttempl/DWARF.sc
++
++cat <<EOF
++  ${TINY_DATA_SECTION}
++  ${TINY_BSS_SECTION}
++
++  ${STACK_ADDR+${STACK}}
++  ${ATTRS_SECTIONS}
++  ${OTHER_SECTIONS}
++  ${RELOCATING+${OTHER_SYMBOLS}}
++  ${RELOCATING+${DISCARDED}}
++}
++EOF
+\ No newline at end of file
+-- 
+2.43.0
+
+
+From 7ce55ae0298324ad68b93e683fd81fcc76310c9e Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Tue, 10 Jan 2023 11:53:08 +0100
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 03/61] 
+ Included cross-build folder to ignore
+
+---
+ .gitignore | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/.gitignore b/.gitignore
+index 719c72e2d10..b31391cf699 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -4,6 +4,8 @@
+ *.orig
+ *.rej
+ 
++cross-build/
++
+ *~
+ .#*
+ *#
+-- 
+2.43.0
+
+
+From 0753dc6d42efe7865aa53d1e7836b032abe30f52 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Wed, 11 Jan 2023 16:46:27 +0100
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 04/61] 
+ Fixed build paremeters
+
+---
+ ld/Makefile.am           | 6 ++----
+ ld/Makefile.in           | 9 +++------
+ ld/emulparams/amigaos.sh | 2 +-
+ 3 files changed, 6 insertions(+), 11 deletions(-)
+
+diff --git a/ld/Makefile.am b/ld/Makefile.am
+index 21c7fb977da..fe85a5adb17 100644
+--- a/ld/Makefile.am
++++ b/ld/Makefile.am
+@@ -158,6 +158,7 @@ ALL_EMULATION_SOURCES = \
+ 	eaixrs6.c \
+ 	ealpha.c \
+ 	ealphavms.c \
++	eamigaos.c \
+ 	earcelf.c \
+ 	earclinux.c \
+ 	earclinux_nps.c \
+@@ -336,8 +337,6 @@ ALL_EMULATION_SOURCES = \
+ 	ens32knbsd.c \
+ 	epc532macha.c \
+ 	epdp11.c \
+-	eppcamiga.c \
+-	eppcamiga_bss.c \
+ 	epjelf.c \
+ 	epjlelf.c \
+ 	eppcmacos.c \
+@@ -655,6 +654,7 @@ $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES): $(GEN_DEPENDS)
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaixrs6.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ealpha.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ealphavms.Pc@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eamigaos.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earcelf.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earclinux.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earclinux_nps.Pc@am__quote@
+@@ -835,8 +835,6 @@ $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES): $(GEN_DEPENDS)
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epdp11.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epjelf.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epjlelf.Pc@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcamiga.Pc@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcamiga_bss.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcmacos.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epruelf.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/escore3_elf.Pc@am__quote@
+diff --git a/ld/Makefile.in b/ld/Makefile.in
+index ad217db2c0b..3e4e8ae458b 100644
+--- a/ld/Makefile.in
++++ b/ld/Makefile.in
+@@ -659,6 +659,7 @@ ALL_EMULATION_SOURCES = \
+ 	eaixrs6.c \
+ 	ealpha.c \
+ 	ealphavms.c \
++	eamigaos.c \
+ 	earcelf.c \
+ 	earclinux.c \
+ 	earclinux_nps.c \
+@@ -837,8 +838,6 @@ ALL_EMULATION_SOURCES = \
+ 	ens32knbsd.c \
+ 	epc532macha.c \
+ 	epdp11.c \
+-	eppcamiga.c \
+-	eppcamiga_bss.c \
+ 	epjelf.c \
+ 	epjlelf.c \
+ 	eppcmacos.c \
+@@ -1274,6 +1273,7 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaixrs6.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ealpha.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ealphavms.Po@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eamigaos.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earcelf.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earclinux.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earclinux_nps.Po@am__quote@
+@@ -1524,8 +1524,6 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ens32knbsd.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epc532macha.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epdp11.Po@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcamiga.Po@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcamiga_bss.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epjelf.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epjlelf.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcmacos.Po@am__quote@
+@@ -2331,6 +2329,7 @@ $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES): $(GEN_DEPENDS)
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaixrs6.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ealpha.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ealphavms.Pc@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eamigaos.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earcelf.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earclinux.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earclinux_nps.Pc@am__quote@
+@@ -2509,8 +2508,6 @@ $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES): $(GEN_DEPENDS)
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ens32knbsd.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epc532macha.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epdp11.Pc@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcamiga.Pc@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcamiga_bss.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epjelf.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/epjlelf.Pc@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eppcmacos.Pc@am__quote@
+diff --git a/ld/emulparams/amigaos.sh b/ld/emulparams/amigaos.sh
+index fea98c85061..95204ddde23 100644
+--- a/ld/emulparams/amigaos.sh
++++ b/ld/emulparams/amigaos.sh
+@@ -1,7 +1,7 @@
+ . ${srcdir}/emulparams/elf32ppccommon.sh
+ . ${srcdir}/emulparams/plt_unwind.sh
+ 
+-TEMPLATE_NAME=amigaos
++TEMPLATE_NAME=elf
+ SCRIPT_NAME=amigaos
+ OUTPUT_FORMAT="elf32-amigaos"
+ MAXPAGESIZE="CONSTANT (MAXPAGESIZE)"
+-- 
+2.43.0
+
+
+From 53f40537b2e2cba5d371c16ecba4680fd8e9bbbf Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 28 Jul 2023 17:17:40 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 05/61] 
+ Changed binutils trageting AmigaOS ELF based on target_od type instead of the
+ link format target
+
+---
+ binutils/objcopy.c | 25 ++++---------------------
+ ld/ldctor.c        |  7 +++++--
+ 2 files changed, 9 insertions(+), 23 deletions(-)
+
+diff --git a/binutils/objcopy.c b/binutils/objcopy.c
+index 47711c7b42f..e99a45f2c45 100644
+--- a/binutils/objcopy.c
++++ b/binutils/objcopy.c
+@@ -4398,10 +4398,11 @@ copy_relocations_in_section (bfd *ibfd, sec_ptr isection, void *obfdarg)
+ 	    }
+ 	}
+ 
+-    /* Never, ever, strip reloc data on the Amiga! */
+     if (strip_symbols == STRIP_ALL &&
+-	  bfd_get_flavour(obfd) != bfd_target_amiga_flavour)
+-	{
++      /* Never, ever, strip reloc data on the Amiga! */
++      !(bfd_get_flavour(obfd) == bfd_target_elf_flavour &&
++      get_elf_backend_data(obfd)->target_os == is_amigaos))
++  {
+ 	  /* Remove relocations which are not in
+ 	     keep_strip_specific_list.  */
+ 	  arelent **w_relpp;
+@@ -4415,24 +4416,6 @@ copy_relocations_in_section (bfd *ibfd, sec_ptr isection, void *obfdarg)
+ 		if( is_specified_symbol (bfd_asymbol_name (*relpp[i]->sym_ptr_ptr),
+ 					keep_specific_htab))
+ 	      *w_relpp++ = relpp[i];
+-		else
+-		{
+-			/* Don't keep the symbol, but keep the reloc unless it is a relative reloc that is
+-			* requested by the user to be removed. For now, we also don't discard the reloc if
+-			* its targeting a different section. This can happen for relocs in the .rodata
+-			* segment that refering to the .text segment. AmigaOS will possibly split these
+-			* up.
+-			*/
+-			if (!strip_unneeded_rel_relocs || !relpp [i]->howto->pc_relative || sec->index != osection->index)
+-			{
+-			temp_relpp [temp_relcount] = relpp[i];
+-			temp_relpp [temp_relcount]->addend = bfd_asymbol_value(*relpp [i]->sym_ptr_ptr)
+-								- sec->vma
+-								+ relpp[i]->addend;
+-			temp_relpp [temp_relcount]->sym_ptr_ptr = sec->symbol_ptr_ptr;
+-			temp_relcount++;
+-			}
+-		}
+ 	  relcount = w_relpp - relpp;
+ 	  *w_relpp = 0;
+ 	}
+diff --git a/ld/ldctor.c b/ld/ldctor.c
+index 841378ed7b1..6bdbba10074 100644
+--- a/ld/ldctor.c
++++ b/ld/ldctor.c
+@@ -32,6 +32,7 @@
+ #include <ldgram.h>
+ #include "ldmain.h"
+ #include "ldctor.h"
++#include "elf-bfd.h"
+ 
+ /* The list of statements needed to handle constructors.  These are
+    invoked by the command CONSTRUCTORS in the linker script.  */
+@@ -259,7 +260,8 @@ ldctor_build_sets (void)
+ 	 /* dgv -- libnix v1.1 uses absolute sets that are also explicitly
+ 	 defined in the library so that the sets need to be build even
+ 	 if the symbol is defined */
+-      if ((bfd_get_flavour (link_info.output_bfd) != bfd_target_amiga_flavour) &&
++	  if (!(bfd_get_flavour (link_info.output_bfd) == bfd_target_elf_flavour &&
++		get_elf_backend_data (link_info.output_bfd)->target_os == is_amigaos) &&
+         (p->h->type == bfd_link_hash_defined
+ 	    || p->h->type == bfd_link_hash_defweak))
+ 	continue;
+@@ -373,7 +375,8 @@ ldctor_build_sets (void)
+ 	  /* dgv -- on the amiga, we want the constructors to be relocateable
+ 	     objects. However, this should be arranged somewhere else (FIXME) */
+ 	  if (bfd_link_relocatable (&link_info) ||
+-	      (bfd_get_flavour (link_info.output_bfd) == bfd_target_amiga_flavour &&
++		  (bfd_get_flavour (link_info.output_bfd) == bfd_target_elf_flavour &&
++           get_elf_backend_data (link_info.output_bfd)->target_os == is_amigaos &&
+ 	       e->section != bfd_abs_section_ptr))
+ 	    lang_add_reloc (p->reloc, howto, e->section, e->name,
+ 			    exp_intop (e->value));
+-- 
+2.43.0
+
+
+From e9fa66ef0374617dc10577a190313d65d147d80d Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Thu, 10 Aug 2023 08:38:30 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 06/61] 
+ Selected target format 'elf32-amigaos' unknown
+
+---
+ .gitignore               | 3 ++-
+ gas/config/tc-ppc.c      | 2 +-
+ ld/emulparams/amigaos.sh | 2 +-
+ ld/ldmain.c              | 3 +--
+ 4 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/.gitignore b/.gitignore
+index b31391cf699..292bcfac37e 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -5,6 +5,7 @@
+ *.rej
+ 
+ cross-build/
++dist/
+ 
+ *~
+ .#*
+@@ -74,4 +75,4 @@ stamp-*
+ /mpfr*
+ /mpc*
+ /gmp*
+-/isl*
++/isl*
+\ No newline at end of file
+diff --git a/gas/config/tc-ppc.c b/gas/config/tc-ppc.c
+index a5da9fc648a..745733b24f5 100644
+--- a/gas/config/tc-ppc.c
++++ b/gas/config/tc-ppc.c
+@@ -1548,7 +1548,7 @@ ppc_target_format (void)
+ #endif
+ #ifdef OBJ_ELF
+ # if TE_AMIGAOS
+-  return "elf32-amigaos";
++  return "elf32-powerpc-amigaos";
+ # else
+ #  ifdef TE_FreeBSD
+   return (ppc_obj64 ? "elf64-powerpc-freebsd" : "elf32-powerpc-freebsd");
+diff --git a/ld/emulparams/amigaos.sh b/ld/emulparams/amigaos.sh
+index 95204ddde23..ac04c3e3dbd 100644
+--- a/ld/emulparams/amigaos.sh
++++ b/ld/emulparams/amigaos.sh
+@@ -3,7 +3,7 @@
+ 
+ TEMPLATE_NAME=elf
+ SCRIPT_NAME=amigaos
+-OUTPUT_FORMAT="elf32-amigaos"
++OUTPUT_FORMAT="elf32-powerpc-amigaos"
+ MAXPAGESIZE="CONSTANT (MAXPAGESIZE)"
+ COMMONPAGESIZE="CONSTANT (COMMONPAGESIZE)"
+ ALIGNMENT=16
+diff --git a/ld/ldmain.c b/ld/ldmain.c
+index 1d44dd2c40e..04b3322fcc3 100644
+--- a/ld/ldmain.c
++++ b/ld/ldmain.c
+@@ -499,11 +499,10 @@ main (int argc, char **argv)
+     /* Print error messages for any missing symbols, for any warning
+      symbols, and possibly multiple definitions.  */
+ #ifdef __amigaos4__
++printf( "%s:%d:Make all stuff excuatbel for aos4!\n", __FILE__, __LINE__ );
+   /* Make all files executable, even relocatable files */
+     link_info.output_bfd->flags |= EXEC_P;
+ #else
+-	/* Print error messages for any missing symbols, for any warning
+-     symbols, and possibly multiple definitions.  */
+   if (bfd_link_relocatable (&link_info))
+     link_info.output_bfd->flags &= ~EXEC_P;
+   else
+-- 
+2.43.0
+
+
+From 2d71c5586a4f296583239296cab039e4e65c731f Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Wed, 16 Aug 2023 10:19:55 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 07/61] 
+ Disable STRIP_ALL default behavior if targeting ppc-amigaos
+
+---
+ binutils/objcopy.c | 13 ++++++-------
+ 1 file changed, 6 insertions(+), 7 deletions(-)
+
+diff --git a/binutils/objcopy.c b/binutils/objcopy.c
+index e99a45f2c45..ef76cb36e7a 100644
+--- a/binutils/objcopy.c
++++ b/binutils/objcopy.c
+@@ -1655,13 +1655,12 @@ filter_symbols (bfd *abfd, bfd *obfd, asymbol **osyms,
+ 	  bfd_set_asymbol_name (sym, n);
+ 	  name = n;
+ 	}
+-
+-      if (strip_symbols == STRIP_ALL)
+-		if (strcmp(name, "_start") == 0 || strcmp(name, "__amigaos4__") == 0 || strcmp(name, "_SDA_BASE_") == 0)
+-          keep = true;
+-        else
+-          keep = false;
+-      else if ((flags & BSF_KEEP) != 0		/* Used in relocation.  */
++      if( (strip_symbols == STRIP_ALL) && 
++		 /* Never, ever, strip everthing on the Amiga, keep reloc data, which hopefully is handled in the other else cases! */
++     	 !(bfd_get_flavour(obfd) == bfd_target_elf_flavour &&
++     	 get_elf_backend_data(obfd)->target_os == is_amigaos))
++		keep = false;
++	  else if ((flags & BSF_KEEP) != 0		/* Used in relocation.  */
+ 	       || ((flags & BSF_SECTION_SYM) != 0
+ 		   && ((*bfd_asymbol_section (sym)->symbol_ptr_ptr)->flags
+ 		       & BSF_KEEP) != 0))
+-- 
+2.43.0
+
+
+From 858eade444e85bcdeae69c5e7e6b296aa6902b20 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 18 Aug 2023 09:27:31 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 08/61] 
+ Added keeping ppc-amigaos symbols with strip all Keeping relocs for
+ ppc-amigaos with included resoling magic
+
+---
+ binutils/objcopy.c | 36 +++++++++++++++++++++++++++---------
+ 1 file changed, 27 insertions(+), 9 deletions(-)
+
+diff --git a/binutils/objcopy.c b/binutils/objcopy.c
+index ef76cb36e7a..b368ebe7f96 100644
+--- a/binutils/objcopy.c
++++ b/binutils/objcopy.c
+@@ -1655,11 +1655,22 @@ filter_symbols (bfd *abfd, bfd *obfd, asymbol **osyms,
+ 	  bfd_set_asymbol_name (sym, n);
+ 	  name = n;
+ 	}
+-      if( (strip_symbols == STRIP_ALL) && 
+-		 /* Never, ever, strip everthing on the Amiga, keep reloc data, which hopefully is handled in the other else cases! */
+-     	 !(bfd_get_flavour(obfd) == bfd_target_elf_flavour &&
+-     	 get_elf_backend_data(obfd)->target_os == is_amigaos))
+-		keep = false;
++      if(strip_symbols == STRIP_ALL) 
++	  { 		
++		  keep = false;
++		 /* Never, ever, strip everthing on the Amiga, keep global symbols, needed by OS 
++		 	_start: 		Entry point of executable, isn't fixed on ppc-amigaos, so OS needs to knwo where to enter
++			__amigaos4__: 	Maker symbol to identify that ELF file is for ppc-amigaos, because no offcial value has been assigned to ELF heder field for ppc-amigaos
++			_SDA_BASE_:		If small data model ist used, the symbol is needed ....?????
++		 */
++     	 if( (bfd_get_flavour(obfd) == bfd_target_elf_flavour && get_elf_backend_data(obfd)->target_os == is_amigaos))
++		 {
++			//  ML: TODO: _SDA_BASE_ onyl needs to be kept if small data section are present ????
++			if (strcmp(name, "_start") == 0 || strcmp(name, "__amigaos4__") == 0 || strcmp(name, "_SDA_BASE_") == 0) {
++			  keep = true;
++			}
++		 }
++	  }
+ 	  else if ((flags & BSF_KEEP) != 0		/* Used in relocation.  */
+ 	       || ((flags & BSF_SECTION_SYM) != 0
+ 		   && ((*bfd_asymbol_section (sym)->symbol_ptr_ptr)->flags
+@@ -4397,10 +4408,7 @@ copy_relocations_in_section (bfd *ibfd, sec_ptr isection, void *obfdarg)
+ 	    }
+ 	}
+ 
+-    if (strip_symbols == STRIP_ALL &&
+-      /* Never, ever, strip reloc data on the Amiga! */
+-      !(bfd_get_flavour(obfd) == bfd_target_elf_flavour &&
+-      get_elf_backend_data(obfd)->target_os == is_amigaos))
++    if (strip_symbols == STRIP_ALL )
+   {
+ 	  /* Remove relocations which are not in
+ 	     keep_strip_specific_list.  */
+@@ -4415,6 +4423,16 @@ copy_relocations_in_section (bfd *ibfd, sec_ptr isection, void *obfdarg)
+ 		if( is_specified_symbol (bfd_asymbol_name (*relpp[i]->sym_ptr_ptr),
+ 					keep_specific_htab))
+ 	      *w_relpp++ = relpp[i];
++		/* Never, ever, strip all? reloc data on the Amiga! */
++		else if( bfd_get_flavour(obfd) == bfd_target_elf_flavour && get_elf_backend_data(obfd)->target_os == is_amigaos)
++		{
++			if (!strip_unneeded_rel_relocs || !relpp [i]->howto->pc_relative || isection->index != osection->index)
++			{
++				relpp[i]->addend = bfd_asymbol_value(*relpp [i]->sym_ptr_ptr) - isection->vma + relpp[i]->addend;
++				relpp[i]->sym_ptr_ptr = isection->symbol_ptr_ptr;
++				*w_relpp++ = relpp[i];
++			}
++		}  
+ 	  relcount = w_relpp - relpp;
+ 	  *w_relpp = 0;
+ 	}
+-- 
+2.43.0
+
+
+From aa27ec4d7db19422c04a6b645b9456d6fabc7502 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 18 Aug 2023 10:00:46 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 09/61] 
+ Fixed relocation reosling to correct section
+
+---
+ binutils/objcopy.c | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/binutils/objcopy.c b/binutils/objcopy.c
+index b368ebe7f96..4e85ed7966a 100644
+--- a/binutils/objcopy.c
++++ b/binutils/objcopy.c
+@@ -1660,7 +1660,7 @@ filter_symbols (bfd *abfd, bfd *obfd, asymbol **osyms,
+ 		  keep = false;
+ 		 /* Never, ever, strip everthing on the Amiga, keep global symbols, needed by OS 
+ 		 	_start: 		Entry point of executable, isn't fixed on ppc-amigaos, so OS needs to knwo where to enter
+-			__amigaos4__: 	Maker symbol to identify that ELF file is for ppc-amigaos, because no offcial value has been assigned to ELF heder field for ppc-amigaos
++			__amigaos4__: 	Maker symbol to identify that ELF file is for ppc-amigaos, because no offcial value has been assigned to ELF heder field OS/ABI for ppc-amigaos
+ 			_SDA_BASE_:		If small data model ist used, the symbol is needed ....?????
+ 		 */
+      	 if( (bfd_get_flavour(obfd) == bfd_target_elf_flavour && get_elf_backend_data(obfd)->target_os == is_amigaos))
+@@ -4419,20 +4419,23 @@ copy_relocations_in_section (bfd *ibfd, sec_ptr isection, void *obfdarg)
+ 	    /* PR 17512: file: 9e907e0c.  */
+ 	    if (relpp[i]->sym_ptr_ptr
+ 		/* PR 20096 */
+-		&& *relpp[i]->sym_ptr_ptr )
++		&& *relpp[i]->sym_ptr_ptr ) {
++		asection *sec = (*(relpp[i]->sym_ptr_ptr))->section;
++
+ 		if( is_specified_symbol (bfd_asymbol_name (*relpp[i]->sym_ptr_ptr),
+ 					keep_specific_htab))
+ 	      *w_relpp++ = relpp[i];
+ 		/* Never, ever, strip all? reloc data on the Amiga! */
+ 		else if( bfd_get_flavour(obfd) == bfd_target_elf_flavour && get_elf_backend_data(obfd)->target_os == is_amigaos)
+ 		{
+-			if (!strip_unneeded_rel_relocs || !relpp [i]->howto->pc_relative || isection->index != osection->index)
++			if (!strip_unneeded_rel_relocs || !relpp [i]->howto->pc_relative || sec->index != osection->index)
+ 			{
+-				relpp[i]->addend = bfd_asymbol_value(*relpp [i]->sym_ptr_ptr) - isection->vma + relpp[i]->addend;
+-				relpp[i]->sym_ptr_ptr = isection->symbol_ptr_ptr;
++				relpp[i]->addend = bfd_asymbol_value(*relpp [i]->sym_ptr_ptr) - sec->vma + relpp[i]->addend;
++				relpp[i]->sym_ptr_ptr = sec->symbol_ptr_ptr;
+ 				*w_relpp++ = relpp[i];
+ 			}
+ 		}  
++		}
+ 	  relcount = w_relpp - relpp;
+ 	  *w_relpp = 0;
+ 	}
+-- 
+2.43.0
+
+
+From dc5612d310cfdfaaa8efde38ce554c8d767a0d5a Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Tue, 10 Oct 2023 06:27:55 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 10/61] 
+ Disable INITF/FINI for binutils being compatibel with current elf.library
+ (dynamic linker) v53.30
+
+---
+ ld/emulparams/amigaos.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/ld/emulparams/amigaos.sh b/ld/emulparams/amigaos.sh
+index ac04c3e3dbd..30642008836 100644
+--- a/ld/emulparams/amigaos.sh
++++ b/ld/emulparams/amigaos.sh
+@@ -2,6 +2,7 @@
+ . ${srcdir}/emulparams/plt_unwind.sh
+ 
+ TEMPLATE_NAME=elf
++EXTRA_EM_FILE=ppc32elf
+ SCRIPT_NAME=amigaos
+ OUTPUT_FORMAT="elf32-powerpc-amigaos"
+ MAXPAGESIZE="CONSTANT (MAXPAGESIZE)"
+@@ -25,4 +26,4 @@ GOT=".got          ${RELOCATING-0} : SPECIAL { *(.got) }"
+ PLT=".plt          ${RELOCATING-0} :  { *(.plt) }"
+ # GOTPLT="${PLT}"
+ OTHER_TEXT_SECTIONS="*(.glink)"
+-EXTRA_EM_FILE=ppc32elf
+\ No newline at end of file
++ENABLE_INITFINI_ARRAY=no
+\ No newline at end of file
+-- 
+2.43.0
+
+
+From 5d7078f2d50891648f60bb33ae3928ea58b77815 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Tue, 22 Aug 2023 13:15:41 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 11/61] 
+ Rework how PLT is handled
+
+---
+ bfd/Makefile.am          |  4 +++-
+ bfd/Makefile.in          |  5 ++++-
+ bfd/configure            |  2 +-
+ bfd/configure.ac         |  2 +-
+ bfd/elf-amigaos.c        | 38 ++++++++++++++++++++++++++++++++++++++
+ bfd/elf-amigaos.h        | 22 ++++++++++++++++++++++
+ bfd/elf32-ppc.c          | 31 ++++---------------------------
+ bfd/elf32-ppc.h          |  3 +--
+ bfd/po/SRC-POTFILES.in   |  2 ++
+ ld/emulparams/amigaos.sh |  3 ++-
+ 10 files changed, 78 insertions(+), 34 deletions(-)
+ create mode 100644 bfd/elf-amigaos.c
+ create mode 100644 bfd/elf-amigaos.h
+
+diff --git a/bfd/Makefile.am b/bfd/Makefile.am
+index e1692e7f8aa..a884108ff98 100644
+--- a/bfd/Makefile.am
++++ b/bfd/Makefile.am
+@@ -292,6 +292,7 @@ BFD32_BACKENDS = \
+ 	elf-m10300.lo \
+ 	elf-nacl.lo \
+ 	elf-strtab.lo \
++	elf-amigaos.lo \
+ 	elf-vxworks.lo \
+ 	elf.lo \
+ 	elf32-am33lin.lo \
+@@ -427,6 +428,7 @@ BFD32_BACKENDS_CFILES = \
+ 	elf-m10300.c \
+ 	elf-nacl.c \
+ 	elf-strtab.c \
++	elf-amigaos.c \
+ 	elf-vxworks.c \
+ 	elf.c \
+ 	elf32-am33lin.c \
+@@ -706,7 +708,7 @@ SOURCE_HFILES = \
+ 	elf32-tic6x.h elf32-tilegx.h elf32-tilepro.h elf32-v850.h \
+ 	elf64-hppa.h elf64-ppc.h elf64-tilegx.h \
+ 	elf-bfd.h elfcode.h elfcore.h elf-hppa.h elf-linker-x86.h \
+-	elf-linux-core.h elf-nacl.h elf-s390.h elf-vxworks.h \
++	elf-linux-core.h elf-nacl.h elf-s390.h elf-amigaos.h elf-vxworks.h \
+ 	elfxx-aarch64.h elfxx-ia64.h elfxx-mips.h elfxx-riscv.h \
+ 	elfxx-sparc.h elfxx-tilegx.h elfxx-x86.h elfxx-loongarch.h \
+ 	genlink.h go32stub.h \
+diff --git a/bfd/Makefile.in b/bfd/Makefile.in
+index 80aed657643..ff4d61b7a3a 100644
+--- a/bfd/Makefile.in
++++ b/bfd/Makefile.in
+@@ -761,6 +761,7 @@ BFD32_BACKENDS = \
+ 	elf-m10300.lo \
+ 	elf-nacl.lo \
+ 	elf-strtab.lo \
++	elf-amigaos.lo \
+ 	elf-vxworks.lo \
+ 	elf.lo \
+ 	elf32-am33lin.lo \
+@@ -896,6 +897,7 @@ BFD32_BACKENDS_CFILES = \
+ 	elf-m10300.c \
+ 	elf-nacl.c \
+ 	elf-strtab.c \
++	elf-amigaos.c \
+ 	elf-vxworks.c \
+ 	elf.c \
+ 	elf32-am33lin.c \
+@@ -1172,7 +1174,7 @@ SOURCE_HFILES = \
+ 	elf32-tic6x.h elf32-tilegx.h elf32-tilepro.h elf32-v850.h \
+ 	elf64-hppa.h elf64-ppc.h elf64-tilegx.h \
+ 	elf-bfd.h elfcode.h elfcore.h elf-hppa.h elf-linker-x86.h \
+-	elf-linux-core.h elf-nacl.h elf-s390.h elf-vxworks.h \
++	elf-linux-core.h elf-nacl.h elf-s390.h elf-amigaos.h  elf-vxworks.h \
+ 	elfxx-aarch64.h elfxx-ia64.h elfxx-mips.h elfxx-riscv.h \
+ 	elfxx-sparc.h elfxx-tilegx.h elfxx-x86.h elfxx-loongarch.h \
+ 	genlink.h go32stub.h \
+@@ -1580,6 +1582,7 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-properties.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-sframe.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-strtab.Plo@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-amigaos.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf-vxworks.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/elf32-aarch64.Plo@am__quote@
+diff --git a/bfd/configure b/bfd/configure
+index 0bc4ba1b28e..a5754abfb0d 100755
+--- a/bfd/configure
++++ b/bfd/configure
+@@ -13780,7 +13780,7 @@ do
+     pj_elf32_vec)		 tb="$tb elf32-pj.lo elf32.lo $elf" ;;
+     pj_elf32_le_vec)		 tb="$tb elf32-pj.lo elf32.lo $elf" ;;
+     powerpc_boot_vec)		 tb="$tb ppcboot.lo" ;;
+-    powerpc_elf32_amigaos_vec)	tb="$tb elf32-ppc.lo elf32.lo $elf" ;;
++    powerpc_elf32_amigaos_vec)	tb="$tb elf32-ppc.lo elf-amigaos.lo elf32.lo $elf" ;;
+ 	powerpc_elf32_vec)		 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
+     powerpc_elf32_le_vec)	 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
+     powerpc_elf32_fbsd_vec)	 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
+diff --git a/bfd/configure.ac b/bfd/configure.ac
+index 8f59f6484e0..352be794f65 100644
+--- a/bfd/configure.ac
++++ b/bfd/configure.ac
+@@ -570,7 +570,7 @@ do
+     pj_elf32_vec)		 tb="$tb elf32-pj.lo elf32.lo $elf" ;;
+     pj_elf32_le_vec)		 tb="$tb elf32-pj.lo elf32.lo $elf" ;;
+     powerpc_boot_vec)		 tb="$tb ppcboot.lo" ;;
+-    powerpc_elf32_amigaos_vec)	tb="$tb elf32-ppc.lo elf32.lo $elf" ;;
++    powerpc_elf32_amigaos_vec)	tb="$tb elf32-ppc.lo elf-amigaos.lo elf32.lo $elf" ;;
+     powerpc_elf32_vec)		 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
+     powerpc_elf32_le_vec)	 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
+     powerpc_elf32_fbsd_vec)	 tb="$tb elf32-ppc.lo elf-vxworks.lo elf32.lo $elf" ;;
+diff --git a/bfd/elf-amigaos.c b/bfd/elf-amigaos.c
+new file mode 100644
+index 00000000000..962fe1e519d
+--- /dev/null
++++ b/bfd/elf-amigaos.c
+@@ -0,0 +1,38 @@
++/* VxWorks support for ELF
++   Copyright (C) 2005-2023 Free Software Foundation, Inc.
++
++   This file is part of BFD, the Binary File Descriptor library.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++
++/* This file provides routines used by all VxWorks targets.  */
++
++#include "sysdep.h"
++#include "bfd.h"
++#include "libbfd.h"
++#include "elf-bfd.h"
++#include "elf-amigaos.h"
++#include "elf/amigaos.h"
++
++/* Add dynamic tags
++   AmigaOS: Flag it as a version 2 dynamic binary */  
++
++bool
++_bfd_elf_amigaos_add_dynamic_tags (struct bfd_link_info *info)
++{
++	struct elf_link_hash_table *htab = elf_hash_table (info);
++	
++	return  htab->target_os != is_amigaos || _bfd_elf_add_dynamic_entry (info,DT_AMIGAOS_DYNVERSION, 2);
++}
++ 
+\ No newline at end of file
+diff --git a/bfd/elf-amigaos.h b/bfd/elf-amigaos.h
+new file mode 100644
+index 00000000000..f7770b1d669
+--- /dev/null
++++ b/bfd/elf-amigaos.h
+@@ -0,0 +1,22 @@
++/* VxWorks support for ELF
++   Copyright (C) 2005-2023 Free Software Foundation, Inc.
++
++   This file is part of BFD, the Binary File Descriptor library.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++
++#include "elf/common.h"
++#include "elf/internal.h"
++
++bool _bfd_elf_amigaos_add_dynamic_tags(struct bfd_link_info *);
+diff --git a/bfd/elf32-ppc.c b/bfd/elf32-ppc.c
+index 00854bcb4f8..00f08ff6418 100644
+--- a/bfd/elf32-ppc.c
++++ b/bfd/elf32-ppc.c
+@@ -34,6 +34,7 @@
+ #include "elf/ppc.h"
+ #include "elf/amigaos.h"
+ #include "elf32-ppc.h"
++#include "elf-amigaos.h"
+ #include "elf-vxworks.h"
+ #include "dwarf2.h"
+ #include "opcode/ppc.h"
+@@ -2534,7 +2535,7 @@ ppc_elf_create_dynamic_sections (bfd *abfd, struct bfd_link_info *info)
+ 
+   s = htab->elf.splt;
+   flags = SEC_ALLOC | SEC_CODE | SEC_LINKER_CREATED;
+-  if (htab->plt_type == PLT_AMIGAOS)
++  if (htab->elf.target_os == is_amigaos )
+      flags |= SEC_READONLY;
+   if (htab->plt_type == PLT_VXWORKS)
+     /* The VxWorks PLT is a loaded section with contents.  */
+@@ -5940,10 +5941,8 @@ ppc_elf_size_dynamic_sections (bfd *output_bfd,
+ 						    relocs))
+ 	return false;
+ 
+-	  /* AmigaOS: Flag it as a version 2 dynamic binary */
+-      if ( htab->plt_type == PLT_AMIGAOS
+-	  && !add_dynamic_entry (DT_AMIGAOS_DYNVERSION, 2) )
+-        return false;
++      if (!_bfd_elf_amigaos_add_dynamic_tags (info))
++		return false;
+ 
+       if (htab->plt_type == PLT_NEW
+ 	  && htab->glink != NULL
+@@ -10543,23 +10542,6 @@ ppc_elf_finish_dynamic_sections (bfd *output_bfd,
+ #undef ELF_TARGET_OS
+ #define ELF_TARGET_OS		is_amigaos
+ 
+-/* Like ppc_elf_link_hash_table_create, but overrides
+-   appropriately for AmigaOS.  */
+-static struct bfd_link_hash_table *
+-ppc_elf_amigaos_link_hash_table_create (bfd *abfd)
+-{
+-  struct bfd_link_hash_table *ret;
+-
+-  ret = ppc_elf_link_hash_table_create (abfd);
+-  if (ret)
+-    {
+-      struct ppc_elf_link_hash_table *htab
+-	= (struct ppc_elf_link_hash_table *)ret;
+-      htab->plt_type = PLT_AMIGAOS;
+-    }
+-  return ret;
+-}
+-
+ /* If we have .sbss2 or .PPC.EMB.sbss0 output sections, we
+    need to bump up the number of section headers.  */
+ 
+@@ -10573,11 +10555,6 @@ ppc_elf_amigaos_additional_program_headers (bfd *abfd,
+   return ret;
+ }
+ 
+-
+-#undef bfd_elf32_bfd_link_hash_table_create
+-#define bfd_elf32_bfd_link_hash_table_create \
+-  ppc_elf_amigaos_link_hash_table_create
+-
+ #undef elf_backend_additional_program_headers
+ #define elf_backend_additional_program_headers \
+   ppc_elf_amigaos_additional_program_headers
+diff --git a/bfd/elf32-ppc.h b/bfd/elf32-ppc.h
+index 34939acfcf5..c1d56bf7197 100644
+--- a/bfd/elf32-ppc.h
++++ b/bfd/elf32-ppc.h
+@@ -23,8 +23,7 @@ enum ppc_elf_plt_type
+   PLT_UNSET,
+   PLT_OLD,
+   PLT_NEW,
+-  PLT_VXWORKS,
+-  PLT_AMIGAOS
++  PLT_VXWORKS
+ };
+ 
+ /* Various options passed from the linker to bfd backend.  */
+diff --git a/bfd/po/SRC-POTFILES.in b/bfd/po/SRC-POTFILES.in
+index 08e2901d3ba..c4ff7a793ec 100644
+--- a/bfd/po/SRC-POTFILES.in
++++ b/bfd/po/SRC-POTFILES.in
+@@ -148,6 +148,8 @@ elf-properties.c
+ elf-s390.h
+ elf-sframe.c
+ elf-strtab.c
++elf-amigaos.c
++elf-amigaos.h
+ elf-vxworks.c
+ elf-vxworks.h
+ elf.c
+diff --git a/ld/emulparams/amigaos.sh b/ld/emulparams/amigaos.sh
+index 30642008836..87e9ec63de5 100644
+--- a/ld/emulparams/amigaos.sh
++++ b/ld/emulparams/amigaos.sh
+@@ -26,4 +26,5 @@ GOT=".got          ${RELOCATING-0} : SPECIAL { *(.got) }"
+ PLT=".plt          ${RELOCATING-0} :  { *(.plt) }"
+ # GOTPLT="${PLT}"
+ OTHER_TEXT_SECTIONS="*(.glink)"
+-ENABLE_INITFINI_ARRAY=no
+\ No newline at end of file
++ENABLE_INITFINI_ARRAY=no
++DYNAMIC_LINK=false
+\ No newline at end of file
+-- 
+2.43.0
+
+
+From 924f09d22b53cc8fa55eee7cbbed715bfe8a4856 Mon Sep 17 00:00:00 2001
+From: migthymax <59331342+migthymax@users.noreply.github.com>
+Date: Wed, 4 Oct 2023 17:26:40 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 12/61] 
+ Modifed pointer_equality_neded before calling ppc_elf_finish_dynamic_symbol
+ to achive that st_value get not cleared (#17)
+
+---
+ bfd/elf32-ppc.c | 36 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 36 insertions(+)
+
+diff --git a/bfd/elf32-ppc.c b/bfd/elf32-ppc.c
+index 00f08ff6418..4a909b60c49 100644
+--- a/bfd/elf32-ppc.c
++++ b/bfd/elf32-ppc.c
+@@ -10555,10 +10555,46 @@ ppc_elf_amigaos_additional_program_headers (bfd *abfd,
+   return ret;
+ }
+ 
++static bool
++ppc_elf_amigaos_finish_dynamic_symbol(
++	bfd *output_bfd,
++	struct bfd_link_info *info,
++	struct elf_link_hash_entry *hashEntry,
++	Elf_Internal_Sym *sym)
++{
++#ifdef DEBUG
++	printf ("Target amigaos-pcc needs reloc R_PPC_JMP_SLOT/... having none zero value\n"); 
++#endif
++ 
++	if( ! hashEntry->def_regular || ( hashEntry->type == STT_GNU_IFUNC && !bfd_link_pic( info ) ) )
++	{
++		for( struct plt_entry *pltEntry = hashEntry->plt.plist;pltEntry != NULL;pltEntry = pltEntry->next )
++		{
++			if( pltEntry->plt.offset != (bfd_vma)-1 ) 
++			{	
++				if( ! hashEntry->def_regular && ! hashEntry->pointer_equality_needed )
++	    		{
++					/* THF: This is peculiar. The compiler generates a R_PPC_JMP_SLOT for externally referenced
++					 * symbols imported from libc.so. Relocation in elf.library requires the symbol to have it's .plt
++					 * stub value, but the linker specifically clears the value to 0, resulting in run-time
++					 * errors when the binary tries to call libc functions.
++					 */	
++					hashEntry->pointer_equality_needed = 1;
++				}
++			}
++		}
++	}
++
++  return ppc_elf_finish_dynamic_symbol( output_bfd,info,hashEntry,sym );
++}
++
+ #undef elf_backend_additional_program_headers
+ #define elf_backend_additional_program_headers \
+   ppc_elf_amigaos_additional_program_headers
+ 
++#undef elf_backend_finish_dynamic_symbol
++#define elf_backend_finish_dynamic_symbol	ppc_elf_amigaos_finish_dynamic_symbol
++
+ #undef elf32_bed
+ #define elf32_bed	elf32_powerpc_amigaos_bed
+ 
+-- 
+2.43.0
+
+
+From a47ff2a427fafa589fbb347cc8999ab502f39412 Mon Sep 17 00:00:00 2001
+From: migthymax <59331342+migthymax@users.noreply.github.com>
+Date: Fri, 29 Sep 2023 08:31:36 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 13/61] 
+ 8 ld crashes in some condition (#14)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+* Changed the way how amiga eumlation is handlled to the new binutils way (maybe)
+
+* Fixed suggest explicit braces to avoid ambiguous ‘else’
+
+* Default to static linking
+
+* Rework how PLT is handled
+
+* Enforce that the .rodata section is put its own read-only segment (program header)
+
+* Removed specific amigaos emulation, now it is based upon ppc32elf
+
+* Put. rodata section in its own segment just after the segment containing the .text section
+
+* Put .newlib_version section in another segment after the segment containing the .rodata section
+
+* .rodata in own segment with no overlap
+---
+ bfd/elf-amigaos.c         |    4 +
+ bfd/elf32-ppc.c           |   99 +-
+ gas/configure.tgt         |    2 +-
+ ld/Makefile.in            |    1 -
+ ld/emulparams/amigaos.sh  |    1 +
+ ld/emultempl/amigaos.em   | 2544 -------------------------------------
+ ld/scripttempl/amigaos.sc |  525 ++++++--
+ 7 files changed, 482 insertions(+), 2694 deletions(-)
+ delete mode 100644 ld/emultempl/amigaos.em
+
+diff --git a/bfd/elf-amigaos.c b/bfd/elf-amigaos.c
+index 962fe1e519d..06771ecc312 100644
+--- a/bfd/elf-amigaos.c
++++ b/bfd/elf-amigaos.c
+@@ -31,6 +31,10 @@
+ bool
+ _bfd_elf_amigaos_add_dynamic_tags (struct bfd_link_info *info)
+ {
++#ifdef DEBUG
++		printf ("Target amigaos-pcc needs addtional marker symbol DT_AMIGAOS_DYNVERSION to mark version used.\n"); 
++#endif
++
+ 	struct elf_link_hash_table *htab = elf_hash_table (info);
+ 	
+ 	return  htab->target_os != is_amigaos || _bfd_elf_add_dynamic_entry (info,DT_AMIGAOS_DYNVERSION, 2);
+diff --git a/bfd/elf32-ppc.c b/bfd/elf32-ppc.c
+index 4a909b60c49..2077aaab94e 100644
+--- a/bfd/elf32-ppc.c
++++ b/bfd/elf32-ppc.c
+@@ -10542,17 +10542,95 @@ ppc_elf_finish_dynamic_sections (bfd *output_bfd,
+ #undef ELF_TARGET_OS
+ #define ELF_TARGET_OS		is_amigaos
+ 
+-/* If we have .sbss2 or .PPC.EMB.sbss0 output sections, we
+-   need to bump up the number of section headers.  */
 +/* The name of the readonly data section.  */
 +#define RDATA_SECTION_NAME ".rodata"
 +
 +/* If we have .rodata section we need to bump the
 +programm headers, so that it is in it own segment. */ 
 +
-+
-+static int
+ 
+ static int
+-ppc_elf_amigaos_additional_program_headers (bfd *abfd,
+-				    struct bfd_link_info *info ATTRIBUTE_UNUSED)
 +ppc_elf_amigaos_additional_program_headers (
 +	bfd *abfd,
 +	struct bfd_link_info *info ATTRIBUTE_UNUSED)
-+{
+ {
+-  int ret = 1;
+-  ret += ppc_elf_additional_program_headers (abfd,info);
 +	int ret = ppc_elf_additional_program_headers(abfd,info);
-+
+ 
+-  return ret;
 +	/* See if we need a RDATA_SECTION_NAME segment.  */
 +	if (bfd_get_section_by_name (abfd, RDATA_SECTION_NAME))
 +	{
@@ -800,3376 +5370,3469 @@ index a8234f27a8a437b2503cd55c971d5d3acbbf6222..2077aaab94e68bb29bce78598ec82c7e
 +	}
 +
 +	return ppc_elf_modify_segment_map( abfd,info );
-+}
-+
-+static bool
-+ppc_elf_amigaos_finish_dynamic_symbol(
-+	bfd *output_bfd,
-+	struct bfd_link_info *info,
-+	struct elf_link_hash_entry *hashEntry,
-+	Elf_Internal_Sym *sym)
-+{
-+#ifdef DEBUG
-+	printf ("Target amigaos-pcc needs reloc R_PPC_JMP_SLOT/... having none zero value\n"); 
-+#endif
-+ 
-+	if( ! hashEntry->def_regular || ( hashEntry->type == STT_GNU_IFUNC && !bfd_link_pic( info ) ) )
-+	{
-+		for( struct plt_entry *pltEntry = hashEntry->plt.plist;pltEntry != NULL;pltEntry = pltEntry->next )
-+		{
-+			if( pltEntry->plt.offset != (bfd_vma)-1 ) 
-+			{	
-+				if( ! hashEntry->def_regular && ! hashEntry->pointer_equality_needed )
-+	    		{
-+					/* THF: This is peculiar. The compiler generates a R_PPC_JMP_SLOT for externally referenced
-+					 * symbols imported from libc.so. Relocation in elf.library requires the symbol to have it's .plt
-+					 * stub value, but the linker specifically clears the value to 0, resulting in run-time
-+					 * errors when the binary tries to call libc functions.
-+					 */	
-+					hashEntry->pointer_equality_needed = 1;
-+				}
-+			}
-+		}
-+	}
-+
-+  return ppc_elf_finish_dynamic_symbol( output_bfd,info,hashEntry,sym );
-+}
-+#undef elf_backend_additional_program_headers
+ }
+ 
+ static bool
+@@ -10587,10 +10665,11 @@ ppc_elf_amigaos_finish_dynamic_symbol(
+ 
+   return ppc_elf_finish_dynamic_symbol( output_bfd,info,hashEntry,sym );
+ }
+-
+ #undef elf_backend_additional_program_headers
+-#define elf_backend_additional_program_headers \
+-  ppc_elf_amigaos_additional_program_headers
 +#define elf_backend_additional_program_headers	ppc_elf_amigaos_additional_program_headers
 +
 +#undef elf_backend_modify_segment_map
 +#define elf_backend_modify_segment_map			ppc_elf_amigaos_modify_segment_map
-+
-+#undef elf_backend_finish_dynamic_symbol
-+#define elf_backend_finish_dynamic_symbol	ppc_elf_amigaos_finish_dynamic_symbol
-+
-+#undef elf32_bed
-+#define elf32_bed	elf32_powerpc_amigaos_bed
-+
-+#include "elf32-target.h"
-+
- /* FreeBSD Target */
  
- #undef  TARGET_LITTLE_SYM
- #undef  TARGET_LITTLE_NAME
- 
- #undef  TARGET_BIG_SYM
-diff --git a/bfd/elflink.c b/bfd/elflink.c
-index 7bf337c7d449b8e1f690b5adccf42d590e15b807..370f4173b22857ab84d06b8ec85311c9b1a5225f 100644
---- a/bfd/elflink.c
-+++ b/bfd/elflink.c
-@@ -10530,12 +10530,14 @@ elf_link_output_extsym (struct bfd_hash_entry *bh, void *data)
-   sym.st_other = h->other;
-   switch (h->root.type)
-     {
-     default:
-     case bfd_link_hash_new:
-     case bfd_link_hash_warning:
-+	  // ML: TODO: really needed, or just  cosmetic?
-+	  (*_bfd_error_handler)(_("Unexpected type (%d) of symbol %s"), h->root.type, h->root.root.string);
-       abort ();
-       return false;
- 
-     case bfd_link_hash_undefined:
-     case bfd_link_hash_undefweak:
-       input_sec = bfd_und_section_ptr;
-diff --git a/bfd/libbfd.h b/bfd/libbfd.h
-index e75935133acd6e9e5000177bff0eaba3e2f17d78..a406a9dc00d31449ceef3de062655720846d2b06 100644
---- a/bfd/libbfd.h
-+++ b/bfd/libbfd.h
-@@ -1648,12 +1648,16 @@ static const char *const bfd_reloc_code_real_names[] = { "@@uninitialized@@",
-   "BFD_RELOC_PPC64_DTPREL34",
-   "BFD_RELOC_PPC64_GOT_TLSGD_PCREL34",
-   "BFD_RELOC_PPC64_GOT_TLSLD_PCREL34",
-   "BFD_RELOC_PPC64_GOT_TPREL_PCREL34",
-   "BFD_RELOC_PPC64_GOT_DTPREL_PCREL34",
-   "BFD_RELOC_PPC64_TLS_PCREL",
-+  "BFD_RELOC_PPC_AMIGAOS_BREL",
-+  "BFD_RELOC_PPC_AMIGAOS_BREL_LO",
-+  "BFD_RELOC_PPC_AMIGAOS_BREL_HI",
-+  "BFD_RELOC_PPC_AMIGAOS_BREL_HA",
-   "BFD_RELOC_I370_D12",
-   "BFD_RELOC_CTOR",
-   "BFD_RELOC_ARM_PCREL_BRANCH",
-   "BFD_RELOC_ARM_PCREL_BLX",
-   "BFD_RELOC_THUMB_PCREL_BLX",
-   "BFD_RELOC_ARM_PCREL_CALL",
-diff --git a/bfd/po/SRC-POTFILES.in b/bfd/po/SRC-POTFILES.in
-index 08e2901d3baf74b92a48cbcc705c4b13701fec63..c4ff7a793ecbebc8fd5e0124c1eb75e4a6a67678 100644
---- a/bfd/po/SRC-POTFILES.in
-+++ b/bfd/po/SRC-POTFILES.in
-@@ -145,12 +145,14 @@ elf-m10300.c
- elf-nacl.c
- elf-nacl.h
- elf-properties.c
- elf-s390.h
- elf-sframe.c
- elf-strtab.c
-+elf-amigaos.c
-+elf-amigaos.h
- elf-vxworks.c
- elf-vxworks.h
- elf.c
- elf32-am33lin.c
- elf32-arc.c
- elf32-arm.c
-diff --git a/bfd/reloc.c b/bfd/reloc.c
-index db4f30d36d0065a670df387215d1329fcbaa9039..0f4faa0c5446c295143360e09d023e6d0c05d253 100644
---- a/bfd/reloc.c
-+++ b/bfd/reloc.c
-@@ -3048,15 +3048,21 @@ ENUMX
- ENUMX
-   BFD_RELOC_PPC64_TLS_PCREL
- ENUMDOC
-   PowerPC and PowerPC64 thread-local storage relocations.
- 
- ENUM
--  BFD_RELOC_I370_D12
-+  BFD_RELOC_PPC_AMIGAOS_BREL
-+ENUMX  
-+  BFD_RELOC_PPC_AMIGAOS_BREL_LO
-+ENUMX  
-+  BFD_RELOC_PPC_AMIGAOS_BREL_HI
-+ENUMX
-+  BFD_RELOC_PPC_AMIGAOS_BREL_HA
- ENUMDOC
--  IBM 370/390 relocations
-+  AmigaOS PowerPC r2 base relative addressing into data section.
- 
- ENUM
-   BFD_RELOC_CTOR
- ENUMDOC
-   The type of reloc used to build a constructor table - at the moment
-   probably a 32 bit wide absolute relocation, but the target can choose.
-diff --git a/bfd/targets.c b/bfd/targets.c
-index 41294ea4d141c44ff58bac3fb1ce3316c8cde63f..f09f2c337a7dc62f5145e14c01182cd97a737ba2 100644
---- a/bfd/targets.c
-+++ b/bfd/targets.c
-@@ -847,12 +847,13 @@ extern const bfd_target pdp11_aout_vec;
- extern const bfd_target pef_vec;
- extern const bfd_target pef_xlib_vec;
- extern const bfd_target pj_elf32_vec;
- extern const bfd_target pj_elf32_le_vec;
- extern const bfd_target plugin_vec;
- extern const bfd_target powerpc_boot_vec;
-+extern const bfd_target powerpc_elf32_amigaos_vec;
- extern const bfd_target powerpc_elf32_vec;
- extern const bfd_target powerpc_elf32_le_vec;
- extern const bfd_target powerpc_elf32_fbsd_vec;
- extern const bfd_target powerpc_elf32_vxworks_vec;
- extern const bfd_target powerpc_elf64_vec;
- extern const bfd_target powerpc_elf64_le_vec;
-@@ -1233,12 +1234,13 @@ static const bfd_target * const _bfd_target_vector[] =
- 	&pef_xlib_vec,
- 
- 	&pj_elf32_vec,
- 	&pj_elf32_le_vec,
- 
- 	&powerpc_boot_vec,
-+	&powerpc_elf32_amigaos_vec,
- 	&powerpc_elf32_vec,
- 	&powerpc_elf32_le_vec,
- 	&powerpc_elf32_fbsd_vec,
- 	&powerpc_elf32_vxworks_vec,
- #ifdef BFD64
- 	&powerpc_elf64_vec,
-diff --git a/binutils/elfcomm.c b/binutils/elfcomm.c
-index 71b595a68a9296fdfbe3fb794f4baa8324ea2a4a..b8c0afa8e0d1914a390ef5d0539549663da0fc26 100644
---- a/binutils/elfcomm.c
-+++ b/binutils/elfcomm.c
-@@ -32,12 +32,24 @@
- #include "aout/ar.h"
- #include "elfcomm.h"
- #include <assert.h>
- 
- extern char *program_name;
- 
-+/* Restore commit 546cb2d85eddba4f56dfbcb0288db68243e3a0fd for AmigaOS4 with clib clib4 */
-+#if defined(__amigaos4__) && defined(__CLIB4__)
-+/* FIXME:  This definition really ought to be in ansidecl.h.  */
-+#ifndef ATTRIBUTE_WEAK
-+#define ATTRIBUTE_WEAK __attribute__((weak))
-+#endif
-+
-+/* Allow the following two functions to be overridden if desired.  */
-+void error (const char *, ...) ATTRIBUTE_WEAK;
-+void warn (const char *, ...) ATTRIBUTE_WEAK;
-+#endif
-+
- void
- error (const char *message, ...)
- {
-   va_list args;
- 
-   /* Try to keep error messages in sync with the program's normal output.  */
-diff --git a/binutils/objcopy.c b/binutils/objcopy.c
-index a6182b48b6c0ebc293ef57f306fa71231f3efbfa..4e85ed7966a56fb86a306c535a051d19166019bb 100644
---- a/binutils/objcopy.c
-+++ b/binutils/objcopy.c
-@@ -119,12 +119,15 @@ enum strip_action
-   STRIP_ALL		/* Strip all symbols.  */
- };
- 
- /* Which symbols to remove.  */
- static enum strip_action strip_symbols = STRIP_UNDEF;
- 
-+/* Shall we strip unneeded relative relocs? */
-+static int strip_unneeded_rel_relocs;
-+
- enum locals_action
- {
-   LOCALS_UNDEF,
-   LOCALS_START_L,	/* Discard locals starting with L.  */
-   LOCALS_ALL		/* Discard all locals.  */
- };
-@@ -363,12 +366,13 @@ enum command_line_switch
-   OPTION_SET_SECTION_ALIGNMENT,
-   OPTION_SET_START,
-   OPTION_SREC_FORCES3,
-   OPTION_SREC_LEN,
-   OPTION_STACK,
-   OPTION_STRIP_DWO,
-+  OPTION_STRIP_UNNEEED_REL_RELOCS,
-   OPTION_STRIP_SYMBOLS,
-   OPTION_STRIP_UNNEEDED,
-   OPTION_STRIP_UNNEEDED_SYMBOL,
-   OPTION_STRIP_UNNEEDED_SYMBOLS,
-   OPTION_SUBSYSTEM,
-   OPTION_UPDATE_SECTION,
-@@ -406,12 +410,13 @@ static struct option strip_options[] =
-   {"remove-relocations", required_argument, 0, OPTION_REMOVE_RELOCS},
-   {"strip-all", no_argument, 0, 's'},
-   {"strip-debug", no_argument, 0, 'S'},
-   {"strip-dwo", no_argument, 0, OPTION_STRIP_DWO},
-   {"strip-symbol", required_argument, 0, 'N'},
-   {"strip-unneeded", no_argument, 0, OPTION_STRIP_UNNEEDED},
-+  {"strip-unneeded-rel-relocs", no_argument, 0, OPTION_STRIP_UNNEEED_REL_RELOCS},
-   {"target", required_argument, 0, 'F'},
-   {"verbose", no_argument, 0, 'v'},
-   {"version", no_argument, 0, 'V'},
-   {"wildcard", no_argument, 0, 'w'},
-   {0, no_argument, 0, 0}
- };
-@@ -1559,12 +1564,17 @@ filter_symbols (bfd *abfd, bfd *obfd, asymbol **osyms,
-       bool undefined;
-       bool rem_leading_char;
-       bool add_leading_char;
- 
-       undefined = bfd_is_und_section (bfd_asymbol_section (sym));
- 
-+	  if (strip_symbols == STRIP_ALL && undefined)
-+        {
-+          add_specific_symbol(name, keep_specific_htab);
-+        }
-+
-       if (add_sym_list)
- 	{
- 	  struct addsym_node *ptr;
- 
- 	  if (need_sym_before (&ptr, name))
- 	    to[dst_count++] = create_new_symbol (ptr, obfd);
-@@ -1642,16 +1652,29 @@ filter_symbols (bfd *abfd, bfd *obfd, asymbol **osyms,
- 	    }
- 
- 	  strcpy (ptr, name);
- 	  bfd_set_asymbol_name (sym, n);
- 	  name = n;
- 	}
--
--      if (strip_symbols == STRIP_ALL)
--	keep = false;
--      else if ((flags & BSF_KEEP) != 0		/* Used in relocation.  */
-+      if(strip_symbols == STRIP_ALL) 
-+	  { 		
-+		  keep = false;
-+		 /* Never, ever, strip everthing on the Amiga, keep global symbols, needed by OS 
-+		 	_start: 		Entry point of executable, isn't fixed on ppc-amigaos, so OS needs to knwo where to enter
-+			__amigaos4__: 	Maker symbol to identify that ELF file is for ppc-amigaos, because no offcial value has been assigned to ELF heder field OS/ABI for ppc-amigaos
-+			_SDA_BASE_:		If small data model ist used, the symbol is needed ....?????
-+		 */
-+     	 if( (bfd_get_flavour(obfd) == bfd_target_elf_flavour && get_elf_backend_data(obfd)->target_os == is_amigaos))
-+		 {
-+			//  ML: TODO: _SDA_BASE_ onyl needs to be kept if small data section are present ????
-+			if (strcmp(name, "_start") == 0 || strcmp(name, "__amigaos4__") == 0 || strcmp(name, "_SDA_BASE_") == 0) {
-+			  keep = true;
-+			}
-+		 }
-+	  }
-+	  else if ((flags & BSF_KEEP) != 0		/* Used in relocation.  */
- 	       || ((flags & BSF_SECTION_SYM) != 0
- 		   && ((*bfd_asymbol_section (sym)->symbol_ptr_ptr)->flags
- 		       & BSF_KEEP) != 0))
- 	{
- 	  keep = true;
- 	  used_in_reloc = true;
-@@ -1706,13 +1729,23 @@ filter_symbols (bfd *abfd, bfd *obfd, asymbol **osyms,
-       if (!keep
- 	  && ((keep_file_symbols && (flags & BSF_FILE))
- 	      || is_specified_symbol (name, keep_specific_htab)))
- 	keep = true;
- 
-       if (keep && is_strip_section (abfd, bfd_asymbol_section (sym)))
--	keep = false;
-+	{
-+          /* If the symbol refers to a stripped section, we still want to
-+           * keep it, e.g., _SDA_BASE_ TODO: We should perhaps output a
-+           * warning or add another option to trigger this behaviour.
-+           * FIXME: The section to which symbol refers must be adjusted
-+           * as well */
-+          if (!is_specified_symbol (name, keep_specific_htab))
-+            {
-+              keep = false;
-+            }
-+	}
- 
-       if (keep)
- 	{
- 	  if (((flags & (BSF_GLOBAL | BSF_GNU_UNIQUE))
- 	       || undefined)
- 	      && (weaken || is_specified_symbol (name, weaken_specific_htab)))
-@@ -3288,12 +3321,13 @@ copy_object (bfd *ibfd, bfd *obfd, const bfd_arch_info_type *input_arch)
- 
- 	 Note we iterate over the input sections examining their
- 	 relocations since the relocations for the output sections
- 	 haven't been set yet.  mark_symbols_used_in_relocations will
- 	 ignore input sections which have no corresponding output
- 	 section.  */
-+	 // ML: TODO: Really needef for maiga to remove the floowing  fi???
-       if (strip_symbols != STRIP_ALL)
- 	{
- 	  bfd_set_error (bfd_error_no_error);
- 	  bfd_map_over_sections (ibfd,
- 				 mark_symbols_used_in_relocations,
- 				 isympp);
-@@ -4371,27 +4405,40 @@ copy_relocations_in_section (bfd *ibfd, sec_ptr isection, void *obfdarg)
- 	      bfd_nonfatal_message (NULL, ibfd, isection,
- 				    _("relocation count is negative"));
- 	      return;
- 	    }
- 	}
- 
--      if (strip_symbols == STRIP_ALL)
--	{
-+    if (strip_symbols == STRIP_ALL )
-+  {
- 	  /* Remove relocations which are not in
- 	     keep_strip_specific_list.  */
- 	  arelent **w_relpp;
- 	  long i;
- 
- 	  for (w_relpp = relpp, i = 0; i < relcount; i++)
- 	    /* PR 17512: file: 9e907e0c.  */
- 	    if (relpp[i]->sym_ptr_ptr
- 		/* PR 20096 */
--		&& *relpp[i]->sym_ptr_ptr
--		&& is_specified_symbol (bfd_asymbol_name (*relpp[i]->sym_ptr_ptr),
-+		&& *relpp[i]->sym_ptr_ptr ) {
-+		asection *sec = (*(relpp[i]->sym_ptr_ptr))->section;
-+
-+		if( is_specified_symbol (bfd_asymbol_name (*relpp[i]->sym_ptr_ptr),
- 					keep_specific_htab))
- 	      *w_relpp++ = relpp[i];
-+		/* Never, ever, strip all? reloc data on the Amiga! */
-+		else if( bfd_get_flavour(obfd) == bfd_target_elf_flavour && get_elf_backend_data(obfd)->target_os == is_amigaos)
-+		{
-+			if (!strip_unneeded_rel_relocs || !relpp [i]->howto->pc_relative || sec->index != osection->index)
-+			{
-+				relpp[i]->addend = bfd_asymbol_value(*relpp [i]->sym_ptr_ptr) - sec->vma + relpp[i]->addend;
-+				relpp[i]->sym_ptr_ptr = sec->symbol_ptr_ptr;
-+				*w_relpp++ = relpp[i];
-+			}
-+		}  
-+		}
- 	  relcount = w_relpp - relpp;
- 	  *w_relpp = 0;
- 	}
- 
-       bfd_set_reloc (obfd, osection, relcount == 0 ? NULL : relpp, relcount);
-     }
-@@ -4747,12 +4794,15 @@ strip_main (int argc, char *argv[])
- 	case OPTION_STRIP_DWO:
- 	  strip_symbols = STRIP_DWO;
- 	  break;
- 	case OPTION_STRIP_UNNEEDED:
- 	  strip_symbols = STRIP_UNNEEDED;
- 	  break;
-+	case OPTION_STRIP_UNNEEED_REL_RELOCS:
-+	  strip_unneeded_rel_relocs = 1;
-+	  break;	  
- 	case 'K':
- 	  add_specific_symbol (optarg, keep_specific_htab);
- 	  break;
- 	case 'M':
- 	  merge_notes = true;
- 	  merge_notes_set = true;
-@@ -4832,12 +4882,17 @@ strip_main (int argc, char *argv[])
- 
-   if (show_version)
-     print_version ("strip");
- 
-   default_deterministic ();
- 
-+  // ML: TODO: For amiga
-+  add_specific_symbol("__amigaos4__", keep_specific_htab);
-+  add_specific_symbol("_start", keep_specific_htab);
-+  add_specific_symbol("_SDA_BASE_", keep_specific_htab);
-+
-   /* Default is to strip all symbols.  */
-   if (strip_symbols == STRIP_UNDEF
-       && discard_locals == LOCALS_UNDEF
-       && htab_elements (strip_specific_htab) == 0)
-     strip_symbols = STRIP_ALL;
- 
-@@ -5906,12 +5961,18 @@ copy_main (int argc, char *argv[])
-   if (show_version)
-     print_version ("objcopy");
- 
-   if (interleave && copy_byte == -1)
-     fatal (_("interleave start byte must be set with --byte"));
- 
-+  // ML: TOOD: For akigaSO
-+  add_specific_symbol("__amigappc__", keep_specific_htab);
-+  add_specific_symbol("__amigaos4__", keep_specific_htab);
-+  add_specific_symbol("_start", keep_specific_htab);
-+  add_specific_symbol("_SDA_BASE_", keep_specific_htab);
-+
-   if (copy_byte >= interleave)
-     fatal (_("byte number must be less than interleave"));
- 
-   if (copy_width > interleave - copy_byte)
-     fatal (_("interleave width must be less than or equal to interleave - byte`"));
- 
-diff --git a/binutils/readelf.c b/binutils/readelf.c
-index 3da3db159ccd2ca8bcc22e9b644447c106b7c110..0439e7af16bd78c35d57187d4af414df3e3404ce 100644
---- a/binutils/readelf.c
-+++ b/binutils/readelf.c
-@@ -94,12 +94,13 @@
- 
- #define RELOC_MACROS_GEN_FUNC
- 
- #include "elf/aarch64.h"
- #include "elf/alpha.h"
- #include "elf/amdgpu.h"
-+#include "elf/amigaos.h"
- #include "elf/arc.h"
- #include "elf/arm.h"
- #include "elf/avr.h"
- #include "elf/bfin.h"
- #include "elf/cr16.h"
- #include "elf/cris.h"
-@@ -2220,12 +2221,13 @@ static const char *
- get_ppc_dynamic_type (unsigned long type)
- {
-   switch (type)
-     {
-     case DT_PPC_GOT:    return "PPC_GOT";
-     case DT_PPC_OPT:    return "PPC_OPT";
-+	case DT_AMIGAOS_DYNVERSION: return "AMIGAOS_DYNVERSION";
-     default:
-       return NULL;
-     }
- }
- 
- static const char *
-@@ -2527,12 +2529,14 @@ get_dynamic_type (Filedata * filedata, unsigned long type)
-     case DT_GNU_CONFLICTSZ: return "GNU_CONFLICTSZ";
-     case DT_GNU_LIBLIST: return "GNU_LIBLIST";
-     case DT_GNU_LIBLISTSZ: return "GNU_LIBLISTSZ";
-     case DT_GNU_HASH:	return "GNU_HASH";
-     case DT_GNU_FLAGS_1: return "GNU_FLAGS_1";
- 
-+	case DT_AMIGAOS_DYNVERSION: return get_ppc_dynamic_type (type);
-+
-     default:
-       if ((type >= DT_LOPROC) && (type <= DT_HIPROC))
- 	{
- 	  const char * result;
- 
- 	  switch (filedata->file_header.e_machine)
-diff --git a/binutils/version.c b/binutils/version.c
-index 08035359ad7fca65322249a37bbf20992eaa7ec3..5752fb4cb0a31c6448c7e5d57d039ec3f00330cf 100644
---- a/binutils/version.c
-+++ b/binutils/version.c
-@@ -33,8 +33,21 @@ print_version (const char *name)
-   printf ("GNU %s %s\n", name, BFD_VERSION_STRING);
-   printf (_("Copyright (C) 2023 Free Software Foundation, Inc.\n"));
-   printf (_("\
- This program is free software; you may redistribute it under the terms of\n\
- the GNU General Public License version 3 or (at your option) any later version.\n\
- This program has absolutely no warranty.\n"));
-+
-+#if defined(__amigaos4__)
-+# if defined( __NEWLIB__)
-+  printf (_("AmigaOS native (ppc-amigaos,newlib).\n"));
-+# elif defined( __CLIB4__)
-+  printf (_("AmigaOS native (ppc-amigaos,clib4).\n"));
-+# elif defined( __CLIB2__ )
-+  printf (_("AmigaOS native (ppc-amigaos,clib2).\n"));
-+# else
-+ printf (_("AmigaOS native (ppc-amigaos,unknown).\n"));
-+# endif
-+#endif
-+
-   exit (0);
- }
-diff --git a/config.sub b/config.sub
-index dba16e84c77c7d25871d80c24deff717faf4c094..3913e5de7c182cd77942ba69027b37f774f104fc 100755
---- a/config.sub
-+++ b/config.sub
-@@ -9,13 +9,13 @@ timestamp='2022-01-03'
- # This file is free software; you can redistribute it and/or modify it
- # under the terms of the GNU General Public License as published by
- # the Free Software Foundation, either version 3 of the License, or
- # (at your option) any later version.
- #
- # This program is distributed in the hope that it will be useful, but
--# WITHOUT ANY WARRANTY; without even the implied warranty of
-+# WITHOUT ANY WARRANTY; without even the implied warranty amigaunix
- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- # General Public License for more details.
- #
- # You should have received a copy of the GNU General Public License
- # along with this program; if not, see <https://www.gnu.org/licenses/>.
- #
-@@ -228,18 +228,14 @@ case $1 in
- 				basic_os=bsd
- 				;;
- 			amdahl)
- 				basic_machine=580-amdahl
- 				basic_os=sysv
- 				;;
--			amiga)
--				basic_machine=m68k-unknown
--				basic_os=
--				;;
--			amigaos | amigados)
--				basic_machine=m68k-unknown
-+			amigaos | amigados | amiga)
-+				basic_machine=powerpc-unknown
- 				basic_os=amigaos
- 				;;
- 			amigaunix | amix)
- 				basic_machine=m68k-unknown
- 				basic_os=sysv4
- 				;;
-diff --git a/elfcpp/powerpc.h b/elfcpp/powerpc.h
-index 9322061daed24fd9e8942129322804ad3282e77b..375468d984fbcc86d2246b2e569564b89cc34f10 100644
---- a/elfcpp/powerpc.h
-+++ b/elfcpp/powerpc.h
-@@ -208,12 +208,18 @@ enum
-   R_PPC64_DTPREL34 = 147,
-   R_PPC64_GOT_TLSGD_PCREL34 = 148,
-   R_PPC64_GOT_TLSLD_PCREL34 = 149,
-   R_PPC64_GOT_TPREL_PCREL34 = 150,
-   R_PPC64_GOT_DTPREL_PCREL34 = 151,
- 
-+  /* ML: TODO: AmigaOS ELF base relative addressing data secion via r2 relocation (compile option -mbaserel)*/
-+  R_PPC_AMIGAOS_BREL = 210,
-+  R_PPC_AMIGAOS_BREL_LO = 211,
-+  R_PPC_AMIGAOS_BREL_HI = 212,
-+  R_PPC_AMIGAOS_BREL_HA = 213,
-+  
-   R_PPC_VLE_REL8 = 216,
-   R_PPC_VLE_REL15 = 217,
-   R_PPC_VLE_REL24 = 218,
-   R_PPC_VLE_LO16A = 219,
-   R_PPC_VLE_LO16D = 220,
-   R_PPC_VLE_HI16A = 221,
-diff --git a/gas/Makefile.am b/gas/Makefile.am
-index ba2896581b75ea89f9a53200d636cdbb9910b751..b6fbe64a10c26c229afc65cad6ae48b84c7f37e5 100644
---- a/gas/Makefile.am
-+++ b/gas/Makefile.am
-@@ -314,12 +314,13 @@ OBJ_FORMAT_HFILES = \
- 
- # Emulation header files in config
- 
- TARG_ENV_HFILES = \
- 	config/te-386bsd.h \
- 	config/te-aix5.h \
-+	config/te-amigaos.h \
- 	config/te-armeabi.h \
- 	config/te-armfbsdeabi.h \
- 	config/te-armfbsdvfp.h \
- 	config/te-armlinuxeabi.h \
- 	config/te-csky_abiv1.h \
- 	config/te-csky_abiv1_linux.h \
-diff --git a/gas/Makefile.in b/gas/Makefile.in
-index 8319181b47278770c2449c23b5dfac043a4ead5d..743c546418da854330df420ed153a67b5d3f8e7c 100644
---- a/gas/Makefile.in
-+++ b/gas/Makefile.in
-@@ -801,12 +801,13 @@ OBJ_FORMAT_HFILES = \
- 
- 
- # Emulation header files in config
- TARG_ENV_HFILES = \
- 	config/te-386bsd.h \
- 	config/te-aix5.h \
-+	config/te-amigaos.h \
- 	config/te-armeabi.h \
- 	config/te-armfbsdeabi.h \
- 	config/te-armfbsdvfp.h \
- 	config/te-armlinuxeabi.h \
- 	config/te-csky_abiv1.h \
- 	config/te-csky_abiv1_linux.h \
-diff --git a/gas/config/tc-ppc.c b/gas/config/tc-ppc.c
-index 9450fa74de1b61542c9a18babf8c8f621ef904fb..cb5da74ab478d0da04fa562f4a96a351e862c35a 100644
---- a/gas/config/tc-ppc.c
-+++ b/gas/config/tc-ppc.c
-@@ -1544,20 +1544,24 @@ ppc_target_format (void)
- #  else
-   return (ppc_obj64 ? "aixcoff64-rs6000" : "aixcoff-rs6000");
- #  endif
- #endif
- #endif
- #ifdef OBJ_ELF
--# ifdef TE_FreeBSD
-+# if TE_AMIGAOS
-+  return "elf32-powerpc-amigaos";
-+# else
-+#  ifdef TE_FreeBSD
-   return (ppc_obj64 ? "elf64-powerpc-freebsd" : "elf32-powerpc-freebsd");
--# elif defined (TE_VXWORKS)
-+#  elif defined (TE_VXWORKS)
-   return "elf32-powerpc-vxworks";
--# else
-+#  else
-   return (target_big_endian
- 	  ? (ppc_obj64 ? "elf64-powerpc" : "elf32-powerpc")
- 	  : (ppc_obj64 ? "elf64-powerpcle" : "elf32-powerpcle"));
-+#  endif
- # endif
- #endif
- }
- 
- /* Validate one entry in powerpc_opcodes[] or vle_opcodes[].
-    Return TRUE if there's a problem, otherwise FALSE.  */
-@@ -2108,12 +2112,16 @@ ppc_elf_suffix (char **str_p, expressionS *exp_p)
- 
- #define MAP(str, reloc)   { str, sizeof (str) - 1, 1, 1, reloc }
- #define MAP32(str, reloc) { str, sizeof (str) - 1, 1, 0, reloc }
- #define MAP64(str, reloc) { str, sizeof (str) - 1, 0, 1, reloc }
- 
-   static const struct map_bfd mapping[] = {
-+    MAP ("brel",		BFD_RELOC_PPC_AMIGAOS_BREL),
-+    MAP ("brel@l",		BFD_RELOC_PPC_AMIGAOS_BREL_LO),
-+    MAP ("brel@h",		BFD_RELOC_PPC_AMIGAOS_BREL_HI),
-+    MAP ("brel@ha",		BFD_RELOC_PPC_AMIGAOS_BREL_HA),	
-     MAP ("l",			BFD_RELOC_LO16),
-     MAP ("h",			BFD_RELOC_HI16),
-     MAP ("ha",			BFD_RELOC_HI16_S),
-     MAP ("brtaken",		BFD_RELOC_PPC_B16_BRTAKEN),
-     MAP ("brntaken",		BFD_RELOC_PPC_B16_BRNTAKEN),
-     MAP ("got",			BFD_RELOC_16_GOTOFF),
-@@ -3108,12 +3116,15 @@ fixup_size (bfd_reloc_code_real_type reloc, bool *pc_relative)
-     case BFD_RELOC_PPC_TOC16_HI:
-     case BFD_RELOC_PPC_TOC16_LO:
-     case BFD_RELOC_PPC_TPREL16:
-     case BFD_RELOC_PPC_TPREL16_HA:
-     case BFD_RELOC_PPC_TPREL16_HI:
-     case BFD_RELOC_PPC_TPREL16_LO:
-+	case BFD_RELOC_PPC_AMIGAOS_BREL_LO:
-+	case BFD_RELOC_PPC_AMIGAOS_BREL_HI:
-+	case BFD_RELOC_PPC_AMIGAOS_BREL_HA:
-       size = 2;
-       break;
- 
-     case BFD_RELOC_16_PCREL:
-     case BFD_RELOC_HI16_PCREL:
-     case BFD_RELOC_HI16_S_PCREL:
-@@ -3172,12 +3183,13 @@ fixup_size (bfd_reloc_code_real_type reloc, bool *pc_relative)
-     case BFD_RELOC_PPC_VLE_SDAREL_HI16A:
-     case BFD_RELOC_PPC_VLE_SDAREL_HI16D:
-     case BFD_RELOC_PPC_VLE_SDAREL_LO16A:
-     case BFD_RELOC_PPC_VLE_SDAREL_LO16D:
-     case BFD_RELOC_PPC64_TLS_PCREL:
-     case BFD_RELOC_RVA:
-+	case BFD_RELOC_PPC_AMIGAOS_BREL:
-       size = 4;
-       break;
- 
-     case BFD_RELOC_24_PLT_PCREL:
-     case BFD_RELOC_32_PCREL:
-     case BFD_RELOC_32_PLT_PCREL:
-@@ -7504,12 +7516,20 @@ md_apply_fix (fixS *fixP, valueT *valP, segT seg)
- 
- 	case BFD_RELOC_VTABLE_ENTRY:
- 	  fixP->fx_done = 0;
- 	  break;
- 
- #ifdef OBJ_ELF
-+	case BFD_RELOC_PPC_AMIGAOS_BREL:
-+	case BFD_RELOC_PPC_AMIGAOS_BREL_HI:
-+	case BFD_RELOC_PPC_AMIGAOS_BREL_LO:
-+	case BFD_RELOC_PPC_AMIGAOS_BREL_HA:
-+	  md_number_to_chars (fixP->fx_frag->fr_literal + fixP->fx_where,
-+			      value, 2);
-+	  break;
-+
- 	  /* These can appear with @l etc. in data.  */
- 	case BFD_RELOC_LO16:
- 	case BFD_RELOC_LO16_PCREL:
- 	case BFD_RELOC_HI16:
- 	case BFD_RELOC_HI16_PCREL:
- 	case BFD_RELOC_HI16_S:
-diff --git a/gas/config/te-amigaos.h b/gas/config/te-amigaos.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..56f213ddd38b0475d86b0d5333aad1060f7f98f3
---- /dev/null
-+++ b/gas/config/te-amigaos.h
-@@ -0,0 +1,14 @@
-+/*
-+ * te-amigaos.h -- Amiga target environment declarations.
-+ */
-+
-+#define TE_AMIGAOS 1
-+
-+#define LOCAL_LABELS_DOLLAR 1
-+#define LOCAL_LABELS_FB 1
-+
-+#ifdef OBJ_HEADER
-+#include OBJ_HEADER
-+#else
-+#include "obj-format.h"
-+#endif
-\ No newline at end of file
+ #undef elf_backend_finish_dynamic_symbol
+ #define elf_backend_finish_dynamic_symbol	ppc_elf_amigaos_finish_dynamic_symbol
 diff --git a/gas/configure.tgt b/gas/configure.tgt
-index 765ba73633df54b51eec560002cc234ce98205c3..6b3d33c96e1eab00caab1a78d0e43798f5a64c31 100644
+index 6f3f613a1dd..6b3d33c96e1 100644
 --- a/gas/configure.tgt
 +++ b/gas/configure.tgt
-@@ -358,12 +358,13 @@ case ${generic_target} in
-   ppc-*-aix5.[01])			fmt=coff em=aix5 ;;
-   ppc-*-aix[5-9].*)			fmt=coff em=aix5 ;;
-   ppc-*-aix*)				fmt=coff em=aix ;;
+@@ -361,7 +361,7 @@ case ${generic_target} in
    ppc-*-beos*)				fmt=coff ;;
    ppc-*-*n*bsd* | ppc-*-elf*)		fmt=elf ;;
    ppc-*-eabi* | ppc-*-sysv4*)		fmt=elf ;;
+-  ppc-*-amigaos*)         	fmt=elf em=amigaos ;;
 +  ppc-*-amigaos*)         	fmt=elf em=amigaos;;
    ppc-*-haiku*)				fmt=elf em=haiku ;;
    ppc-*-linux-*)			fmt=elf em=linux ;;
    ppc-*-solaris*)			fmt=elf em=solaris ;;
-   ppc-*-macos*)				fmt=coff em=macos ;;
-   ppc-*-nto*)				fmt=elf ;;
-   ppc-*-kaos*)				fmt=elf ;;
-diff --git a/gas/doc/.dirstamp b/gas/doc/.dirstamp
-deleted file mode 100644
-index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..0000000000000000000000000000000000000000
-diff --git a/gas/po/POTFILES.in b/gas/po/POTFILES.in
-index 8f2efdb8d556578d94a98c68b5f4ddfc36bea36c..b0d625ffa80e23f05a8ae3f6d6064c8ab4d7aa17 100644
---- a/gas/po/POTFILES.in
-+++ b/gas/po/POTFILES.in
-@@ -182,12 +182,13 @@ config/tc-xtensa.h
- config/tc-z80.c
- config/tc-z80.h
- config/tc-z8k.c
- config/tc-z8k.h
- config/te-386bsd.h
- config/te-aix5.h
-+config/te-amigaos.h
- config/te-armeabi.h
- config/te-armfbsdeabi.h
- config/te-armfbsdvfp.h
- config/te-armlinuxeabi.h
- config/te-csky_abiv1.h
- config/te-csky_abiv1_linux.h
-diff --git a/gdb/Makefile.in b/gdb/Makefile.in
-index 9bc81cda03f5600b6fe7996741abdc5cffce04ef..dfa148e582bf6822b02762f1b563ebdad984c921 100644
---- a/gdb/Makefile.in
-+++ b/gdb/Makefile.in
-@@ -1750,12 +1750,14 @@ ALLDEPFILES = \
- 	nios2-linux-tdep.c \
- 	nios2-tdep.c \
- 	obsd-nat.c \
- 	obsd-tdep.c \
- 	or1k-linux-nat.c \
- 	posix-hdep.c \
-+	ppc-amigaos-nat.c \
-+	ppc-amigaos-tdep.c \
- 	ppc-fbsd-nat.c \
- 	ppc-fbsd-tdep.c \
- 	ppc-linux-nat.c \
- 	ppc-linux-tdep.c \
- 	ppc-netbsd-nat.c \
- 	ppc-netbsd-tdep.c \
-diff --git a/gdb/auto-load.c b/gdb/auto-load.c
-index 198bb073a1baa3ecdcc5e87d4b6f81a8e6d1382f..4a577f88219f1569441d78551919c3dde6beb9ce 100644
---- a/gdb/auto-load.c
-+++ b/gdb/auto-load.c
-@@ -40,12 +40,17 @@
- #include "extension.h"
- #include "gdb/section-scripts.h"
- #include <algorithm>
- #include "gdbsupport/pathstuff.h"
- #include "cli/cli-style.h"
- 
-+#ifdef __amigaos4__
-+#define AUTO_LOAD_DIR "$debugdir;$datadir/auto-load"
-+#define AUTO_LOAD_SAFE_PATH AUTO_LOAD_DIR
-+#endif
-+
- /* The section to look in for auto-loaded scripts (in file formats that
-    support sections).
-    Each entry in this section is a record that begins with a leading byte
-    identifying the record type.
-    At the moment we only support one record type: A leading byte of 1,
-    followed by the path of a python script to load.  */
-diff --git a/gdb/configure.host b/gdb/configure.host
-index da71675b201b11ea5236c1818e01ab37423585c0..90512728e550a5b6650175acd777e181edbee21d 100644
---- a/gdb/configure.host
-+++ b/gdb/configure.host
-@@ -134,12 +134,13 @@ mips*-*-freebsd*)	gdb_host=fbsd ;;
- mips64*-*-openbsd*)	gdb_host=obsd64 ;;
- 
- or1k-*-linux*)		gdb_host=linux ;;
- 
- powerpc-*-aix* | rs6000-*-* | powerpc64-*-aix*)
- 			gdb_host=aix ;;
-+powerpc-*-amigaos*) gdb_host=amigaos ;;
- powerpc*-*-freebsd*)	gdb_host=fbsd ;;
- powerpc-*-netbsdaout* | powerpc-*-knetbsd*-gnu)
- 			gdb_host=nbsd ;;
- powerpc-*-openbsd*)	gdb_host=obsd ;;
- 
- powerpc64*-*-linux*)	gdb_host=ppc64-linux ;;
-diff --git a/gdb/configure.nat b/gdb/configure.nat
-index d219d6a960c396056571cc9af2e07c47930f6507..5a0b27b20977fc3f39cc6c41ef8d21cae7cff1b8 100644
---- a/gdb/configure.nat
-+++ b/gdb/configure.nat
-@@ -109,12 +109,20 @@ case ${gdb_host} in
- 		# should be passed.  We have no idea who our current
- 		# compiler is though, so we skip it.
- 		# MH_CFLAGS='-bnodelcsect'
- 		;;
- 	esac
- 	;;
-+    amigaos)
-+	case ${gdb_host_cpu} in
-+	    powerpc)
-+		# Host: Big-endian PowerPC running AmigaOS
-+		NATDEPFILES="${NATDEPFILES} ppc-amigaos-nat.o"
-+		;;
-+	esac
-+	;;
-     alpha-linux)
- 	case ${gdb_host_cpu} in
- 	    alpha)
- 		# Host: Little-endian Alpha running Linux
- 		NATDEPFILES="${NATDEPFILES} linux-nat-trad.o alpha-linux-nat.o"
- 		# doublest.c currently assumes some properties of FP arithmetic
-diff --git a/gdb/configure.tgt b/gdb/configure.tgt
-index e84e222ba0d9c9610efe719abd5eecb5f760e3eb..fbacf9530c93918bbd3dd29d5405aa3eb3636adf 100644
---- a/gdb/configure.tgt
-+++ b/gdb/configure.tgt
-@@ -504,12 +504,18 @@ powerpc*-*-linux*)
- 			ppc64-tdep.o solib-svr4.o \
- 			glibc-tdep.o symfile-mem.o linux-tdep.o \
- 			ravenscar-thread.o ppc-ravenscar-thread.o \
- 			linux-record.o \
- 			arch/ppc-linux-common.o"
- 	;;
-+powerpc-*-amigaos*)
-+	# Target: PowerPC running AmigaOS
-+	gdb_target_obs="rs6000-tdep.o ppc-sysv-tdep.o \
-+			ppc-amigaos-tdep.o \
-+			ravenscar-thread.o ppc-ravenscar-thread.o"
-+	;;	
- powerpc-*-lynx*178)
- 	# Target: PowerPC running Lynx178.
- 	gdb_target_obs="rs6000-tdep.o rs6000-lynx178-tdep.o \
- 			xcoffread.o ppc-sysv-tdep.o \
- 			ravenscar-thread.o ppc-ravenscar-thread.o"
- 	;;
-@@ -796,12 +802,13 @@ m68*-*-openbsd* | m88*-*-openbsd* | vax-*-openbsd*) ;;
- *-*-*-gnu*)	;; # prevent non-GNU kernels to match the Hurd rule below
- *-*-gnu*)	gdb_osabi=GDB_OSABI_HURD ;;
- *-*-mingw32ce*)	gdb_osabi=GDB_OSABI_WINCE ;;
- *-*-mingw*)	gdb_osabi=GDB_OSABI_WINDOWS ;;
- *-*-cygwin*)	gdb_osabi=GDB_OSABI_CYGWIN ;;
- *-*-dicos*)	gdb_osabi=GDB_OSABI_DICOS ;;
-+powerpc-*-amigaos*)	gdb_osabi=GDB_OSABI_AMIGAOS ;;
- powerpc-*-aix* | rs6000-*-* | powerpc64-*-aix*)
-                 gdb_osabi=GDB_OSABI_AIX ;;
- esac
- 
- # Check whether this target supports gcore.
- # Such target has to call set_gdbarch_find_memory_regions.
-diff --git a/gdb/defs.h b/gdb/defs.h
-index 4771d02a92a4572265a9565afb1ef903d0d699b4..b73f1a823f8502ea1649335426f63c943912757f 100644
---- a/gdb/defs.h
-+++ b/gdb/defs.h
-@@ -31,12 +31,15 @@
- #undef PACKAGE_NAME
- #undef PACKAGE_VERSION
- #undef PACKAGE_STRING
- #undef PACKAGE_TARNAME
- 
- #include <config.h>
-+#if defined(__amigaos4__) 
-+# undef HAVE_SOCKETPAIR
-+#endif
- #include "bfd.h"
- 
- #include <sys/types.h>
- #include <limits.h>
- 
- /* The libdecnumber library, on which GDB depends, includes a header file
-diff --git a/gdb/dwarf2/read.c b/gdb/dwarf2/read.c
-index b33ea6847e0e8634dcf977ebf473679cf83c8871..fe903d83177ff4004691796482f78ac9264c2c2d 100644
---- a/gdb/dwarf2/read.c
-+++ b/gdb/dwarf2/read.c
-@@ -2855,32 +2855,32 @@ dw2_get_file_names (dwarf2_per_cu_data *this_cu,
- 
- /* A helper for the "quick" functions which computes and caches the
-    real path for a given file name from the line table.  */
- 
- static const char *
- dw2_get_real_path (dwarf2_per_objfile *per_objfile,
--		   struct quick_file_names *qfn, int index)
-+		   struct quick_file_names *qfn, int i)
- {
-   if (qfn->real_names == NULL)
-     qfn->real_names = OBSTACK_CALLOC (&per_objfile->per_bfd->obstack,
- 				      qfn->num_file_names, const char *);
- 
--  if (qfn->real_names[index] == NULL)
-+  if (qfn->real_names[i] == NULL)
-     {
-       const char *dirname = nullptr;
- 
--      if (!IS_ABSOLUTE_PATH (qfn->file_names[index]))
-+      if (!IS_ABSOLUTE_PATH (qfn->file_names[i]))
- 	dirname = qfn->comp_dir;
- 
-       gdb::unique_xmalloc_ptr<char> fullname;
--      fullname = find_source_or_rewrite (qfn->file_names[index], dirname);
-+      fullname = find_source_or_rewrite (qfn->file_names[i], dirname);
- 
--      qfn->real_names[index] = fullname.release ();
-+      qfn->real_names[i] = fullname.release ();
-     }
- 
--  return qfn->real_names[index];
-+  return qfn->real_names[i];
- }
- 
- struct symtab *
- dwarf2_base_index_functions::find_last_source_symtab (struct objfile *objfile)
- {
-   dwarf2_per_objfile *per_objfile = get_dwarf2_per_objfile (objfile);
-@@ -11168,19 +11168,19 @@ try_open_dwop_file (dwarf2_per_objfile *per_objfile,
- 
-   gdb::unique_xmalloc_ptr<char> search_path_holder;
-   if (search_cwd)
-     {
-       if (!debug_file_directory.empty ())
- 	{
--	  search_path_holder.reset (concat (".", dirname_separator_string,
-+	  search_path_holder.reset (concat ("", dirname_separator_string,
- 					    debug_file_directory.c_str (),
- 					    (char *) NULL));
- 	  search_path = search_path_holder.get ();
- 	}
-       else
--	search_path = ".";
-+	search_path = "";
-     }
-   else
-     search_path = debug_file_directory.c_str ();
- 
-   /* Add the path for the executable binary to the list of search paths.  */
-   std::string objfile_dir = ldirname (objfile_name (per_objfile->objfile));
-diff --git a/gdb/filesystem.c b/gdb/filesystem.c
-index f9aaeed7b406b28e0ac7125e9dab7d833fc948b2..f768d99413f936bbe409819c6d1653b69f2ac0e3 100644
---- a/gdb/filesystem.c
-+++ b/gdb/filesystem.c
-@@ -22,40 +22,46 @@
- #include "gdbarch.h"
- #include "gdbcmd.h"
- 
- const char file_system_kind_auto[] = "auto";
- const char file_system_kind_unix[] = "unix";
- const char file_system_kind_dos_based[] = "dos-based";
-+const char file_system_kind_amigaos_based[] = "amiga-based";
- const char *const target_file_system_kinds[] =
- {
-   file_system_kind_auto,
-   file_system_kind_unix,
-   file_system_kind_dos_based,
-+  file_system_kind_amigaos_based,
-   NULL
- };
- const char *target_file_system_kind = file_system_kind_auto;
- 
- const char *
- effective_target_file_system_kind (void)
- {
-   if (target_file_system_kind == file_system_kind_auto)
-     {
-       if (gdbarch_has_dos_based_file_system (target_gdbarch ()))
- 	return file_system_kind_dos_based;
-+	  else if (gdbarch_has_amiga_based_file_system (target_gdbarch ()))
-+	return file_system_kind_amigaos_based;
-       else
- 	return file_system_kind_unix;
-     }
-   else
-     return target_file_system_kind;
- }
- 
- const char *
- target_lbasename (const char *kind, const char *name)
- {
-   if (kind == file_system_kind_dos_based)
-     return dos_lbasename (name);
-+  else if (kind == file_system_kind_amigaos_based)
-+    return amiga_lbasename (name);
-   else
-     return unix_lbasename (name);
- }
- 
- static void
- show_target_file_system_kind_command (struct ui_file *file,
-@@ -89,13 +95,16 @@ Show assumed file system kind for target reported file names."),
- 			_("\
- If `unix', target file names (e.g., loaded shared library file names)\n\
- starting the forward slash (`/') character are considered absolute,\n\
- and the directory separator character is the forward slash (`/').  If\n\
- `dos-based', target file names starting with a drive letter followed\n\
- by a colon (e.g., `c:'), are also considered absolute, and the\n\
--backslash (`\\') is also considered a directory separator.  Set to\n\
-+backslash (`\\') is also considered a directory separator. If\n\
-+`amiga-based', target file names starting with a drive name followed\n\
-+by a colon (e.g., `sys:'), are also considered absolute, and the\n\
-+directory separator character is the forward slash (`/'). Set to\n\
- `auto' (which is the default), to let GDB decide, based on its\n\
- knowledge of the target operating system."),
- 			NULL, /* setfunc */
- 			show_target_file_system_kind_command,
- 			&setlist, &showlist);
- }
-diff --git a/gdb/filesystem.h b/gdb/filesystem.h
-index 2485f6b4e359a306dc38d9c28440f9be0219be94..7e2994b818312c12971e2321b95b25dbecfd964d 100644
---- a/gdb/filesystem.h
-+++ b/gdb/filesystem.h
-@@ -19,34 +19,38 @@
- #ifndef FILESYSTEM_H
- #define FILESYSTEM_H
- 
- extern const char file_system_kind_auto[];
- extern const char file_system_kind_unix[];
- extern const char file_system_kind_dos_based[];
-+extern const char file_system_kind_amigaos_based[];
- 
- extern const char *target_file_system_kind;
- 
- /* Same as IS_DIR_SEPARATOR but with file system kind KIND's
-    semantics, instead of host semantics.  */
- 
- #define IS_TARGET_DIR_SEPARATOR(kind, c)				\
-   (((kind) == file_system_kind_dos_based) ? IS_DOS_DIR_SEPARATOR (c) \
-+   : ((kind) == file_system_kind_amigaos_based) ? IS_AMIGOS_DIR_SEPARATOR(c) \
-    : IS_UNIX_DIR_SEPARATOR (c))
- 
- /* Same as IS_ABSOLUTE_PATH but with file system kind KIND's
-    semantics, instead of host semantics.  */
- 
- #define IS_TARGET_ABSOLUTE_PATH(kind, p)				\
-   (((kind) == file_system_kind_dos_based) ? IS_DOS_ABSOLUTE_PATH (p) \
-+   : ((kind) == file_system_kind_amigaos_based) ? IS_AMIGOS_ABSOLUTE_PATH(p) \
-    : IS_UNIX_ABSOLUTE_PATH (p))
- 
- /* Same as HAS_DRIVE_SPEC but with file system kind KIND's semantics,
-    instead of host semantics.  */
- 
- #define HAS_TARGET_DRIVE_SPEC(kind, p)					\
-   (((kind) == file_system_kind_dos_based) ? HAS_DOS_DRIVE_SPEC (p) \
-+   : ((kind) == file_system_kind_amigaos_based) ? HAS_AMIGOS_DRIVE_SPEC(p) \
-    : 0)
- 
- /* Same as lbasename, but with file system kind KIND's semantics,
-    instead of host semantics.  */
- extern const char *target_lbasename (const char *kind, const char *name);
- 
-diff --git a/gdb/gdbarch-gen.h b/gdb/gdbarch-gen.h
-index 5918de517ef29f74c2685431f2c1c2ed59614f59..fdcccd706869fff3b9b94f28688704219ba39f76 100644
---- a/gdb/gdbarch-gen.h
-+++ b/gdb/gdbarch-gen.h
-@@ -1482,12 +1482,19 @@ extern void set_gdbarch_solib_symbols_extension (struct gdbarch *gdbarch, const
-    is, absolute paths include a drive name, and the backslash is
-    considered a directory separator. */
- 
- extern int gdbarch_has_dos_based_file_system (struct gdbarch *gdbarch);
- extern void set_gdbarch_has_dos_based_file_system (struct gdbarch *gdbarch, int has_dos_based_file_system);
- 
-+/* If true, the target OS has AMIGA-based file system semantics.  That
-+   is, absolute paths include a drive name, and the slash is
-+   considered a directory separator. */
-+
-+extern int gdbarch_has_amiga_based_file_system (struct gdbarch *gdbarch);
-+extern void set_gdbarch_has_amiga_based_file_system (struct gdbarch *gdbarch, int has_dos_based_file_system);
-+
- /* Generate bytecodes to collect the return address in a frame.
-    Since the bytecodes run on the target, possibly with GDB not even
-    connected, the full unwinding machinery is not available, and
-    typically this function will issue bytecodes for one or more likely
-    places that the return address may be found. */
- 
-diff --git a/gdb/gdbarch.c b/gdb/gdbarch.c
-index 2d4b1164e2051143efc455c044443f20f527883b..9dffb4931c458f3d3b05771ac017d151bef9e43c 100644
---- a/gdb/gdbarch.c
-+++ b/gdb/gdbarch.c
-@@ -229,12 +229,13 @@ struct gdbarch
-   gdbarch_fast_tracepoint_valid_at_ftype *fast_tracepoint_valid_at = default_fast_tracepoint_valid_at;
-   gdbarch_guess_tracepoint_registers_ftype *guess_tracepoint_registers = default_guess_tracepoint_registers;
-   gdbarch_auto_charset_ftype *auto_charset = default_auto_charset;
-   gdbarch_auto_wide_charset_ftype *auto_wide_charset = default_auto_wide_charset;
-   const char * solib_symbols_extension = 0;
-   int has_dos_based_file_system = 0;
-+  int has_amiga_based_file_system = 0;
-   gdbarch_gen_return_address_ftype *gen_return_address = default_gen_return_address;
-   gdbarch_info_proc_ftype *info_proc = nullptr;
-   gdbarch_core_info_proc_ftype *core_info_proc = nullptr;
-   gdbarch_iterate_over_objfiles_in_search_order_ftype *iterate_over_objfiles_in_search_order = default_iterate_over_objfiles_in_search_order;
-   struct ravenscar_arch_ops * ravenscar_ops = NULL;
-   gdbarch_insn_is_call_ftype *insn_is_call = default_insn_is_call;
-@@ -1271,12 +1272,15 @@ gdbarch_dump (struct gdbarch *gdbarch, struct ui_file *file)
-   gdb_printf (file,
- 	      "gdbarch_dump: solib_symbols_extension = %s\n",
- 	      pstring (gdbarch->solib_symbols_extension));
-   gdb_printf (file,
- 	      "gdbarch_dump: has_dos_based_file_system = %s\n",
- 	      plongest (gdbarch->has_dos_based_file_system));
-+  gdb_printf (file,
-+	      "gdbarch_dump: has_amiga_based_file_system = %s\n",
-+	      plongest (gdbarch->has_amiga_based_file_system));
-   gdb_printf (file,
- 	      "gdbarch_dump: gen_return_address = <%s>\n",
- 	      host_address_to_string (gdbarch->gen_return_address));
-   gdb_printf (file,
- 	      "gdbarch_dump: gdbarch_info_proc_p() = %d\n",
- 	      gdbarch_info_proc_p (gdbarch));
-@@ -4898,12 +4902,34 @@ gdbarch_has_dos_based_file_system (struct gdbarch *gdbarch)
- 
- void
- set_gdbarch_has_dos_based_file_system (struct gdbarch *gdbarch,
- 				       int has_dos_based_file_system)
- {
-   gdbarch->has_dos_based_file_system = has_dos_based_file_system;
-+
-+  if( has_dos_based_file_system )
-+	set_gdbarch_has_amiga_based_file_system( gdbarch,0 );
-+}
-+
-+int gdbarch_has_amiga_based_file_system (struct gdbarch *gdbarch)
-+{
-+  gdb_assert (gdbarch != NULL);
-+  /* Skip verify of has_amiga_based_file_system, invalid_p == 0 */
-+  if (gdbarch_debug >= 2)
-+    gdb_printf (gdb_stdlog, "gdbarch_has_amiga_based_file_system called\n");
-+  return gdbarch->has_amiga_based_file_system;
-+}
-+
-+void
-+set_gdbarch_has_amiga_based_file_system (struct gdbarch *gdbarch,
-+				       int has_amiga_based_file_system)
-+{
-+  gdbarch->has_amiga_based_file_system = has_amiga_based_file_system;
-+
-+  if( has_amiga_based_file_system )
-+	set_gdbarch_has_dos_based_file_system( gdbarch,0 );
- }
- 
- void
- gdbarch_gen_return_address (struct gdbarch *gdbarch, struct agent_expr *ax, struct axs_value *value, CORE_ADDR scope)
- {
-   gdb_assert (gdbarch != NULL);
-diff --git a/gdb/osabi.c b/gdb/osabi.c
-index 57e2df6b25c1b515b9a5b28ed67670203016136e..2eb227d2fc15f2669167f84f646c861115f44540 100644
---- a/gdb/osabi.c
-+++ b/gdb/osabi.c
-@@ -79,12 +79,13 @@ static const struct osabi_names gdb_osabi_names[] =
-   { "Darwin", NULL },
-   { "OpenVMS", NULL },
-   { "LynxOS178", NULL },
-   { "Newlib", NULL },
-   { "SDE", NULL },
-   { "PikeOS", NULL },
-+  { "AmigaOS", NULL },
- 
-   { "<invalid>", NULL }
- };
- 
- const char *
- gdbarch_osabi_name (enum gdb_osabi osabi)
-@@ -608,12 +609,32 @@ generic_elf_osabi_sniffer (bfd *abfd)
- 	 header to "brand" their ELF binaries in FreeBSD 3.x.  */
-       if (memcmp (&elf_elfheader (abfd)->e_ident[8],
- 		  "FreeBSD", sizeof ("FreeBSD")) == 0)
- 	osabi = GDB_OSABI_FREEBSD;
-     }
- 
-+  if (osabi == GDB_OSABI_UNKNOWN)
-+	{
-+	  /* AmigaOS has a symbol __amigaos4__ which marks the ELF */
-+	  if (bfd_get_symtab_upper_bound (abfd) > 0 )
-+	  {
-+		asymbol **symbol_table = (asymbol **)xmalloc (bfd_get_symtab_upper_bound (abfd));
-+		if (symbol_table)
-+		{
-+		  for (int i = 0; i < bfd_canonicalize_symtab(abfd, symbol_table); i++) {
-+        	if (strcmp("__amigaos4__", bfd_asymbol_name(symbol_table[i])) == 0) {
-+              osabi = GDB_OSABI_AMIGAOS;
-+              break;
-+			}
-+          }
-+		  
-+		  xfree (symbol_table);
-+		}
-+	  }
-+	}
-+
-   return osabi;
- }
- 
- static void
- set_osabi (const char *args, int from_tty, struct cmd_list_element *c)
- {
-diff --git a/gdb/osabi.h b/gdb/osabi.h
-index 478a418aac235b30e29093e399b82fdabcacdc56..58750743b3942402f4d6997d9e24e733ef26c5db 100644
---- a/gdb/osabi.h
-+++ b/gdb/osabi.h
-@@ -43,12 +43,13 @@ enum gdb_osabi
-   GDB_OSABI_DARWIN,
-   GDB_OSABI_OPENVMS,
-   GDB_OSABI_LYNXOS178,
-   GDB_OSABI_NEWLIB,
-   GDB_OSABI_SDE,
-   GDB_OSABI_PIKEOS,
-+  GDB_OSABI_AMIGAOS,
- 
-   GDB_OSABI_INVALID		/* keep this last */
- };
- 
- /* Register an OS ABI sniffer.  Each arch/flavour may have more than
-    one sniffer.  This is used to e.g. differentiate one OS's a.out from
-diff --git a/gdb/ppc-amigaos-nat.c b/gdb/ppc-amigaos-nat.c
-new file mode 100644
-index 0000000000000000000000000000000000000000..576cc0ee91d485ac3cd1e3e9a47f8e2b058f8598
---- /dev/null
-+++ b/gdb/ppc-amigaos-nat.c
-@@ -0,0 +1,1122 @@
-+
-+/* Native-dependent code for PowerPC's running AmigaOS, for GDB.
-+   Copyright (C) 2013-2024 Free Software Foundation, Inc.
-+
-+   This file is part of GDB.
-+
-+   This program is free software; you can redistribute it and/or modify
-+   it under the terms of the GNU General Public License as published by
-+   the Free Software Foundation; either version 3 of the License, or
-+   (at your option) any later version.
-+
-+   This program is distributed in the hope that it will be useful,
-+   but WITHOUT ANY WARRANTY; without even the implied warranty of
-+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+   GNU General Public License for more details.
-+
-+   You should have received a copy of the GNU General Public License
-+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
-+
-+#include "ppc-amigaos-nat.h"
-+#include "defs.h"
-+#include "gdbcore.h"
-+#include "objfiles.h"
-+#include "symtab.h"
-+#include "exec.h"
-+#include "inferior.h"
-+#include "regset.h"
-+#include "regcache.h"
-+#include "inf-child.h"
-+#include "ppc-tdep.h"
-+#include "gdbsupport/ptid.h"
-+#include "gdbsupport/gdb_wait.h"
-+
-+#include <proto/dos.h>
-+#include <proto/exec.h>
-+#include <proto/elf.h>
-+
-+#include <exec/exec.h>
-+#include <exec/execbase.h>
-+#include <exec/exectags.h>
-+#include <exec/tasks.h>
-+#include <exec/interrupts.h>
-+
-+#include <dos/dos.h>
-+#include <dos/dostags.h>
-+#include <dos/dosextens.h>
-+
-+
-+struct regcache_map_entry ppc_amigaos_vrregmap[] =
-+{
-+	{ 1,	PPC_VSCR_REGNUM,	16 },
-+	{ 32,	PPC_VR0_REGNUM,		16 },
-+	{ 1,	PPC_VRSAVE_REGNUM,	 4 },
-+	{ 0 }
-+};
-+
-+const struct regset ppc_amigaos_vrregset = 
-+{
-+	ppc_amigaos_vrregmap,
-+	regcache_supply_regset,
-+	regcache_collect_regset
-+};
-+
-+// From clib4 , bucket list to clear up 
-+extern struct Library *ElfBase;
-+extern struct ElfIFace *IElf;
-+
-+struct DebugIFace *IDebug = NULL;
-+struct MMUIFace *IMMU = NULL;
-+
-+struct amigaos_debug_hook_data
-+{
-+    struct Process		*current_process;
-+    struct Task			*debugger_task;
-+    struct MsgPort		*debugger_port;
-+};
-+
-+/* The type of Message sent by IDebug->AddDebugHook () */
-+struct KernelDebugMessage
-+{
-+  uint32 type;
-+  union
-+  {
-+    struct ExceptionContext *context;
-+    struct Library *library;
-+  } message;
-+};
-+
-+static VOID amigaos_debug_suspend ( struct Hook *amigaos_debug_hook );
-+static VOID amigaos_debug_kill ( int32 return_code,struct debugger_message *dmsg );
-+static ULONG amigaos_debug_callback (struct Hook *, struct Task *, struct KernelDebugMessage *);
-+static int trap_to_signal(struct ExceptionContext *context, uint32 flags);
-+void ppc_amigaos_relocate_sections (const char *exec_file,BPTR exec_seglist);
-+
-+#define MAX_DEBUG_MESSAGES 20
-+
-+class ppc_amigaos_nat_target : public inf_child_target
-+{
-+private:
-+
-+	struct Hook *					amigaos_debug_hook;
-+	void *							amigaos_debug_messages_storage = 0;
-+	struct List	*					amigaos_debug_messages_list;
-+
-+public:
-+
-+	struct amigaos_debug_hook_data	amigaos_debug_hook_data;
-+
-+	/**
-+	 * Get an empty message and initialize it.
-+	 * @return
-+	 */
-+	struct debugger_message *
-+	alloc_message ( struct Process *process )
-+	{
-+		struct debugger_message *message = (struct debugger_message *)IExec->RemHead(amigaos_debug_messages_list);
-+
-+		message->msg.mn_Node.ln_Type = NT_MESSAGE;
-+		message->msg.mn_Node.ln_Name = NULL;
-+		message->msg.mn_ReplyPort = NULL;
-+		message->msg.mn_Length = sizeof(struct debugger_message);
-+		message->process = process;
-+
-+		return message;
-+	}
-+
-+	/**
-+	 * Return a message to the pool. Note that we disable here so that we're not
-+	 * interrupted. Can't use semaphores because get_msg_packet is called during an
-+	 * exception.
-+	 *
-+	 * @param msg
-+	 */
-+	void
-+	free_message( struct debugger_message *message )
-+	{
-+		if (message)
-+		{
-+			IExec->AddTail(amigaos_debug_messages_list, (struct Node *)message);
-+		}
-+	}
-+	
-+	ppc_amigaos_nat_target ();
-+	~ppc_amigaos_nat_target () override;
-+	
-+	ptid_t wait (ptid_t, struct target_waitstatus *, target_wait_flags) override;
-+
-+	void fetch_registers (struct regcache *, int) override;	
-+	void store_registers (struct regcache *, int) override;
-+
-+    enum target_xfer_status xfer_partial (enum target_object object,const char *annex,gdb_byte *readbuf,const gdb_byte *writebuf,ULONGEST offset, ULONGEST len,ULONGEST *xfered_len) override;
-+
-+	void attach (const char *, int) override;
-+
-+	bool attach_no_wait () override
-+	{
-+		return true;
-+	}
-+
-+	/*
-+	void post_attach (int pid) override
-+	{
-+		printf( "[GDB] %s (pid: %d)\n",__func__,pid );
-+	}
-+	
-+	void detach (inferior *inf, int from_tty) override
-+	{
-+		printf( "[GDB] %s ( inferior: %p, from_tty: %d )\n",__func__,inf,from_tty );
-+	}
-+	*/
-+
-+	void create_inferior (const char *, const std::string &,char **, int) override;
-+
-+	/*
-+	void mourn_inferior() override
-+	{
-+		printf( "[GDB] %s ()\n",__func__ );
-+	}
-+	*/
-+	
-+	// TODO: ? void prepare_to_store (regcache *regs) override;
-+	// TODO: ? int async_wait_fd () override
-+	
-+	void resume (ptid_t ptid,int step,enum gdb_signal signal) override
-+	{
-+		struct Task *task = (struct Task *)(ptid == minus_one_ptid ? inferior_ptid.pid () : ptid.pid ());
-+		
-+		IExec->DebugPrintF("[GDB] %s ( step: %d, gdb_signal: %d, Task: %p  )\n",__func__,step,signal,task);
-+
-+		IExec->RestartTask (task,0);
-+	}
-+
-+	void kill () override
-+	{
-+		struct inferior *inf = current_inferior ();
-+
-+		if (inferior_ptid == null_ptid)
-+			return;
-+
-+		gdb_assert (inf != NULL);
-+
-+		struct Task *task = (struct Task *)inf->pid;
-+
-+		IExec->DebugPrintF( "[GDB] %s ( task: %p )\n",__func__,task );
-+
-+		if( task ) 
-+		{
-+			/* Clear the debug hook (necessary to avoid the shell reusing it) */ 
-+			IDebug->AddDebugHook ( task,NULL );
-+
-+			// ML: According to the dos Autodoc DeleteTask/RemTask shouldn't be used on Process, but no other API avaiblle
-+			IExec->DeleteTask ( task );		
-+		}
-+
-+		target_mourn_inferior(inferior_ptid);		
-+	}
-+	
-+	/*
-+	std::string pid_to_str (ptid_t ptid) override
-+	{
-+		IExec->DebugPrintF ("[GDB] %s Entering\n",__func__);
-+		
-+		/ *
-+		if( ptid != minus_one_ptid )
-+		{
-+			struct Task *task = (struct Task *)ptid.pid();
-+
-+			IExec->Forbid();
-+			// ML: Should actually check that Task address is still a valid Task!?
-+			std::string str = string_printf (_("Task '%s' @ %s"), task->tc_Node.ln_Name ,phex ((ULONGEST)task, sizeof (void *)));
-+			IExec->Permit();
-+
-+			return str;
-+		}
-+		* /
-+
-+	  return normal_pid_to_str (ptid);
-+	}
-+	*/
-+	
-+	// TODO: char *pid_to_exec_file (int pid) override;
-+	
-+	/*
-+	bool info_proc (const char *args, enum info_proc_what what) override 
-+	{
-+		IExec->DebugPrintF("[GDB] %s (false)\n",__func__);
-+		return false;
-+	}
-+	*/
-+};
-+
-+ppc_amigaos_nat_target::ppc_amigaos_nat_target ()
-+{
-+	ElfBase = IExec->OpenLibrary ("elf.library",0);
-+	if (!ElfBase)
-+	{
-+		error ("Can't open elf.library. How did you run *this* program ?\n");
-+	}
-+
-+	IElf = (struct ElfIFace *)IExec->GetInterface (ElfBase,"main",1,0);
-+	if (!IElf)
-+	{
-+		IExec->CloseLibrary (ElfBase);
-+
-+		ElfBase = NULL;
-+
-+		error ("Can't get elf.library::main\n");
-+	}
-+
-+	IMMU = (struct MMUIFace *)IExec->GetInterface ((struct Library *)SysBase,"mmu",1,0 );
-+	if (!IMMU)
-+	{
-+		IExec->DropInterface ((struct Interface *)IElf);
-+		IExec->CloseLibrary (ElfBase);
-+
-+		IElf = NULL;
-+		ElfBase = NULL;
-+
-+		error ("Can't get MMU access\n");
-+	}
-+
-+	IDebug = (struct DebugIFace *)IExec->GetInterface ((struct Library *)SysBase,"debug",1,0 );
-+	if (!IDebug)
-+	{
-+		IExec->DropInterface ((struct Interface *)IMMU);
-+		IExec->DropInterface ((struct Interface *)IElf);
-+		IExec->CloseLibrary (ElfBase);
-+
-+		IMMU = NULL;
-+		IElf = NULL;
-+		ElfBase = NULL;
-+
-+		error ("Can't find kernel's debugger interface\n");
-+	}
-+
-+	amigaos_debug_hook_data.debugger_port = (struct MsgPort *)IExec->AllocSysObjectTags (ASOT_PORT, ASOPORT_Name, "GDB", TAG_DONE);
-+	if (!amigaos_debug_hook_data.debugger_port)
-+	{
-+		IExec->DropInterface ((struct Interface *)IDebug);
-+		IExec->DropInterface ((struct Interface *)IMMU);
-+		IExec->DropInterface ((struct Interface *)IElf);
-+		IExec->CloseLibrary (ElfBase);
-+
-+		IDebug = NULL;
-+		IMMU = NULL;
-+		IElf = NULL;
-+		ElfBase = NULL;
-+
-+		error ("Can't allocate message port\n");
-+	}
-+
-+	amigaos_debug_hook_data.current_process	= 0;
-+	amigaos_debug_hook_data.debugger_task	= IExec->FindTask ( NULL );
-+
-+	amigaos_debug_hook = (struct Hook *)IExec->AllocSysObjectTags ( ASOT_HOOK, 
-+		ASOHOOK_Entry,	(HOOKFUNC)amigaos_debug_callback,
-+		ASOHOOK_Data,	(APTR)this,
-+		TAG_DONE);
-+	if (!amigaos_debug_hook)
-+	{
-+		IExec->FreeSysObject (ASOT_PORT,amigaos_debug_hook_data.debugger_port);
-+		IExec->DropInterface ((struct Interface *)IDebug);
-+		IExec->DropInterface ((struct Interface *)IMMU);
-+		IExec->DropInterface ((struct Interface *)IElf);
-+		IExec->CloseLibrary (ElfBase);
-+
-+		IDebug = NULL;
-+		IMMU = NULL;
-+		IElf = NULL;
-+		ElfBase = NULL;
-+
-+		error ("Can't allocate debugger hook\n");
-+	}
-+
-+	if (!(amigaos_debug_messages_storage = IExec->AllocVecTags (MAX_DEBUG_MESSAGES * sizeof(struct debugger_message), AVT_Type, MEMF_SHARED, TAG_DONE)))
-+	{
-+		IExec->FreeSysObject (ASOT_PORT,amigaos_debug_hook);
-+		IExec->FreeSysObject (ASOT_PORT,amigaos_debug_hook_data.debugger_port);
-+		IExec->DropInterface ((struct Interface *)IDebug);
-+		IExec->DropInterface ((struct Interface *)IMMU);
-+		IExec->DropInterface ((struct Interface *)IElf);
-+		IExec->CloseLibrary (ElfBase);
-+
-+		IDebug = NULL;
-+		IMMU = NULL;
-+		IElf = NULL;
-+		ElfBase = NULL;
-+	
-+	
-+		error ("Can't allocate memory for messages\n");
-+	}
-+
-+	amigaos_debug_messages_list = (struct List *)IExec->AllocSysObjectTags ( ASOT_LIST, TAG_DONE);
-+	if (!amigaos_debug_messages_list)
-+	{
-+		IExec->FreeVec(amigaos_debug_messages_storage);
-+		IExec->FreeSysObject (ASOT_PORT,amigaos_debug_hook);
-+		IExec->FreeSysObject (ASOT_PORT,amigaos_debug_hook_data.debugger_port);
-+		IExec->DropInterface ((struct Interface *)IDebug);
-+		IExec->DropInterface ((struct Interface *)IMMU);
-+		IExec->DropInterface ((struct Interface *)IElf);
-+		IExec->CloseLibrary (ElfBase);
-+
-+		IDebug = NULL;
-+		IMMU = NULL;
-+		IElf = NULL;
-+		ElfBase = NULL;
-+
-+		error ("Can't allocate list for debug message\n");
-+	}
-+
-+	struct debugger_message *msg = (struct debugger_message *)amigaos_debug_messages_storage;
-+	for (int i = 0; i < MAX_DEBUG_MESSAGES; i++)
-+	{
-+		IExec->AddHead( amigaos_debug_messages_list, (struct Node *)msg);
-+		msg++;
-+	}
-+}
-+
-+ppc_amigaos_nat_target::~ppc_amigaos_nat_target ()
-+{
-+	/* Free pending messages and port */
-+	while (struct debugger_message *message = (struct debugger_message *)IExec->GetMsg (amigaos_debug_hook_data.debugger_port))
-+		free_message (message);
-+
-+	if (amigaos_debug_messages_list)
-+	{
-+		IExec->FreeSysObject (ASOT_LIST,amigaos_debug_messages_list);
-+	}
-+
-+	if (amigaos_debug_messages_storage)
-+	{
-+		IExec->FreeVec(amigaos_debug_messages_storage);
-+	}
-+
-+	if (amigaos_debug_hook_data.debugger_port)
-+	{
-+		IExec->FreeSysObject (ASOT_PORT,amigaos_debug_hook_data.debugger_port);
-+	}
-+	amigaos_debug_hook_data.debugger_port = NULL;
-+
-+	if (amigaos_debug_hook)
-+	{
-+		IExec->FreeSysObject (ASOT_HOOK,amigaos_debug_hook);
-+	}
-+	amigaos_debug_hook = NULL;
-+
-+	if (IElf)
-+	{
-+		IExec->DropInterface ((struct Interface *)IElf);
-+	}
-+	IElf = NULL;
-+
-+	if (ElfBase)
-+	{
-+		IExec->CloseLibrary (ElfBase);
-+	}
-+	ElfBase = NULL;
-+
-+	if (IMMU)
-+	{
-+		IExec->DropInterface ((struct Interface *)IMMU);
-+	}
-+	IMMU = NULL;
-+
-+	if (IDebug)
-+	{
-+		IExec->DropInterface ((struct Interface *)IDebug);
-+	}
-+	IDebug = NULL;
-+}
-+
-+ptid_t
-+ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,target_wait_flags options)
-+{
-+	struct Process *process = (ptid == minus_one_ptid ? amigaos_debug_hook_data.current_process : (struct Process *)ptid.pid());
-+
-+	if( ptid == minus_one_ptid )
-+		ptid = ptid_t ((int)amigaos_debug_hook_data.current_process);
-+
-+	while( 1 )
-+	{
-+		IExec->DebugPrintF("[GDB] %s Entering wait loop\n",__func__);
-+
-+		uint32 signal = IExec->Wait (SIGBREAKF_CTRL_D|SIGBREAKF_CTRL_C|1<<amigaos_debug_hook_data.debugger_port->mp_SigBit);
-+
-+		if( ( signal & SIGBREAKF_CTRL_D ) == SIGBREAKF_CTRL_D )
-+		{
-+			IExec->DebugPrintF("[GDB] %s received SIGBREAKF_CTRL_D\n",__func__);
-+
-+			ourstatus->set_exited (0);
-+
-+			IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
-+
-+			return ptid;
-+		}
-+
-+		if( ( signal & SIGBREAKF_CTRL_C ) == SIGBREAKF_CTRL_C )
-+		{
-+			IExec->DebugPrintF("[GDB] %s received SIGBREAKF_CTRL_C\n",__func__);
-+
-+			IExec->SuspendTask ((struct Task *)process,0);
-+
-+			ourstatus->set_stopped (GDB_SIGNAL_TRAP);
-+
-+			IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
-+
-+			return ptid;
-+		}
-+
-+		while (struct Message *message = IExec->GetMsg (amigaos_debug_hook_data.debugger_port) ) 		
-+		{
-+			IExec->DebugPrintF("[GDB] %s received message: %p\n",__func__,message );
-+
-+			struct debugger_message *debuggerMessage = (struct debugger_message *)message;
-+
-+			IExec->DebugPrintF("[GDB] %s received debug message for task: %p\n",__func__,debuggerMessage->process );
-+
-+			if( debuggerMessage->signal == -1 )
-+			{
-+				switch( debuggerMessage->flags )
-+				{
-+					case DM_FLAGS_TASK_OPENLIB:
-+					{
-+						IExec->DebugPrintF("[GDB] %s received task open library\n",__func__);
-+
-+						break;
-+					}
-+					case DM_FLAGS_TASK_CLOSELIB:
-+					{
-+						IExec->DebugPrintF("[GDB] %s received task close library\n",__func__);
-+
-+						break;
-+					}
-+					case DM_FLAGS_TASK_TERMINATED:
-+					{
-+						IExec->DebugPrintF("[GDB] %s received task terminated\n",__func__);
-+
-+						if( process == debuggerMessage->process) 
-+						{
-+							ourstatus->set_exited (0);
-+
-+							kill();
-+						}
-+
-+						break;
-+					}
-+					case DM_FLAGS_TASK_FINAL:
-+					{
-+						IExec->DebugPrintF("[GDB] %s received SIGB_CHILD of Process %p with dos return: %ld\n",__func__,debuggerMessage->process,debuggerMessage->ReturnCode);
-+
-+						if( debuggerMessage->process == process ) {
-+							ourstatus->set_exited (debuggerMessage->ReturnCode);
-+
-+							kill();
-+
-+							IDOS->UnLoadSeg( (BPTR)debuggerMessage->seglist );
-+
-+							free_message (debuggerMessage);
-+
-+							IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
-+
-+							return ptid;
-+						}
-+						else
-+						{
-+							IExec->DebugPrintF("[GDB] Process %p already killed\n",__func__,__LINE__,debuggerMessage->process );
-+						}
-+
-+						break;
-+					}
-+					default:
-+					{
-+						IExec->DebugPrintF("[GDB] %s received unknown flags for signal -1 from callback %ld\n",__func__,debuggerMessage->flags);
-+	
-+						break;
-+					}
-+				}
-+
-+				free_message (debuggerMessage);
-+			}
-+			else
-+			{
-+				IExec->DebugPrintF("[GDB] %s Inferior (%p) signaled : '%s'\n",__func__,process,gdb_signal_to_name ((enum gdb_signal)debuggerMessage->signal));
-+
-+				switch (debuggerMessage->signal)
-+				{
-+					case GDB_SIGNAL_CHLD:
-+					{
-+						ourstatus->set_signalled (GDB_SIGNAL_0);
-+
-+						break;
-+					}
-+					case GDB_SIGNAL_QUIT:
-+					{
-+						ourstatus->set_signalled (GDB_SIGNAL_QUIT);
-+
-+						break;
-+					}
-+					case GDB_SIGNAL_TRAP:
-+					{
-+						ourstatus->set_stopped (GDB_SIGNAL_TRAP);
-+
-+						break;
-+					}
-+					case GDB_SIGNAL_SEGV:
-+					case GDB_SIGNAL_BUS:
-+					case GDB_SIGNAL_INT:
-+					case GDB_SIGNAL_FPE:
-+					case GDB_SIGNAL_ILL:
-+					case GDB_SIGNAL_ALRM:					
-+					{					
-+						ourstatus->set_stopped (GDB_SIGNAL_0);
-+
-+						break;
-+					}
-+					default:
-+					{
-+						IExec->DebugPrintF("[GDB] %s received unknown signal from callback %ld\n",__func__,debuggerMessage->signal);
-+
-+						break;
-+					}
-+				}
-+
-+				free_message (debuggerMessage);
-+				
-+				IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
-+
-+				return ptid;
-+			}		
-+		}
-+	}
-+
-+	IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid_t::make_minus_one () );
-+
-+	return ptid_t::make_minus_one ();
-+}
-+
-+/* Fetch register REGNO from the inferior.  */
-+void 
-+ppc_amigaos_nat_target::fetch_registers (struct regcache *regcache, int regno) 
-+{
-+	struct gdbarch *gdbarch = regcache->arch ();
-+	ppc_gdbarch_tdep *tdep = gdbarch_tdep<ppc_gdbarch_tdep> (gdbarch);	
-+	struct Task *task = (struct Task *)regcache->ptid().pid();
-+
-+	IExec->DebugPrintF("[GDB] %s ( regcache: %p, regno: %d (%s), task: %p)\n",__func__,regcache,regno,gdbarch_register_name( gdbarch,regno ),task);
-+
-+	struct ExceptionContext context;
-+	IDebug->ReadTaskContext( task,&context,RTCF_INFO | RTCF_SPECIAL | RTCF_STATE | RTCF_GENERAL | RTCF_FPU | RTCF_VECTOR );
-+
-+	if( regno == -1 )
-+	{
-+		for (int i = 0; i < 31; i++)
-+			regcache->raw_supply (regno, (void*)&context.gpr[i]);
-+
-+		for (int i = 0; i < 31; i++)
-+			regcache->raw_supply (regno, (void*)&context.fpr[i]);
-+
-+		regcache->raw_supply (gdbarch_pc_regnum (gdbarch), (void *)&context.ip);
-+		regcache->raw_supply (tdep->ppc_ps_regnum, (void *)&context.msr);
-+		regcache->raw_supply (tdep->ppc_cr_regnum, (void *)&context.cr);
-+		regcache->raw_supply (tdep->ppc_lr_regnum, (void *)&context.lr);
-+		regcache->raw_supply (tdep->ppc_ctr_regnum, (void *)&context.ctr);
-+		regcache->raw_supply (tdep->ppc_xer_regnum, (void *)&context.xer);
-+		regcache->raw_supply (tdep->ppc_fpscr_regnum, (void *)&context.fpscr);			
-+
-+		if (tdep->ppc_vr0_regnum != -1 && tdep->ppc_vrsave_regnum != -1)
-+		{
-+			ppc_amigaos_vrregset.supply_regset( &ppc_amigaos_vrregset,regcache,regno,(void *)&context.vscr,PPC_AMIGAOS_SIZEOF_VRREGSET );
-+		}
-+	}
-+	else 
-+	{
-+		if (regno == gdbarch_pc_regnum (gdbarch) )
-+		{			
-+			regcache->raw_supply (regno, (void*)&context.ip);
-+		}
-+		else if (regno >= 0 && regno <= 31) 
-+		{
-+			regcache->raw_supply (regno, (void*)&context.gpr[regno]);
-+		}
-+		else if (altivec_register_p (gdbarch, regno))
-+		{
-+			ppc_amigaos_vrregset.supply_regset( &ppc_amigaos_vrregset,regcache,regno,(void *)&context.vscr,PPC_AMIGAOS_SIZEOF_VRREGSET );
-+		}
-+		else if (regno >= 32 && regno <= 64)
-+			regcache->raw_supply (regno, (void*)&context.fpr[regno]);
-+		else if (regno == tdep->ppc_ps_regnum)
-+			regcache->raw_supply (regno, (void *)&context.msr);
-+		else if (regno == tdep->ppc_cr_regnum)
-+			regcache->raw_supply (tdep->ppc_cr_regnum, (void *)&context.cr);
-+		else if (regno == tdep->ppc_lr_regnum)
-+			regcache->raw_supply (tdep->ppc_lr_regnum, (void *)&context.lr);
-+		else if (regno == tdep->ppc_ctr_regnum) 
-+			regcache->raw_supply (tdep->ppc_ctr_regnum, (void *)&context.ctr);
-+		else if (regno == tdep->ppc_xer_regnum)
-+			regcache->raw_supply (tdep->ppc_xer_regnum, (void *)&context.xer);
-+		else if (regno == tdep->ppc_fpscr_regnum)
-+			regcache->raw_supply (tdep->ppc_fpscr_regnum, (void *)&context.fpscr);		
-+		else if (regno == tdep->ppc_vr0_regnum)
-+			regcache->raw_supply (tdep->ppc_vr0_regnum, (void *)&context.vr );		
-+		else if (regno == tdep->ppc_vrsave_regnum)
-+			regcache->raw_supply (tdep->ppc_vrsave_regnum, (void *)&context.vrsave );		
-+		else
-+		{
-+			internal_error (_("fetch_registers: unexpected register: '%s'"),gdbarch_register_name ( gdbarch,regno ));
-+		}
-+	}
-+}
-+
-+void
-+ppc_amigaos_nat_target::store_registers (struct regcache *regcache, int regno)
-+{
-+	printf( "[GDB] %s Todo ( regcache: %p, regno: %d)\n",__func__,regcache,regno );
-+}
-+
-+enum target_xfer_status
-+ppc_amigaos_nat_target::xfer_partial (enum target_object object,const char *annex, gdb_byte *readbuf,const gdb_byte *writebuf,ULONGEST offset, ULONGEST len, ULONGEST *xfered_len)
-+{
-+	IExec->DebugPrintF ( string_printf (_("[GDB] %s called for memory tranfser at address: 0x%s for %s bytes (readbuf: %p, writebuf: %p, annex: '%s', object: %d )\n"),__func__,phex (offset, sizeof (offset)),pulongest (len), readbuf, writebuf, annex, object).c_str());
-+
-+	switch (object)
-+	{
-+		case TARGET_OBJECT_MEMORY:
-+		{
-+			if (offset == 0) 
-+			{
-+				// ML: Helps to unwind farme correctly
-+				return TARGET_XFER_E_IO;
-+			}
-+			else
-+			{
-+				APTR user_stack = IExec->SuperState();
-+
-+				ULONG currentAttrs = IMMU->GetMemoryAttrs( (APTR)offset,0 );
-+				IMMU->SetMemoryAttrs ( (APTR)offset,len,MEMATTRF_READ_WRITE );
-+
-+				if (readbuf) 
-+				{
-+					IExec->CopyMem( (APTR)offset,(APTR)readbuf,len );
-+				}
-+				else // if(writebuf)
-+				{
-+					IExec->CopyMem( (APTR)writebuf,(APTR)offset,len );
-+					IExec->CacheClearE( (APTR)offset,len,CACRF_ClearI );
-+				}
-+
-+				IMMU->SetMemoryAttrs( (APTR)offset,len,currentAttrs );
-+
-+				if (user_stack)
-+				{
-+					IExec->UserState( user_stack );
-+				}
-+			}
-+
-+			*xfered_len = len;
-+
-+			IExec->DebugPrintF ( string_printf (_("[GDB] %s tansferfed %s bytes\n"),__func__,pulongest (*xfered_len)).c_str());
-+
-+			return TARGET_XFER_OK;			
-+		}
-+		break;
-+
-+		case TARGET_OBJECT_LIBRARIES:
-+		{
-+			IExec->DebugPrintF("[GDB] %s tansferfed object library '%s' failed, aka not supported yet\n",__func__,annex);
-+
-+			return TARGET_XFER_E_IO;			
-+		}
-+		break;
-+
-+		default:
-+			if (beneath()) 
-+			{
-+				IExec->DebugPrintF("[GDB] %s tansferfed delegated to beneath for target_object %d\n",__func__,object);
-+
-+				return this->beneath ()->xfer_partial (object,annex,readbuf,writebuf,offset,len,xfered_len);
-+			}
-+			/* This can happen when requesting the transfer of unsupported
-+			 objects before a program has been started (and therefore
-+			 with the current_target having no target beneath).  */
-+	}
-+
-+	return TARGET_XFER_E_IO;
-+}
-+
-+void
-+ppc_amigaos_nat_target::attach (const char *args, int from_tty)
-+{
-+	printf( "[GDB] %s ( args: '%s', from_tty: %d )\n",__func__,args,from_tty );
-+}
-+
-+void
-+ppc_amigaos_relocate_sections (const char *exec_file,BPTR exec_seglist) 
-+{
-+	// To debug this stuff, enableing elf debug out with 'SetENV ELF.debug 1' helps alot on thr target
-+	Elf32_Handle exec_elfhandle = 0;
-+	if( 1 == IDOS->GetSegListInfoTags( exec_seglist,
-+		GSLI_ElfHandle,		&exec_elfhandle,
-+		TAG_DONE) )
-+	{
-+		Elf32_Handle exec_opendelf = IElf->OpenElfTags(
-+			OET_ElfHandle,			exec_elfhandle,
-+			OET_ReadOnlyCopy,		TRUE,
-+			TAG_DONE );
-+		if( exec_opendelf ) 
-+		{
-+			if( current_program_space->symfile_object_file ) 
-+			{
-+				struct objfile *symfile = current_program_space->symfile_object_file;
-+				section_offsets offsets (symfile->section_offsets.size () );
-+
-+				struct obj_section *osect;
-+				ALL_OBJFILE_OSECTIONS(symfile, osect)
-+				{
-+					struct bfd_section *section = osect->the_bfd_section;
-+					int osect_idx = osect - symfile->sections;
-+					
-+					void *address = IElf->GetSectionTags( exec_opendelf,
-+						GST_SectionName, section->name,
-+						TAG_DONE );
-+						
-+					if( address )
-+					{
-+						IExec->DebugPrintF ( string_printf (_("[GDB] On symfile_object relocated %d section '%s' from 0x%08lx to %p, size %ld, old offset: 0x%s\n"),section->index,section->name,section->vma,address,section->size,phex ( osect->addr(), sizeof (osect->addr()))).c_str());
-+						
-+						offsets[ osect_idx ] = (CORE_ADDR)address - osect->addr();
-+					}
-+				}
-+
-+				objfile_relocate(symfile, offsets);
-+			}
-+			else if( current_program_space->exec_bfd() )
-+			{
-+				/* Go through all GDB sections, and make sure they are loaded and relocated */
-+				for (asection *section : gdb_bfd_sections (current_program_space->exec_bfd ())) {
-+
-+					void *address = IElf->GetSectionTags( exec_opendelf,
-+						GST_SectionName, section->name,
-+						TAG_DONE );
-+								
-+					if( address )
-+					{
-+						printf ( "[GDB] On exec_bfd relocated %d section '%s' from %08lx to %p, size %ld\n",section->index,section->name,section->vma,address,section->size);
-+						
-+						exec_set_section_address( exec_file,section->index,(CORE_ADDR)address );							
-+					}
-+				}
-+			}
-+
-+			IElf->CloseElfTags( exec_opendelf,
-+				CET_FreeUnneeded,		TRUE,
-+				TAG_DONE );
-+		}
-+	}
-+}
-+
-+/* Start a new inferior AmigaOS DOS process.  EXEC_FILE is the file to
-+   run, ALLARGS is a string containing the arguments to the program.
-+   ENV is the environment vector to pass.  */
-+void ppc_amigaos_nat_target::create_inferior (const char *exec_file,const std::string &allargs,char **env, int from_tty)
-+{
-+	inferior *inf = current_inferior ();
-+	if( !inf )
-+	{
-+		error ("No current inferior present" );
-+	}
-+
-+	/* If no exec file handed to us, get it from the exec-file command -- with
-+	 a good, common error message if none is specified.  */
-+	if (exec_file == 0)
-+	{
-+	    exec_file = get_exec_file (1);
-+	}
-+
-+	struct debugger_message *dmsg = alloc_message( NULL );
-+	if( dmsg == NULL )
-+	{
-+		error ("Can't allocate memory for death message\n");
-+	}
-+
-+	dmsg->msg.mn_Node.ln_Name	= (char*)"DeathMessage";
-+	dmsg->msg.mn_ReplyPort		= amigaos_debug_hook_data.debugger_port;
-+	dmsg->flags					= DM_FLAGS_TASK_FINAL;
-+	dmsg->signal				= -1; 	
-+
-+	dmsg->seglist = (void*)IDOS->LoadSeg( exec_file );
-+	if( ! dmsg->seglist )
-+	{
-+		error ("'%s': not an executable file\n",exec_file );
-+	}
-+
-+	BPTR exec_home = ZERO;
-+	BPTR exec_lock = IDOS->Lock( exec_file,SHARED_LOCK );
-+	if( exec_lock )
-+	{
-+		exec_home = IDOS->ParentDir( exec_lock );
-+
-+		IDOS->UnLock( exec_lock );
-+	}
-+
-+	dmsg->process = amigaos_debug_hook_data.current_process = IDOS->CreateNewProcTags(
-+			NP_Seglist,										dmsg->seglist,
-+			NP_FreeSeglist,									FALSE,
-+			NP_EntryCode,									amigaos_debug_suspend,
-+			NP_EntryData,									amigaos_debug_hook,
-+			NP_Child,										TRUE,
-+			NP_FinalCode,									amigaos_debug_kill,
-+			NP_FinalData,									dmsg,
-+			NP_Name,										lbasename( exec_file ),
-+			NP_CommandName,									lbasename( exec_file ),
-+			NP_Cli,											TRUE,
-+			NP_Arguments,									allargs.c_str(),
-+			NP_Input,										IDOS->Input(),
-+			NP_CloseInput,									FALSE,
-+			NP_Output,										IDOS->Output(),
-+			NP_CloseOutput,									FALSE,
-+			NP_Error,										IDOS->ErrorOutput(),
-+			NP_CloseError,									FALSE,
-+			(exec_home ? NP_ProgramDir: TAG_IGNORE),		exec_home,
-+			TAG_DONE
-+		);
-+
-+	IExec->DebugPrintF ( "[GDB] Process %p has debug message %p\n",amigaos_debug_hook_data.current_process,dmsg );
-+
-+	if (! amigaos_debug_hook_data.current_process)
-+	{
-+		error ("Can't create AmigaOS DOS process\n");
-+	}
-+
-+	IDebug->AddDebugHook((struct Task *)amigaos_debug_hook_data.current_process,amigaos_debug_hook);
-+
-+	inferior_ptid = ptid_t ((int)amigaos_debug_hook_data.current_process);
-+	inferior_appeared (inf,(int)amigaos_debug_hook_data.current_process);
-+	/* We have something that executes now.  We'll be running through
-+	 the shell at this point (if startup-with-shell is true), but the
-+	 pid shouldn't change.  */
-+
-+	/* Do not change either targets above or the same target if already present.
-+	 The reason is the target stack is shared across multiple inferiors.  */
-+	inf->unpush_target(this);
-+	
-+	if(!inf->target_is_pushed(this))
-+		inf->push_target(this);
-+
-+	thread_info *thr = add_thread (this, inferior_ptid);
-+	switch_to_thread (thr);
-+
-+	clear_proceed_status (0);
-+	init_wait_for_inferior ();
-+
-+	ppc_amigaos_relocate_sections (exec_file,(BPTR)dmsg->seglist);
-+
-+	IExec->DebugPrintF("[GDB] %s inferior_ptid=0x%08x inf=%p thr=%p\n",__func__,inferior_ptid.pid(),inf,thr);
-+}
-+
-+static ppc_amigaos_nat_target the_ppc_amigaos_nat_target;
-+
-+void _initialize_ppcamigaos_nat ();
-+void
-+_initialize_ppcamigaos_nat ()
-+{
-+	add_inf_child_target (&the_ppc_amigaos_nat_target);
-+}
-+
-+VOID amigaos_debug_suspend( struct Hook *amigaos_debug_hook ) 
-+{
-+	struct Task *current = IExec->FindTask (NULL);
-+
-+	IExec->DebugPrintF("[GDB] %s inferiorer %p started by kernel, suspending myself and installing debug hook: %p\n",__func__,current,amigaos_debug_hook);
-+	
-+	IExec->SuspendTask (current,0);
-+
-+	IExec->DebugPrintF("[GDB] %s inferiorer %p started by gdb\n",__func__,current);
-+}
-+
-+VOID amigaos_debug_kill( int32 return_code,struct debugger_message *dmsg ) 
-+{
-+	struct Task *current = IExec->FindTask (NULL);
-+
-+	dmsg->ReturnCode = return_code;
-+
-+	IExec->DebugPrintF("[GDB] %s inferiorer %p killed by kernel, sending death message: %p\n",__func__,current,dmsg);
-+
-+	IExec->PutMsg( dmsg->msg.mn_ReplyPort,(struct Message *)dmsg );	
-+}
-+
-+ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct KernelDebugMessage *dbgmsg )
-+{
-+	class ppc_amigaos_nat_target *ppc_amigaos_nat_target = (class ppc_amigaos_nat_target *)hook->h_Data;
-+	struct amigaos_debug_hook_data *data = &(ppc_amigaos_nat_target->amigaos_debug_hook_data);
-+	
-+	if( (struct Task *)data->current_process != currentTask )
-+	{
-+		IExec->DebugPrintF ("[GDB] Task: %p ('%s'), task NOT under our observation\n",currentTask,currentTask->tc_Node.ln_Name);
-+
-+		return 0;
-+	}
-+	IExec->DebugPrintF ("[GDB] Task: %p ('%s'), task IS under our observation\n",currentTask,currentTask->tc_Node.ln_Name);
-+
-+
-+	switch( dbgmsg->type ) 
-+	{
-+		case DBHMT_EXCEPTION:
-+		{
-+			IExec->DebugPrintF ("[GDB] Task: %p ('%s'),Exception ooccured (DBHMT_EXCEPTION)\n",currentTask,currentTask->tc_Node.ln_Name);
-+
-+			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);
-+			message->flags	= 0;
-+			message->signal	= trap_to_signal( dbgmsg->message.context,message->flags );
-+			
-+			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
-+
-+			IExec->PutMsg (data->debugger_port,(struct Message *)message);
-+
-+			return 1; // Suspend execution
-+		}
-+		case DBHMT_ADDTASK:
-+		{
-+			IExec->DebugPrintF("[GDB] Task: %p ('%s'), (DBHMT_ADDTASK), Task added\n",currentTask,currentTask->tc_Node.ln_Name);
-+
-+			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);	
-+			message->flags	= DM_FLAGS_TASK_ATTACHED;
-+			message->signal	= -1;
-+			
-+			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
-+
-+			IExec->PutMsg (data->debugger_port,(struct Message *)message);
-+
-+			break;
-+		}
-+		case DBHMT_REMTASK:
-+		{
-+			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_REMTASK), Task removed\n",currentTask,currentTask->tc_Node.ln_Name);
-+
-+			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);
-+			message->flags	= DM_FLAGS_TASK_TERMINATED;
-+			message->signal	= -1;
-+			
-+			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
-+
-+			IExec->PutMsg (data->debugger_port,(struct Message *)message);
-+			
-+			break;
-+		}
-+		case DBHMT_OPENLIB:
-+		{
-+			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_OPENLIB), Task opened library '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
-+
-+			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);
-+			message->flags		= DM_FLAGS_TASK_OPENLIB;
-+			message->signal		= -1;
-+			message->library	= dbgmsg->message.library;
-+			
-+			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
-+
-+			IExec->PutMsg (data->debugger_port,(struct Message *)message);
-+
-+			break;
-+		}
-+		case DBHMT_CLOSELIB:
-+		{
-+			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_CLOSELIB), Task closed library '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
-+
-+			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);	
-+			message->flags		= DM_FLAGS_TASK_CLOSELIB;
-+			message->signal		= -1;
-+			message->library	= dbgmsg->message.library;
-+
-+			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
-+
-+			IExec->PutMsg (data->debugger_port,(struct Message *)message);
-+
-+			break;
-+		}
-+		case DBHMT_SHAREDOBJECTOPEN:
-+		{
-+			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_SHAREDOBJECTOPEN), Task opened shared object '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
-+			break;
-+		}
-+		case DBHMT_SHAREDOBJECTCLOSE:
-+		{
-+			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_SHAREDOBJECTCLOSE), Task closed shared object '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
-+			break;
-+		}
-+		default:
-+		{
-+			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_UNKNOWN), Task unknown message type %lu\n",currentTask,currentTask->tc_Node.ln_Name,dbgmsg->type);
-+		}
-+	}
-+
-+	return 0; // Resume execution
-+}
-+
-+static int
-+trap_to_signal(struct ExceptionContext *context, uint32 flags)
-+{
-+	IExec->DebugPrintF( "[GDB] trap_to_signal ( flags: 0x%lx )\n",flags );
-+
-+	if (!context || (flags & DM_FLAGS_TASK_TERMINATED)) {
-+		IExec->DebugPrintF( "[GDB] Return GDB_SIGNAL_QUIT )\n" );
-+	
-+		return GDB_SIGNAL_QUIT;
-+	}
-+
-+	IExec->DebugPrintF( "[GDB] traptype: 0x%lx\n",context->Traptype );
-+
-+	switch (context->Traptype)
-+	{
-+	case TRAP_MCE:
-+	case TRAP_DSI:
-+		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_SEGV )\n" );
-+		return GDB_SIGNAL_SEGV;
-+	case TRAP_ISI:
-+	case TRAP_ALIGN:
-+		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_BUS )\n" );
-+		return GDB_SIGNAL_BUS;
-+	case TRAP_EXTERN:
-+		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_INT )\n" );
-+		return GDB_SIGNAL_INT;
-+	case TRAP_PROG: 
-+		if (context->msr & EXC_FPE) {
-+			IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
-+			return GDB_SIGNAL_FPE;
-+		}
-+		else if (context->msr & EXC_ILLEGAL) {
-+			IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
-+			return GDB_SIGNAL_ILL;
-+		}
-+		else if (context->msr & EXC_PRIV) {
-+			IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
-+			return GDB_SIGNAL_ILL;
-+		}
-+		else {
-+			IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_TRAP )\n" );
-+			return GDB_SIGNAL_TRAP;
-+		}
-+	case TRAP_FPU:
-+		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
-+		return GDB_SIGNAL_FPE;
-+	case TRAP_DEC:
-+		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_ALRM )\n" );
-+		return GDB_SIGNAL_ALRM;
-+	case TRAP_RESERVEDA:
-+	case TRAP_RESERVEDB:
-+		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
-+		return GDB_SIGNAL_ILL;
-+	case TRAP_SYSCALL:
-+		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_CHLD )\n" );
-+		return GDB_SIGNAL_CHLD;
-+	case TRAP_TRACEI:
-+		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_TRAP )\n" );
-+		return GDB_SIGNAL_TRAP;
-+	case TRAP_FPA:
-+		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
-+		return GDB_SIGNAL_FPE;
-+	default:
-+		IExec->DebugPrintF( "[GDB] Return ( -1 )\n" );
-+		return -1;
-+	}
-+}
-\ No newline at end of file
-diff --git a/gdb/ppc-amigaos-nat.h b/gdb/ppc-amigaos-nat.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..e0796f44cf4df6efa7073500e13c7c180126b3c0
---- /dev/null
-+++ b/gdb/ppc-amigaos-nat.h
-@@ -0,0 +1,81 @@
-+/* Native-dependent code for PowerPC's running AmigaOS, for GDB.
-+
-+   Copyright (C) 2013-2024 Free Software Foundation, Inc.
-+
-+   This file is part of GDB.
-+
-+   This program is free software; you can redistribute it and/or modify
-+   it under the terms of the GNU General Public License as published by
-+   the Free Software Foundation; either version 3 of the License, or
-+   (at your option) any later version.
-+
-+   This program is distributed in the hope that it will be useful,
-+   but WITHOUT ANY WARRANTY; without even the implied warranty of
-+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+   GNU General Public License for more details.
-+
-+   You should have received a copy of the GNU General Public License
-+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
-+
-+#ifndef PPC_AMIGAOS_NAT_H
-+#define PPC_AMIGAOS_NAT_H
-+
-+#include <exec/ports.h>
-+
-+#define PPC_AMIGAOS_SIZEOF_VRREGSET 532
-+
-+// Chapter Interrupt Reference union from different ppc32 cpus
-+#define TRAP_RESET 			0x0100 /* System reset */
-+#define TRAP_MCE   			0x0200 /* Machine check */
-+#define TRAP_DSI    		0x0300 /* Data storage */
-+#define TRAP_DSEGI   		0x0380 /* Data segment (Book III v2.01) */
-+#define TRAP_ISI     		0x0400 /* Instruction storage */
-+#define TRAP_ISEGI   		0x0480 /* Instruction segment (Book III v2.01)*/
-+#define TRAP_EXTERN   		0x0500 /* External Interrupt */
-+#define TRAP_ALIGN   		0x0600 /* Alignment */
-+#define TRAP_PROG    		0x0700 /* Program */
-+#define TRAP_FPU			0x0800 /* FPU Disabled */
-+#define TRAP_DEC			0x0900 /* Decrementer */
-+#define TRAP_RESERVEDA		0x0a00 /* Reserved (Book III v2.01)*/
-+#define TRAP_RESERVEDB		0x0b00 /* Reserved (Book III v2.01)*/
-+#define TRAP_SYSCALL		0x0c00 /* System call */
-+#define TRAP_TRACEI			0x0d00 /* Trace */
-+#define TRAP_FPA			0x0e00 /* Floating-point Assist */
-+#define TRAP_PMI     		0x0f00 /* Performance monitor (Book III v2.01)*/
-+#define TRAP_APU			0x0f20 /* APU Unavailble */
-+#define TRAP_PIT			0x1000 /* Programmable-interval timer (PIT) */
-+#define TRAP_FIT			0x1010 /* Fixed-interval timer (FIT) */
-+#define TRAP_WATCHDOG		0x1020 /* Watch Dog */
-+#define TRAP_DTBL			0x1100 /* Data TBL error */
-+#define TRAP_ITBL			0x1200 /* Instruction TBL error */
-+#define TRAP_DEBUG			0x2000 /* Debug */
-+
-+/* MSR Bits */
-+#define    MSR_TRACE_ENABLE           0x00000400
-+#define    EXC_FPE                    0x00100000
-+#define    EXC_ILLEGAL                0x00080000
-+#define    EXC_PRIV                   0x00040000
-+#define    EXC_TRAP                   0x00020000
-+
-+/* Message sent from debugger hook to debugger to alert debugger
-+   of an event that happened */
-+struct debugger_message
-+{
-+	struct Message msg;
-+	struct Process *process;
-+	uint32 flags;
-+	uint32 signal;
-+	struct Library *library;
-+	void* seglist;
-+	int32 ReturnCode;
-+};
-+
-+/* Possible debuger_message flags */
-+#define    DM_FLAGS_TASK_TERMINATED				0x00000001
-+#define    DM_FLAGS_TASK_ATTACHED				0x00000002
-+#define    DM_FLAGS_TASK_INTERRUPTED			0x00000004
-+#define	   DM_FLAGS_TASK_OPENLIB				0x00000008
-+#define	   DM_FLAGS_TASK_CLOSELIB				0x00000010
-+#define    DM_FLAGS_TASK_FINAL					0x10000000
-+
-+#endif /* PPC_AMIGAOS_NAT_H */
-diff --git a/gdb/ppc-amigaos-tdep.c b/gdb/ppc-amigaos-tdep.c
-new file mode 100644
-index 0000000000000000000000000000000000000000..4dba12da78e14abca777e8d2e4d4bc9a933d0b38
---- /dev/null
-+++ b/gdb/ppc-amigaos-tdep.c
-@@ -0,0 +1,153 @@
-+/* Target-dependent code for GDB, the GNU debugger.
-+
-+   Copyright (C) 1986-2024 Free Software Foundation, Inc.
-+
-+   This file is part of GDB.
-+
-+   This program is free software; you can redistribute it and/or modify
-+   it under the terms of the GNU General Public License as published by
-+   the Free Software Foundation; either version 3 of the License, or
-+   (at your option) any later version.
-+
-+   This program is distributed in the hope that it will be useful,
-+   but WITHOUT ANY WARRANTY; without even the implied warranty of
-+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+   GNU General Public License for more details.
-+
-+   You should have received a copy of the GNU General Public License
-+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
-+
-+#include "defs.h"
-+#include "gdbcore.h"
-+#include "gdbarch.h"
-+#include "ppc-tdep.h"
-+
-+static int
-+ppc_amigaos_has_shared_address_space (struct gdbarch *gdbarch)
-+{
-+	return true;
-+}
-+
-+/* 1 to 1 copy from rs6000aix-tdp.c branch_dest , 
-+except removed AIX_TEXT_SEGMENT_BASE checks, 
-+removed byte_order */
-+static CORE_ADDR
-+branch_dest (struct regcache *regcache, int opcode, int instr,
-+	     CORE_ADDR pc, CORE_ADDR safety)
-+{
-+  struct gdbarch *gdbarch = regcache->arch ();
-+  ppc_gdbarch_tdep *tdep = gdbarch_tdep<ppc_gdbarch_tdep> (gdbarch);
-+  CORE_ADDR dest;
-+  int immediate;
-+  int absolute;
-+  int ext_op;
-+
-+  absolute = (int) ((instr >> 1) & 1);
-+
-+  switch (opcode)
-+    {
-+    case 18:
-+      immediate = ((instr & ~3) << 6) >> 6;	/* br unconditional */
-+      if (absolute)
-+	dest = immediate;
-+      else
-+	dest = pc + immediate;
-+      break;
-+
-+    case 16:
-+      immediate = ((instr & ~3) << 16) >> 16;	/* br conditional */
-+      if (absolute)
-+	dest = immediate;
-+      else
-+	dest = pc + immediate;
-+      break;
-+
-+    case 19:
-+      ext_op = (instr >> 1) & 0x3ff;
-+
-+      if (ext_op == 16)		/* br conditional register */
-+	  dest = regcache_raw_get_unsigned (regcache, tdep->ppc_lr_regnum) & ~3;
-+      else if (ext_op == 528)	/* br cond to count reg */
-+	  dest = regcache_raw_get_unsigned (regcache,
-+					    tdep->ppc_ctr_regnum) & ~3;
-+      else
-+	return -1;
-+      break;
-+
-+    default:
-+      return -1;
-+    }
-+  return dest;
-+}
-+
-+/* 1 to 1 copy from rs6000aix-tdp.c rs6000_software_single_step */
-+static std::vector<CORE_ADDR>
-+ppc_amigaos_software_single_step (struct regcache *regcache)
-+{
-+  struct gdbarch *gdbarch = regcache->arch ();
-+  enum bfd_endian byte_order = gdbarch_byte_order (gdbarch);
-+  int ii, insn;
-+  CORE_ADDR loc;
-+  CORE_ADDR breaks[2];
-+  int opcode;
-+
-+  loc = regcache_read_pc (regcache);
-+
-+  insn = read_memory_integer (loc, 4, byte_order);
-+
-+  std::vector<CORE_ADDR> next_pcs = ppc_deal_with_atomic_sequence (regcache);
-+  if (!next_pcs.empty ())
-+    return next_pcs;
-+  
-+  breaks[0] = loc + PPC_INSN_SIZE;
-+  opcode = insn >> 26;
-+  breaks[1] = branch_dest (regcache, opcode, insn, loc, breaks[0]);
-+
-+  /* Don't put two breakpoints on the same address.  */
-+  if (breaks[1] == breaks[0])
-+    breaks[1] = -1;
-+
-+  for (ii = 0; ii < 2; ++ii)
-+    {
-+      /* ignore invalid breakpoint.  */
-+      if (breaks[ii] == -1)
-+	continue;
-+
-+      next_pcs.push_back (breaks[ii]);
-+    }
-+
-+  errno = 0;			/* FIXME, don't ignore errors!  */
-+  /* What errors?  {read,write}_memory call error().  */
-+  return next_pcs;
-+}
-+
-+static void
-+ppc_amigaos_init_abi (struct gdbarch_info info, struct gdbarch *gdbarch)
-+{
-+	/* Canonical paths on this target look like `SYS:Utilities/Clock', for example.  */
-+	set_gdbarch_has_amiga_based_file_system (gdbarch, 1);
-+
-+	/* Everything runs in the same address space, but might have a priveta adresse area */
-+	set_gdbarch_has_shared_address_space (gdbarch, ppc_amigaos_has_shared_address_space);
-+
-+	// PT_STEP not supported so, need to simulate it, like rs6000-aix
-+	set_gdbarch_software_single_step (gdbarch, ppc_amigaos_software_single_step);
-+	/* Displaced stepping is currently not supported in combination with
-+		software single-stepping.  These override the values set by
-+		rs6000_gdbarch_init.  */
-+	set_gdbarch_displaced_step_copy_insn (gdbarch, NULL);
-+	set_gdbarch_displaced_step_fixup (gdbarch, NULL);
-+	set_gdbarch_displaced_step_prepare (gdbarch, NULL);
-+	set_gdbarch_displaced_step_finish (gdbarch, NULL);
-+
-+  	// Traget bfd name, seems to be only needed for message/debug output
-+	set_gdbarch_gcore_bfd_target (gdbarch, "elf32-powerpc-amigaos");
-+}
-+
-+void _initialize_ppc_amigaos_tdep ();
-+void
-+_initialize_ppc_amigaos_tdep ()
-+{
-+	gdbarch_register_osabi (bfd_arch_rs6000, 0, GDB_OSABI_AMIGAOS, ppc_amigaos_init_abi);
-+	gdbarch_register_osabi (bfd_arch_powerpc, 0, GDB_OSABI_AMIGAOS, ppc_amigaos_init_abi);
-+}
-diff --git a/gdb/source.c b/gdb/source.c
-index d0f2d1c763523da801eb77736b7c141267ba25ad..ed5c1ae25593411e08224ee55883b7a9da2db0f8 100644
---- a/gdb/source.c
-+++ b/gdb/source.c
-@@ -828,13 +828,17 @@ openp (const char *path, openp_flags opts, const char *string,
-     {
-       errno = ENOENT;
-       return -1;
-     }
- 
-   if (!path)
-+  #if defined(__amigaos4__) 
-+    path = "\"\"";
-+  #else
-     path = ".";
-+  #endif
- 
-   mode |= O_BINARY;
- 
-   if ((opts & OPF_TRY_CWD_FIRST) || IS_ABSOLUTE_PATH (string))
-     {
-       int i, reg_file_errno;
-@@ -875,13 +879,13 @@ openp (const char *path, openp_flags opts, const char *string,
-   for (const gdb::unique_xmalloc_ptr<char> &dir_up : dir_vec)
-     {
-       char *dir = dir_up.get ();
-       size_t len = strlen (dir);
-       int reg_file_errno;
- 
--      if (strcmp (dir, "$cwd") == 0)
-+      if (strcmp (dir, "$cwd") == 0 || strcmp (dir, "") == 0)
- 	{
- 	  /* Name is $cwd -- insert current directory name instead.  */
- 	  int newlen;
- 
- 	  /* First, realloc the filename buffer if too short.  */
- 	  len = strlen (current_directory);
-diff --git a/gdbsupport/common-defs.h b/gdbsupport/common-defs.h
-index e4985332e3f4016ccec2b2502dfe28bab16e2c92..e92e54ef41a87b64a1fabeb3cbf0ad74432ce79c 100644
---- a/gdbsupport/common-defs.h
-+++ b/gdbsupport/common-defs.h
-@@ -18,12 +18,13 @@
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
- 
- #ifndef COMMON_COMMON_DEFS_H
- #define COMMON_COMMON_DEFS_H
- 
- #include <gdbsupport/config.h>
-+#include <gdbsupport/host-defs.h>
- 
- #undef PACKAGE_NAME
- #undef PACKAGE
- #undef PACKAGE_VERSION
- #undef PACKAGE_STRING
- #undef PACKAGE_TARNAME
-diff --git a/gdbsupport/common-inferior.cc b/gdbsupport/common-inferior.cc
-index 7e1a5b6fa447c21b2a8ae1c8315c965447b7cffb..b48dc4f06397a5f01c49ec06fc8c9fd3d231bf57 100644
---- a/gdbsupport/common-inferior.cc
-+++ b/gdbsupport/common-inferior.cc
-@@ -36,12 +36,17 @@ construct_inferior_arguments (gdb::array_view<char * const> argv)
-     {
- #ifdef __MINGW32__
-       /* This holds all the characters considered special to the
- 	 Windows shells.  */
-       static const char special[] = "\"!&*|[]{}<>?`~^=;, \t\n";
-       static const char quote = '"';
-+#elif __amigaos4__
-+      /* This holds all the characters considered special to the
-+	 Amiga shells. Currently copy of unix */
-+      static const char special[] = "\"!#$&*()\\|[]{}<>?'`~^; \t\n";
-+      static const char quote = '"';
- #else
-       /* This holds all the characters considered special to the
- 	 typical Unix shells.  We include `^' because the SunOS
- 	 /bin/sh treats it as a synonym for `|'.  */
-       static const char special[] = "\"!#$&*()\\|[]{}<>?'`~^; \t\n";
-       static const char quote = '\'';
-diff --git a/gdbsupport/host-defs.h b/gdbsupport/host-defs.h
-index 4e0d71244a5abb5efb2525b653f701b9fb4b3039..e7deafff6a79c6a30c0e029264baa1d486e84661 100644
---- a/gdbsupport/host-defs.h
-+++ b/gdbsupport/host-defs.h
-@@ -47,12 +47,19 @@
- #endif
- 
- #if !defined (__CYGWIN__) && defined (_WIN32)
- # define DIRNAME_SEPARATOR ';'
- #endif
- 
-+#if defined(__amigaos4__) 
-+# define CANT_FORK
-+# undef HAVE_POLL
-+# undef HAVE_SOCKETPAIR
-+# define DIRNAME_SEPARATOR ';'
-+#endif
-+
- #ifndef DIRNAME_SEPARATOR
- #define DIRNAME_SEPARATOR ':'
- #endif
- 
- #ifndef SLASH_STRING
- #define SLASH_STRING "/"
-diff --git a/gdbsupport/pathstuff.cc b/gdbsupport/pathstuff.cc
-index 390f10b1b5e4895cef6c4a7656cb1199d76d83b3..4a8f4719324796fbdd20265ecc348e9218c96036 100644
---- a/gdbsupport/pathstuff.cc
-+++ b/gdbsupport/pathstuff.cc
-@@ -229,12 +229,14 @@ contains_dir_separator (const char *path)
- 
- std::string
- get_standard_cache_dir ()
- {
- #ifdef __APPLE__
- #define HOME_CACHE_DIR "Library/Caches"
-+#elif __amigaos4__
-+#define HOME_CACHE_DIR "cache"
- #else
- #define HOME_CACHE_DIR ".cache"
- #endif
- 
- #ifndef __APPLE__
-   const char *xdg_cache_home = getenv ("XDG_CACHE_HOME");
-@@ -261,13 +263,20 @@ get_standard_cache_dir ()
-       /* Make sure the path is absolute and tilde-expanded.  */
-       std::string abs = gdb_abspath (win_home);
-       return path_join (abs.c_str (), "gdb");
-     }
- #endif
- 
-+#ifdef __amigaos4__
-+  // Its always PROGDIR: on AmigaOS
-+  /* Make sure the path is absolute and tilde-expanded.  */
-+  std::string abs = gdb_abspath ("PROGDIR:");
-+  return path_join (abs.c_str (), HOME_CACHE_DIR, "gdb");
-+#else
-   return {};
-+#endif
- }
- 
- /* See gdbsupport/pathstuff.h.  */
- 
- std::string
- get_standard_temp_dir ()
-@@ -279,13 +288,14 @@ get_standard_temp_dir ()
- 
-   tmp = getenv ("TEMP");
-   if (tmp != nullptr)
-     return tmp;
- 
-   error (_("Couldn't find temp dir path, both TMP and TEMP are unset."));
--
-+#elif __amigaos4__
-+  return "T:";
- #else
-   const char *tmp = getenv ("TMPDIR");
-   if (tmp != nullptr)
-     return tmp;
- 
-   return "/tmp";
-@@ -318,13 +328,20 @@ get_standard_config_dir ()
-     {
-       /* Make sure the path is absolute and tilde-expanded.  */
-       std::string abs = gdb_abspath (home);
-       return path_join (abs.c_str (), HOME_CONFIG_DIR, "gdb");
-     }
- 
-+#ifdef __amigaos4__
-+  // Its always ENVARC: on AmigaOS
-+  /* Make sure the path is absolute and tilde-expanded.  */
-+  std::string abs = gdb_abspath ("ENVARC:");
-+  return path_join (abs.c_str (), HOME_CONFIG_DIR, "gdb");
-+#else
-   return {};
-+#endif
- }
- 
- /* See pathstuff.h. */
- 
- std::string
- get_standard_config_filename (const char *filename)
-diff --git a/gnulib/configure b/gnulib/configure
-index cc7e8287d5a0a250e2b4f55c1c2fa270399793bd..aaa4b6c0801485d544f2be07237b2be1d3b92f67 100644
---- a/gnulib/configure
-+++ b/gnulib/configure
-@@ -12920,12 +12920,14 @@ else
-   if test "$cross_compiling" = yes; then :
-   case "$host_os" in
-                            # Guess yes on glibc systems.
-             *-gnu* | gnu*) gl_cv_func_getcwd_null="guessing yes";;
-                            # Guess yes on musl systems.
-             *-musl*)       gl_cv_func_getcwd_null="guessing yes";;
-+						   # Guess yes on AmigaOS
-+			amigaos*) 	   gl_cv_func_getcwd_null="guessing yes";;
-                            # Guess yes on Cygwin.
-             cygwin*)       gl_cv_func_getcwd_null="guessing yes";;
-                            # If we don't know, obey --enable-cross-guesses.
-             *)             gl_cv_func_getcwd_null="$gl_cross_guess_normal";;
-           esac
- 
-@@ -25495,12 +25497,14 @@ else
-   # Cross-compilation guesses:
-         case "$host_os" in
-           aix*) # On AIX, it has the AIX bug.
-             gl_cv_func_getcwd_path_max='guessing no, it has the AIX bug' ;;
-           gnu*) # On Hurd, it is 'yes'.
-             gl_cv_func_getcwd_path_max='guessing yes' ;;
-+		  amigaos*) # On AmigaOS, it is 'yes'
-+		    gl_cv_func_getcwd_path_max="guessing yes";;
-           linux* | kfreebsd*)
-             # On older Linux+glibc it's 'no, but it is partly working',
-             # on newer Linux+glibc it's 'yes'.
-             # On Linux+musl libc, it's 'no, but it is partly working'.
-             # On kFreeBSD+glibc, it's 'no, but it is partly working'.
-             gl_cv_func_getcwd_path_max='guessing no, but it is partly working' ;;
-diff --git a/gnulib/import/m4/getcwd-path-max.m4 b/gnulib/import/m4/getcwd-path-max.m4
-index e12045596b13d6352d7ba2fad1c31fd12638b456..bddf75ed4071b22163c95cc57461e6b6b3ce7f34 100644
---- a/gnulib/import/m4/getcwd-path-max.m4
-+++ b/gnulib/import/m4/getcwd-path-max.m4
-@@ -219,12 +219,14 @@ main ()
-        [# Cross-compilation guesses:
-         case "$host_os" in
-           aix*) # On AIX, it has the AIX bug.
-             gl_cv_func_getcwd_path_max='guessing no, it has the AIX bug' ;;
-           gnu*) # On Hurd, it is 'yes'.
-             gl_cv_func_getcwd_path_max='guessing yes' ;;
-+		  amigaos*) # On AmigaOS, it is 'yes'
-+		    gl_cv_func_getcwd_path_max="guessing yes";;
-           linux* | kfreebsd*)
-             # On older Linux+glibc it's 'no, but it is partly working',
-             # on newer Linux+glibc it's 'yes'.
-             # On Linux+musl libc, it's 'no, but it is partly working'.
-             # On kFreeBSD+glibc, it's 'no, but it is partly working'.
-             gl_cv_func_getcwd_path_max='guessing no, but it is partly working' ;;
-diff --git a/gnulib/import/m4/getcwd.m4 b/gnulib/import/m4/getcwd.m4
-index 076ca31485853b9789786079118de3648a6a188c..a7e0e7f9b863458665ef8f2d8a2bb45b5b61c740 100644
---- a/gnulib/import/m4/getcwd.m4
-+++ b/gnulib/import/m4/getcwd.m4
-@@ -52,12 +52,14 @@ AC_DEFUN([gl_FUNC_GETCWD_NULL],
-                            # Guess yes on glibc systems.
-             *-gnu* | gnu*) gl_cv_func_getcwd_null="guessing yes";;
-                            # Guess yes on musl systems.
-             *-musl*)       gl_cv_func_getcwd_null="guessing yes";;
-                            # Guess yes on Cygwin.
-             cygwin*)       gl_cv_func_getcwd_null="guessing yes";;
-+						   # Guess yes on AmigaOS
-+			amigaos*) 	   gl_cv_func_getcwd_null="guessing yes";;
-                            # If we don't know, obey --enable-cross-guesses.
-             *)             gl_cv_func_getcwd_null="$gl_cross_guess_normal";;
-           esac
-         ]])])
- ])
- 
-diff --git a/gnulib/import/sys_time.in.h b/gnulib/import/sys_time.in.h
-index 87db1a88745b034cf736ebefb9dd279e1f7a2bdf..93fce036d36505c27126603d1cce3e116e1ea2eb 100644
---- a/gnulib/import/sys_time.in.h
-+++ b/gnulib/import/sys_time.in.h
-@@ -58,12 +58,13 @@
- /* The definitions of _GL_FUNCDECL_RPL etc. are copied here.  */
- 
- /* The definition of _GL_ARG_NONNULL is copied here.  */
- 
- /* The definition of _GL_WARN_ON_USE is copied here.  */
- 
-+#ifndef __amigaos4__
- #ifdef __cplusplus
- extern "C" {
- #endif
- 
- #if !@HAVE_STRUCT_TIMEVAL@ || @REPLACE_STRUCT_TIMEVAL@
- 
-@@ -82,12 +83,13 @@ struct timeval
- 
- #endif
- 
- #ifdef __cplusplus
- }
- #endif
-+#endif
- 
- #if @GNULIB_GETTIMEOFDAY@
- # if @REPLACE_GETTIMEOFDAY@
- #  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
- #   undef gettimeofday
- #   define gettimeofday rpl_gettimeofday
-diff --git a/include/elf/amigaos.h b/include/elf/amigaos.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..2f12286430f85a5487808af69d3d38881de573c3
---- /dev/null
-+++ b/include/elf/amigaos.h
-@@ -0,0 +1,27 @@
-+/* AmigaOS ELF support for BFD.
-+   Copyright 2001 Free Software Foundation, Inc.
-+
-+This file is part of BFD, the Binary File Descriptor library.
-+
-+This program is free software; you can redistribute it and/or modify
-+it under the terms of the GNU General Public License as published by
-+the Free Software Foundation; either version 2 of the License, or
-+(at your option) any later version.
-+
-+This program is distributed in the hope that it will be useful,
-+but WITHOUT ANY WARRANTY; without even the implied warranty of
-+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+GNU General Public License for more details.
-+
-+You should have received a copy of the GNU General Public License
-+along with this program; if not, write to the Free Software Foundation, Inc.,
-+51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.  */
-+
-+#ifndef _ELF_AMIGAOS_H
-+#define _ELF_AMIGAOS_H
-+
-+#include "elf/common.h"
-+
-+#define DT_AMIGAOS_DYNVERSION	(DT_LOOS + 1)
-+
-+#endif /* _ELF_AMIGAOS_H */
-\ No newline at end of file
-diff --git a/include/elf/ppc.h b/include/elf/ppc.h
-index e0c54a66292c99dbc87d5fdf754421c63e158311..8af55a10a85f9017146c89a590a37aee8602439d 100644
---- a/include/elf/ppc.h
-+++ b/include/elf/ppc.h
-@@ -135,12 +135,18 @@ START_RELOC_NUMBERS (elf_ppc_reloc_type)
-   RELOC_NUMBER (R_PPC_EMB_RELSDA,	116)
- 
- /* Marker reloc for inline plt call insns.  */
-   RELOC_NUMBER (R_PPC_PLTSEQ,		119)
-   RELOC_NUMBER (R_PPC_PLTCALL,		120)
- 
-+/* AmigaOS4 relocs */
-+  RELOC_NUMBER (R_PPC_AMIGAOS_BREL,	210)
-+  RELOC_NUMBER (R_PPC_AMIGAOS_BREL_LO,	211)
-+  RELOC_NUMBER (R_PPC_AMIGAOS_BREL_HI,  212)
-+  RELOC_NUMBER (R_PPC_AMIGAOS_BREL_HA,  213)
-+  
- /* PowerPC VLE relocations.  */
-   RELOC_NUMBER (R_PPC_VLE_REL8,		216)
-   RELOC_NUMBER (R_PPC_VLE_REL15,	217)
-   RELOC_NUMBER (R_PPC_VLE_REL24,	218)
-   RELOC_NUMBER (R_PPC_VLE_LO16A,	219)
-   RELOC_NUMBER (R_PPC_VLE_LO16D,	220)
-diff --git a/include/filenames.h b/include/filenames.h
-index 444c5cc411cfc0518488193f378299ea13bc5584..3a12e2d025dc651e0faf16f9682f16976bdfd5a6 100644
---- a/include/filenames.h
-+++ b/include/filenames.h
-@@ -40,12 +40,22 @@ extern "C" {
- #  ifndef HAVE_CASE_INSENSITIVE_FILE_SYSTEM
- #    define HAVE_CASE_INSENSITIVE_FILE_SYSTEM 1
- #  endif
- #  define HAS_DRIVE_SPEC(f) HAS_DOS_DRIVE_SPEC (f)
- #  define IS_DIR_SEPARATOR(c) IS_DOS_DIR_SEPARATOR (c)
- #  define IS_ABSOLUTE_PATH(f) IS_DOS_ABSOLUTE_PATH (f)
-+#elif defined(__amigaos4__)
-+#  ifndef HAVE_AMIGA_BASED_FILE_SYSTEM
-+#    define HAVE_AMIGA_BASED_FILE_SYSTEM 1
-+#  endif
-+#  ifndef HAVE_CASE_INSENSITIVE_FILE_SYSTEM
-+#    define HAVE_CASE_INSENSITIVE_FILE_SYSTEM 1
-+#  endif
-+#  define HAS_DRIVE_SPEC(f) HAS_AMIGOS_DRIVE_SPEC (f)
-+#  define IS_DIR_SEPARATOR(c) IS_AMIGOS_DIR_SEPARATOR (c)
-+#  define IS_ABSOLUTE_PATH(f) IS_AMIGOS_ABSOLUTE_PATH (f)
- #else /* not DOSish */
- #  if defined(__APPLE__)
- #    ifndef HAVE_CASE_INSENSITIVE_FILE_SYSTEM
- #      define HAVE_CASE_INSENSITIVE_FILE_SYSTEM 1
- #    endif
- #  endif /* __APPLE__ */
-@@ -60,18 +70,26 @@ extern "C" {
- 
- #define HAS_DRIVE_SPEC_1(dos_based, f)			\
-   ((f)[0] && ((f)[1] == ':') && (dos_based))
- 
- /* Remove the drive spec from F, assuming HAS_DRIVE_SPEC (f).
-    The result is a pointer to the remainder of F.  */
-+#if defined(__amigaos4__)
-+#define STRIP_DRIVE_SPEC(f)	(index( &(f)[0],':') + 1 )
-+#else
- #define STRIP_DRIVE_SPEC(f)	((f) + 2)
-+#endif
- 
- #define IS_DOS_DIR_SEPARATOR(c) IS_DIR_SEPARATOR_1 (1, c)
- #define IS_DOS_ABSOLUTE_PATH(f) IS_ABSOLUTE_PATH_1 (1, f)
- #define HAS_DOS_DRIVE_SPEC(f) HAS_DRIVE_SPEC_1 (1, f)
- 
-+#define IS_AMIGOS_DIR_SEPARATOR(c) ( ((c) == '/') || ((c) == ':') )
-+#define IS_AMIGOS_ABSOLUTE_PATH(f) HAS_AMIGOS_DRIVE_SPEC(f)
-+#define HAS_AMIGOS_DRIVE_SPEC(f) (index (&(f)[0], ':') != NULL ) 
-+
- #define IS_UNIX_DIR_SEPARATOR(c) IS_DIR_SEPARATOR_1 (0, c)
- #define IS_UNIX_ABSOLUTE_PATH(f) IS_ABSOLUTE_PATH_1 (0, f)
- 
- /* Note that when DOS_BASED is true, IS_ABSOLUTE_PATH accepts d:foo as
-    well, although it is only semi-absolute.  This is because the users
-    of IS_ABSOLUTE_PATH want to know whether to prepend the current
-diff --git a/include/libiberty.h b/include/libiberty.h
-index 1d5c779fcff358a9c96ea0111f7306a9e6ffa6d0..e9d103d797572248720ffa8ff993ea61082fb991 100644
---- a/include/libiberty.h
-+++ b/include/libiberty.h
-@@ -124,12 +124,17 @@ extern const char *lbasename (const char *) ATTRIBUTE_RETURNS_NONNULL ATTRIBUTE_
- 
- /* Same, but assumes DOS semantics (drive name, backslash is also a
-    dir separator) regardless of host.  */
- 
- extern const char *dos_lbasename (const char *) ATTRIBUTE_RETURNS_NONNULL ATTRIBUTE_NONNULL(1);
- 
-+/* Same, but assumes AMIGA semantics (drive name, slash is also a
-+   dir separator) regardless of host.  */
-+
-+extern const char *amiga_lbasename (const char *) ATTRIBUTE_RETURNS_NONNULL ATTRIBUTE_NONNULL(1);
-+
- /* Same, but assumes Unix semantics (absolute paths always start with
-    a slash, only forward slash is accepted as dir separator)
-    regardless of host.  */
- 
- extern const char *unix_lbasename (const char *) ATTRIBUTE_RETURNS_NONNULL ATTRIBUTE_NONNULL(1);
- 
-diff --git a/ld/Makefile.am b/ld/Makefile.am
-index 12b2c3c453fdbdb1fcac74bf5047bc4d0001483f..fe85a5adb17fe595aedd7fa05d4d7428721e9a16 100644
---- a/ld/Makefile.am
-+++ b/ld/Makefile.am
-@@ -155,12 +155,13 @@ ALL_EMULATION_SOURCES = \
- 	eaix5ppc.c \
- 	eaix5rs6.c \
- 	eaixppc.c \
- 	eaixrs6.c \
- 	ealpha.c \
- 	ealphavms.c \
-+	eamigaos.c \
- 	earcelf.c \
- 	earclinux.c \
- 	earclinux_nps.c \
- 	earcv2elf.c \
- 	earcv2elfx.c \
- 	earm_wince_pe.c \
-@@ -650,12 +651,13 @@ $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES): $(GEN_DEPENDS)
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaix5ppc.Pc@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaix5rs6.Pc@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaixppc.Pc@am__quote@
+diff --git a/ld/Makefile.in b/ld/Makefile.in
+index 3e4e8ae458b..63ad373bbd0 100644
+--- a/ld/Makefile.in
++++ b/ld/Makefile.in
+@@ -2329,7 +2329,6 @@ $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES): $(GEN_DEPENDS)
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaixrs6.Pc@am__quote@
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ealpha.Pc@am__quote@
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ealphavms.Pc@am__quote@
-+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eamigaos.Pc@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eamigaos.Pc@am__quote@
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earcelf.Pc@am__quote@
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earclinux.Pc@am__quote@
  @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earclinux_nps.Pc@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earcv2elf.Pc@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earcv2elfx.Pc@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earm_wince_pe.Pc@am__quote@
-diff --git a/ld/Makefile.in b/ld/Makefile.in
-index 3d5685d6bae1ce6258f053190da8d84f9eaba463..63ad373bbd053b1cbbbcce79e4cd0fd44dd780cb 100644
---- a/ld/Makefile.in
-+++ b/ld/Makefile.in
-@@ -656,12 +656,13 @@ ALL_EMULATION_SOURCES = \
- 	eaix5ppc.c \
- 	eaix5rs6.c \
- 	eaixppc.c \
- 	eaixrs6.c \
- 	ealpha.c \
- 	ealphavms.c \
-+	eamigaos.c \
- 	earcelf.c \
- 	earclinux.c \
- 	earclinux_nps.c \
- 	earcv2elf.c \
- 	earcv2elfx.c \
- 	earm_wince_pe.c \
-@@ -1269,12 +1270,13 @@ distclean-compile:
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaix5ppc.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaix5rs6.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaixppc.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eaixrs6.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ealpha.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ealphavms.Po@am__quote@
-+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eamigaos.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earcelf.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earclinux.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earclinux_nps.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earcv2elf.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earcv2elfx.Po@am__quote@
- @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/earm_wince_pe.Po@am__quote@
-diff --git a/ld/configure.tgt b/ld/configure.tgt
-index de04a44b8125f08095b792285be5ddbaf41e95f2..a2b3a54a94452c6ec882df7c41e63bd00b905b81 100644
---- a/ld/configure.tgt
-+++ b/ld/configure.tgt
-@@ -674,12 +674,16 @@ pdp11-*-*)		targ_emul=pdp11
- pjl*-*-*)		targ_emul=pjlelf
- 			targ_extra_emuls="elf_i386 elf_iamcu"
- 			;;
- pj*-*-*)		targ_emul=pjelf
- 			targ_extra_ofiles=ldelfgen.o
- 			;;
-+powerpc-*-amigaos*)
-+			targ_emul=amigaos
-+			targ_extra_emuls=elf32ppc
-+			;;			
- powerpc-*-freebsd* | powerpc-*-kfreebsd*-gnu)
- 			targ_emul=elf32ppc_fbsd
- 			targ_extra_emuls="elf32ppc elf32ppcsim"
- 			targ_extra_libpath=elf32ppc;
- 			tdir_elf32ppcsim=`echo ${targ_alias} | sed -e 's/ppc/ppcsim/'`
- 			;;
-@@ -1141,12 +1145,16 @@ i[03-9x]86-*-cygwin* | x86_64-*-cygwin*)
- *-*-linux*)
-   ;;
- 
- *-*-netbsd*)
-   ;;
- 
-+powerpc-*-amigaos*)
-+  NATIVE_LIB_DIRS='/gcc/local/lib /gcc/lib'
-+  ;;
-+
- alpha*-*-*)
-   NATIVE_LIB_DIRS='/usr/local/lib /usr/ccs/lib /lib /usr/lib'
-   ;;
- 
- esac
- 
 diff --git a/ld/emulparams/amigaos.sh b/ld/emulparams/amigaos.sh
-new file mode 100644
-index 0000000000000000000000000000000000000000..c9e25b1cbb5060faac798aa9480dae874751ef5d
---- /dev/null
+index 87e9ec63de5..c9e25b1cbb5 100644
+--- a/ld/emulparams/amigaos.sh
 +++ b/ld/emulparams/amigaos.sh
-@@ -0,0 +1,31 @@
-+. ${srcdir}/emulparams/elf32ppccommon.sh
-+. ${srcdir}/emulparams/plt_unwind.sh
-+
-+TEMPLATE_NAME=elf
-+EXTRA_EM_FILE=ppc32elf
-+SCRIPT_NAME=amigaos
-+OUTPUT_FORMAT="elf32-powerpc-amigaos"
-+MAXPAGESIZE="CONSTANT (MAXPAGESIZE)"
-+COMMONPAGESIZE="CONSTANT (COMMONPAGESIZE)"
+@@ -7,6 +7,7 @@ SCRIPT_NAME=amigaos
+ OUTPUT_FORMAT="elf32-powerpc-amigaos"
+ MAXPAGESIZE="CONSTANT (MAXPAGESIZE)"
+ COMMONPAGESIZE="CONSTANT (COMMONPAGESIZE)"
 +DATA_SEGMENT_ALIGN="ALIGN(${SEGMENT_SIZE})"
-+ALIGNMENT=16
-+ARCH=powerpc
-+MACHINE=
-+GENERATE_SHLIB_SCRIPT=yes
-+TEXT_START_ADDR=0x01000000
-+SHLIB_TEXT_START_ADDR=0x10000000
-+unset WRITABLE_RODATA
-+DATA_START_SYMBOLS="_DATA_BASE_ = .;"
-+SDATA_START_SYMBOLS="_SDA_BASE_ = . + 0x8000;"
-+DATA_GOT=
-+SDATA_GOT=
-+TEXT_PLT=yes
-+SEPARATE_GOTPLT=0
-+unset BSS_PLT
-+unset DATA_PLT
-+GOT=".got          ${RELOCATING-0} : SPECIAL { *(.got) }"
-+PLT=".plt          ${RELOCATING-0} :  { *(.plt) }"
-+# GOTPLT="${PLT}"
-+OTHER_TEXT_SECTIONS="*(.glink)"
-+ENABLE_INITFINI_ARRAY=no
-+DYNAMIC_LINK=false
+ ALIGNMENT=16
+ ARCH=powerpc
+ MACHINE=
+diff --git a/ld/emultempl/amigaos.em b/ld/emultempl/amigaos.em
+deleted file mode 100644
+index ecf2fdb40b9..00000000000
+--- a/ld/emultempl/amigaos.em
++++ /dev/null
+@@ -1,2544 +0,0 @@
+-# This shell script emits a C file. -*- C -*-
+-# It does some substitutions.
+-# This file is now misnamed, because it supports both 32 bit and 64 bit
+-# ELF emulations.
+-test -z "${ELFSIZE}" && ELFSIZE=32
+-if [ -z "$MACHINE" ]; then
+-  OUTPUT_ARCH=${ARCH}
+-else
+-  OUTPUT_ARCH=${ARCH}:${MACHINE}
+-fi
+-fragment <<EOF
+-/* This file is is generated by a shell script.  DO NOT EDIT! */
+-
+-/* ${ELFSIZE} bit ELF emulation code for ${EMULATION_NAME}
+-   Copyright 1991, 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001,
+-   2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013
+-   Free Software Foundation, Inc.
+-   Written by Steve Chamberlain <sac@cygnus.com>
+-   ELF support by Ian Lance Taylor <ian@cygnus.com>
+-
+-   This file is part of the GNU Binutils.
+-
+-   This program is free software; you can redistribute it and/or modify
+-   it under the terms of the GNU General Public License as published by
+-   the Free Software Foundation; either version 3 of the License, or
+-   (at your option) any later version.
+-
+-   This program is distributed in the hope that it will be useful,
+-   but WITHOUT ANY WARRANTY; without even the implied warranty of
+-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-   GNU General Public License for more details.
+-
+-   You should have received a copy of the GNU General Public License
+-   along with this program; if not, write to the Free Software
+-   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
+-   MA 02110-1301, USA.  */
+-
+-#define TARGET_IS_${EMULATION_NAME}
+-
+-#include "sysdep.h"
+-#include "bfd.h"
+-#include "libiberty.h"
+-#include "filenames.h"
+-#include "safe-ctype.h"
+-#include "getopt.h"
+-#include "md5.h"
+-#include "sha1.h"
+-#include <fcntl.h>
+-
+-#include "bfdlink.h"
+-
+-#include "ld.h"
+-#include "ldmain.h"
+-#include "ldmisc.h"
+-#include "ldexp.h"
+-#include "ldlang.h"
+-#include "ldfile.h"
+-#include "ldemul.h"
+-#include <ldgram.h>
+-#include "elf/common.h"
+-#include "elf-bfd.h"
+-#include "filenames.h"
+-
+-/* Declare functions used by various EXTRA_EM_FILEs.  */
+-static void gld${EMULATION_NAME}_before_parse (void);
+-static void gld${EMULATION_NAME}_after_open (void);
+-static void gld${EMULATION_NAME}_before_allocation (void);
+-static void gld${EMULATION_NAME}_after_allocation (void);
+-static lang_output_section_statement_type *gld${EMULATION_NAME}_place_orphan
+-  (asection *, const char *, int);
+-EOF
+-
+-if [ "x${USE_LIBPATH}" = xyes ] ; then
+-  case ${target} in
+-    *-*-linux-* | *-*-k*bsd*-* | *-*-gnu*)
+-  fragment <<EOF
+-#ifdef HAVE_GLOB
+-#include <glob.h>
+-#endif
+-EOF
+-    ;;
+-  esac
+-fi
+-
+-# Import any needed special functions and/or overrides.
+-#
+-source_em ${srcdir}/emultempl/elf-generic.em
+-if test -n "$EXTRA_EM_FILE" ; then
+-  source_em ${srcdir}/emultempl/${EXTRA_EM_FILE}.em
+-fi
+-
+-# Functions in this file can be overridden by setting the LDEMUL_* shell
+-# variables.  If the name of the overriding function is the same as is
+-# defined in this file, then don't output this file's version.
+-# If a different overriding name is given then output the standard function
+-# as presumably it is called from the overriding function.
+-#
+-if test x"$LDEMUL_BEFORE_PARSE" != xgld"$EMULATION_NAME"_before_parse; then
+-fragment <<EOF
+-
+-static void
+-gld${EMULATION_NAME}_before_parse (void)
+-{
+-  ldfile_set_output_arch ("${OUTPUT_ARCH}", bfd_arch_`echo ${ARCH} | sed -e 's/:.*//'`);
+-  input_flags.dynamic = ${DYNAMIC_LINK-TRUE};
+-  config.has_shared = `if test -n "$GENERATE_SHLIB_SCRIPT" ; then echo TRUE ; else echo FALSE ; fi`;
+-  config.separate_code = `if test "x${SEPARATE_CODE}" = xyes ; then echo TRUE ; else echo FALSE ; fi`;
+-}
+-
+-EOF
+-fi
+-
+-if test x"$LDEMUL_RECOGNIZED_FILE" != xgld"${EMULATION_NAME}"_load_symbols; then
+-fragment <<EOF
+-/* Handle the generation of DT_NEEDED tags.  */
+-
+-static bfd_boolean
+-gld${EMULATION_NAME}_load_symbols (lang_input_statement_type *entry)
+-{
+-  int link_class = 0;
+-
+-  /* Tell the ELF linker that we don't want the output file to have a
+-     DT_NEEDED entry for this file, unless it is used to resolve
+-     references in a regular object.  */
+-  if (entry->flags.add_DT_NEEDED_for_regular)
+-    link_class = DYN_AS_NEEDED;
+-
+-  /* Tell the ELF linker that we don't want the output file to have a
+-     DT_NEEDED entry for any dynamic library in DT_NEEDED tags from
+-     this file at all.  */
+-  if (!entry->flags.add_DT_NEEDED_for_dynamic)
+-    link_class |= DYN_NO_ADD_NEEDED;
+-
+-  if (entry->flags.just_syms
+-      && (bfd_get_file_flags (entry->the_bfd) & DYNAMIC) != 0)
+-    einfo (_("%P%F: --just-symbols may not be used on DSO: %B\n"),
+-	   entry->the_bfd);
+-
+-  if (link_class == 0
+-      || (bfd_get_file_flags (entry->the_bfd) & DYNAMIC) == 0)
+-    return FALSE;
+-
+-  bfd_elf_set_dyn_lib_class (entry->the_bfd,
+-			     (enum dynamic_lib_link_class) link_class);
+-
+-  /* Continue on with normal load_symbols processing.  */
+-  return FALSE;
+-}
+-EOF
+-fi
+-
+-fragment <<EOF
+-
+-/* These variables are required to pass information back and forth
+-   between after_open and check_needed and stat_needed and vercheck.  */
+-
+-static struct bfd_link_needed_list *global_needed;
+-static struct stat global_stat;
+-static lang_input_statement_type *global_found;
+-static struct bfd_link_needed_list *global_vercheck_needed;
+-static bfd_boolean global_vercheck_failed;
+-
+-/* These variables are used to implement target options */
+-
+-static char *audit; /* colon (typically) separated list of libs */
+-static char *depaudit; /* colon (typically) separated list of libs */
+-
+-/* Style of .note.gnu.build-id section.  */
+-static const char *emit_note_gnu_build_id;
+-
+-/* On Linux, it's possible to have different versions of the same
+-   shared library linked against different versions of libc.  The
+-   dynamic linker somehow tags which libc version to use in
+-   /etc/ld.so.cache, and, based on the libc that it sees in the
+-   executable, chooses which version of the shared library to use.
+-
+-   We try to do a similar check here by checking whether this shared
+-   library needs any other shared libraries which may conflict with
+-   libraries we have already included in the link.  If it does, we
+-   skip it, and try to find another shared library farther on down the
+-   link path.
+-
+-   This is called via lang_for_each_input_file.
+-   GLOBAL_VERCHECK_NEEDED is the list of objects needed by the object
+-   which we are checking.  This sets GLOBAL_VERCHECK_FAILED if we find
+-   a conflicting version.  */
+-
+-static void
+-gld${EMULATION_NAME}_vercheck (lang_input_statement_type *s)
+-{
+-  const char *soname;
+-  struct bfd_link_needed_list *l;
+-
+-  if (global_vercheck_failed)
+-    return;
+-  if (s->the_bfd == NULL
+-      || (bfd_get_file_flags (s->the_bfd) & DYNAMIC) == 0)
+-    return;
+-
+-  soname = bfd_elf_get_dt_soname (s->the_bfd);
+-  if (soname == NULL)
+-    soname = lbasename (bfd_get_filename (s->the_bfd));
+-
+-  for (l = global_vercheck_needed; l != NULL; l = l->next)
+-    {
+-      const char *suffix;
+-
+-      if (filename_cmp (soname, l->name) == 0)
+-	{
+-	  /* Probably can't happen, but it's an easy check.  */
+-	  continue;
+-	}
+-
+-      if (strchr (l->name, '/') != NULL)
+-	continue;
+-
+-      suffix = strstr (l->name, ".so.");
+-      if (suffix == NULL)
+-	continue;
+-
+-      suffix += sizeof ".so." - 1;
+-
+-      if (filename_ncmp (soname, l->name, suffix - l->name) == 0)
+-	{
+-	  /* Here we know that S is a dynamic object FOO.SO.VER1, and
+-	     the object we are considering needs a dynamic object
+-	     FOO.SO.VER2, and VER1 and VER2 are different.  This
+-	     appears to be a version mismatch, so we tell the caller
+-	     to try a different version of this library.  */
+-	  global_vercheck_failed = TRUE;
+-	  return;
+-	}
+-    }
+-}
+-
+-
+-/* See if an input file matches a DT_NEEDED entry by running stat on
+-   the file.  */
+-
+-static void
+-gld${EMULATION_NAME}_stat_needed (lang_input_statement_type *s)
+-{
+-  struct stat st;
+-  const char *suffix;
+-  const char *soname;
+-
+-  if (global_found != NULL)
+-    return;
+-  if (s->the_bfd == NULL)
+-    return;
+-
+-  /* If this input file was an as-needed entry, and wasn't found to be
+-     needed at the stage it was linked, then don't say we have loaded it.  */
+-  if ((bfd_elf_get_dyn_lib_class (s->the_bfd) & DYN_AS_NEEDED) != 0)
+-    return;
+-
+-  if (bfd_stat (s->the_bfd, &st) != 0)
+-    {
+-      einfo ("%P:%B: bfd_stat failed: %E\n", s->the_bfd);
+-      return;
+-    }
+-
+-  /* Some operating systems, e.g. Windows, do not provide a meaningful
+-     st_ino; they always set it to zero.  (Windows does provide a
+-     meaningful st_dev.)  Do not indicate a duplicate library in that
+-     case.  While there is no guarantee that a system that provides
+-     meaningful inode numbers will never set st_ino to zero, this is
+-     merely an optimization, so we do not need to worry about false
+-     negatives.  */
+-  if (st.st_dev == global_stat.st_dev
+-      && st.st_ino == global_stat.st_ino
+-      && st.st_ino != 0)
+-    {
+-      global_found = s;
+-      return;
+-    }
+-
+-  /* We issue a warning if it looks like we are including two
+-     different versions of the same shared library.  For example,
+-     there may be a problem if -lc picks up libc.so.6 but some other
+-     shared library has a DT_NEEDED entry of libc.so.5.  This is a
+-     heuristic test, and it will only work if the name looks like
+-     NAME.so.VERSION.  FIXME: Depending on file names is error-prone.
+-     If we really want to issue warnings about mixing version numbers
+-     of shared libraries, we need to find a better way.  */
+-
+-  if (strchr (global_needed->name, '/') != NULL)
+-    return;
+-  suffix = strstr (global_needed->name, ".so.");
+-  if (suffix == NULL)
+-    return;
+-  suffix += sizeof ".so." - 1;
+-
+-  soname = bfd_elf_get_dt_soname (s->the_bfd);
+-  if (soname == NULL)
+-    soname = lbasename (s->filename);
+-
+-  if (filename_ncmp (soname, global_needed->name, suffix - global_needed->name) == 0)
+-    einfo ("%P: warning: %s, needed by %B, may conflict with %s\n",
+-	   global_needed->name, global_needed->by, soname);
+-}
+-
+-struct dt_needed
+-{
+-  bfd *by;
+-  const char *name;
+-};
+-
+-/* This function is called for each possible name for a dynamic object
+-   named by a DT_NEEDED entry.  The FORCE parameter indicates whether
+-   to skip the check for a conflicting version.  */
+-
+-static bfd_boolean
+-gld${EMULATION_NAME}_try_needed (struct dt_needed *needed,
+-				 int force)
+-{
+-  bfd *abfd;
+-  const char *name = needed->name;
+-  const char *soname;
+-  int link_class;
+-
+-  abfd = bfd_openr (name, bfd_get_target (link_info.output_bfd));
+-  if (abfd == NULL)
+-    return FALSE;
+-
+-  /* Linker needs to decompress sections.  */
+-  abfd->flags |= BFD_DECOMPRESS;
+-
+-  if (! bfd_check_format (abfd, bfd_object))
+-    {
+-      bfd_close (abfd);
+-      return FALSE;
+-    }
+-  if ((bfd_get_file_flags (abfd) & DYNAMIC) == 0)
+-    {
+-      bfd_close (abfd);
+-      return FALSE;
+-    }
+-
+-  /* For DT_NEEDED, they have to match.  */
+-  if (abfd->xvec != link_info.output_bfd->xvec)
+-    {
+-      bfd_close (abfd);
+-      return FALSE;
+-    }
+-
+-  /* Check whether this object would include any conflicting library
+-     versions.  If FORCE is set, then we skip this check; we use this
+-     the second time around, if we couldn't find any compatible
+-     instance of the shared library.  */
+-
+-  if (! force)
+-    {
+-      struct bfd_link_needed_list *needs;
+-
+-      if (! bfd_elf_get_bfd_needed_list (abfd, &needs))
+-	einfo ("%F%P:%B: bfd_elf_get_bfd_needed_list failed: %E\n", abfd);
+-
+-      if (needs != NULL)
+-	{
+-	  global_vercheck_needed = needs;
+-	  global_vercheck_failed = FALSE;
+-	  lang_for_each_input_file (gld${EMULATION_NAME}_vercheck);
+-	  if (global_vercheck_failed)
+-	    {
+-	      bfd_close (abfd);
+-	      /* Return FALSE to force the caller to move on to try
+-		 another file on the search path.  */
+-	      return FALSE;
+-	    }
+-
+-	  /* But wait!  It gets much worse.  On Linux, if a shared
+-	     library does not use libc at all, we are supposed to skip
+-	     it the first time around in case we encounter a shared
+-	     library later on with the same name which does use the
+-	     version of libc that we want.  This is much too horrible
+-	     to use on any system other than Linux.  */
+-
+-EOF
+-case ${target} in
+-  *-*-linux-* | *-*-k*bsd*-* | *-*-gnu*)
+-    fragment <<EOF
+-	  {
+-	    struct bfd_link_needed_list *l;
+-
+-	    for (l = needs; l != NULL; l = l->next)
+-	      if (CONST_STRNEQ (l->name, "libc.so"))
+-		break;
+-	    if (l == NULL)
+-	      {
+-		bfd_close (abfd);
+-		return FALSE;
+-	      }
+-	  }
+-
+-EOF
+-    ;;
+-esac
+-fragment <<EOF
+-	}
+-    }
+-
+-  /* We've found a dynamic object matching the DT_NEEDED entry.  */
+-
+-  /* We have already checked that there is no other input file of the
+-     same name.  We must now check again that we are not including the
+-     same file twice.  We need to do this because on many systems
+-     libc.so is a symlink to, e.g., libc.so.1.  The SONAME entry will
+-     reference libc.so.1.  If we have already included libc.so, we
+-     don't want to include libc.so.1 if they are the same file, and we
+-     can only check that using stat.  */
+-
+-  if (bfd_stat (abfd, &global_stat) != 0)
+-    einfo ("%F%P:%B: bfd_stat failed: %E\n", abfd);
+-
+-  /* First strip off everything before the last '/'.  */
+-  soname = lbasename (abfd->filename);
+-
+-  if (verbose)
+-    info_msg (_("found %s at %s\n"), soname, name);
+-
+-  global_found = NULL;
+-  lang_for_each_input_file (gld${EMULATION_NAME}_stat_needed);
+-  if (global_found != NULL)
+-    {
+-      /* Return TRUE to indicate that we found the file, even though
+-	 we aren't going to do anything with it.  */
+-      return TRUE;
+-    }
+-
+-  /* Specify the soname to use.  */
+-  bfd_elf_set_dt_needed_name (abfd, soname);
+-
+-  /* Tell the ELF linker that we don't want the output file to have a
+-     DT_NEEDED entry for this file, unless it is used to resolve
+-     references in a regular object.  */
+-  link_class = DYN_DT_NEEDED;
+-
+-  /* Tell the ELF linker that we don't want the output file to have a
+-     DT_NEEDED entry for this file at all if the entry is from a file
+-     with DYN_NO_ADD_NEEDED.  */
+-  if (needed->by != NULL
+-      && (bfd_elf_get_dyn_lib_class (needed->by) & DYN_NO_ADD_NEEDED) != 0)
+-    link_class |= DYN_NO_NEEDED | DYN_NO_ADD_NEEDED;
+-
+-  bfd_elf_set_dyn_lib_class (abfd, (enum dynamic_lib_link_class) link_class);
+-
+-  /* Add this file into the symbol table.  */
+-  if (! bfd_link_add_symbols (abfd, &link_info))
+-    einfo ("%F%B: error adding symbols: %E\n", abfd);
+-
+-  return TRUE;
+-}
+-
+-
+-/* Search for a needed file in a path.  */
+-
+-static bfd_boolean
+-gld${EMULATION_NAME}_search_needed (const char *path,
+-				    struct dt_needed *n, int force)
+-{
+-  const char *s;
+-  const char *name = n->name;
+-  size_t len;
+-  struct dt_needed needed;
+-
+-  if (name[0] == '/')
+-    return gld${EMULATION_NAME}_try_needed (n, force);
+-
+-  if (path == NULL || *path == '\0')
+-    return FALSE;
+-
+-  needed.by = n->by;
+-  needed.name = n->name;
+-
+-  len = strlen (name);
+-  while (1)
+-    {
+-      char *filename, *sset;
+-
+-      s = strchr (path, config.rpath_separator);
+-      if (s == NULL)
+-	s = path + strlen (path);
+-
+-#if HAVE_DOS_BASED_FILE_SYSTEM
+-      /* Assume a match on the second char is part of drive specifier.  */
+-      else if (config.rpath_separator == ':'
+-	       && s == path + 1
+-	       && ISALPHA (*path))
+-	{
+-	  s = strchr (s + 1, config.rpath_separator);
+-	  if (s == NULL)
+-	    s = path + strlen (path);
+-	}
+-#endif
+-      filename = (char *) xmalloc (s - path + len + 2);
+-      if (s == path)
+-	sset = filename;
+-      else
+-	{
+-	  memcpy (filename, path, s - path);
+-	  filename[s - path] = '/';
+-	  sset = filename + (s - path) + 1;
+-	}
+-      strcpy (sset, name);
+-
+-      needed.name = filename;
+-      if (gld${EMULATION_NAME}_try_needed (&needed, force))
+-	return TRUE;
+-
+-      free (filename);
+-
+-      if (*s == '\0')
+-	break;
+-      path = s + 1;
+-    }
+-
+-  return FALSE;
+-}
+-
+-EOF
+-if [ "x${USE_LIBPATH}" = xyes ] ; then
+-  fragment <<EOF
+-
+-/* Add the sysroot to every entry in a path separated by
+-   config.rpath_separator.  */
+-
+-static char *
+-gld${EMULATION_NAME}_add_sysroot (const char *path)
+-{
+-  int len, colons, i;
+-  char *ret, *p;
+-
+-  len = strlen (path);
+-  colons = 0;
+-  i = 0;
+-  while (path[i])
+-    if (path[i++] == config.rpath_separator)
+-      colons++;
+-
+-  if (path[i])
+-    colons++;
+-
+-  len = len + (colons + 1) * strlen (ld_sysroot);
+-  ret = xmalloc (len + 1);
+-  strcpy (ret, ld_sysroot);
+-  p = ret + strlen (ret);
+-  i = 0;
+-  while (path[i])
+-    if (path[i] == config.rpath_separator)
+-      {
+-	*p++ = path[i++];
+-	strcpy (p, ld_sysroot);
+-	p = p + strlen (p);
+-      }
+-    else
+-      *p++ = path[i++];
+-
+-  *p = 0;
+-  return ret;
+-}
+-
+-EOF
+-  case ${target} in
+-    *-*-freebsd* | *-*-dragonfly*)
+-      fragment <<EOF
+-/* Read the system search path the FreeBSD way rather than the Linux way.  */
+-#ifdef HAVE_ELF_HINTS_H
+-#include <elf-hints.h>
+-#else
+-#include "elf-hints-local.h"
+-#endif
+-
+-static bfd_boolean
+-gld${EMULATION_NAME}_check_ld_elf_hints (const struct bfd_link_needed_list *l,
+-					 int force)
+-{
+-  static bfd_boolean initialized;
+-  static char *ld_elf_hints;
+-  struct dt_needed needed;
+-
+-  if (!initialized)
+-    {
+-      FILE *f;
+-      char *tmppath;
+-
+-      tmppath = concat (ld_sysroot, _PATH_ELF_HINTS, (const char *) NULL);
+-      f = fopen (tmppath, FOPEN_RB);
+-      free (tmppath);
+-      if (f != NULL)
+-	{
+-	  struct elfhints_hdr hdr;
+-
+-	  if (fread (&hdr, 1, sizeof (hdr), f) == sizeof (hdr)
+-	      && hdr.magic == ELFHINTS_MAGIC
+-	      && hdr.version == 1)
+-	    {
+-	      if (fseek (f, hdr.strtab + hdr.dirlist, SEEK_SET) != -1)
+-		{
+-		  char *b;
+-
+-		  b = xmalloc (hdr.dirlistlen + 1);
+-		  if (fread (b, 1, hdr.dirlistlen + 1, f) ==
+-		      hdr.dirlistlen + 1)
+-		    ld_elf_hints = gld${EMULATION_NAME}_add_sysroot (b);
+-
+-		  free (b);
+-		}
+-	    }
+-	  fclose (f);
+-	}
+-
+-      initialized = TRUE;
+-    }
+-
+-  if (ld_elf_hints == NULL)
+-    return FALSE;
+-
+-  needed.by = l->by;
+-  needed.name = l->name;
+-  return gld${EMULATION_NAME}_search_needed (ld_elf_hints, &needed, force);
+-}
+-EOF
+-    # FreeBSD
+-    ;;
+-
+-    *-*-linux-* | *-*-k*bsd*-* | *-*-gnu*)
+-      fragment <<EOF
+-/* For a native linker, check the file /etc/ld.so.conf for directories
+-   in which we may find shared libraries.  /etc/ld.so.conf is really
+-   only meaningful on Linux.  */
+-
+-struct gld${EMULATION_NAME}_ld_so_conf
+-{
+-  char *path;
+-  size_t len, alloc;
+-};
+-
+-static bfd_boolean
+-gld${EMULATION_NAME}_parse_ld_so_conf
+-     (struct gld${EMULATION_NAME}_ld_so_conf *info, const char *filename);
+-
+-static void
+-gld${EMULATION_NAME}_parse_ld_so_conf_include
+-     (struct gld${EMULATION_NAME}_ld_so_conf *info, const char *filename,
+-      const char *pattern)
+-{
+-  char *newp = NULL;
+-#ifdef HAVE_GLOB
+-  glob_t gl;
+-#endif
+-
+-  if (pattern[0] != '/')
+-    {
+-      char *p = strrchr (filename, '/');
+-      size_t patlen = strlen (pattern) + 1;
+-
+-      newp = xmalloc (p - filename + 1 + patlen);
+-      memcpy (newp, filename, p - filename + 1);
+-      memcpy (newp + (p - filename + 1), pattern, patlen);
+-      pattern = newp;
+-    }
+-
+-#ifdef HAVE_GLOB
+-  if (glob (pattern, 0, NULL, &gl) == 0)
+-    {
+-      size_t i;
+-
+-      for (i = 0; i < gl.gl_pathc; ++i)
+-	gld${EMULATION_NAME}_parse_ld_so_conf (info, gl.gl_pathv[i]);
+-      globfree (&gl);
+-    }
+-#else
+-  /* If we do not have glob, treat the pattern as a literal filename.  */
+-  gld${EMULATION_NAME}_parse_ld_so_conf (info, pattern);
+-#endif
+-
+-  if (newp)
+-    free (newp);
+-}
+-
+-static bfd_boolean
+-gld${EMULATION_NAME}_parse_ld_so_conf
+-     (struct gld${EMULATION_NAME}_ld_so_conf *info, const char *filename)
+-{
+-  FILE *f = fopen (filename, FOPEN_RT);
+-  char *line;
+-  size_t linelen;
+-
+-  if (f == NULL)
+-    return FALSE;
+-
+-  linelen = 256;
+-  line = xmalloc (linelen);
+-  do
+-    {
+-      char *p = line, *q;
+-
+-      /* Normally this would use getline(3), but we need to be portable.  */
+-      while ((q = fgets (p, linelen - (p - line), f)) != NULL
+-	     && strlen (q) == linelen - (p - line) - 1
+-	     && line[linelen - 2] != '\n')
+-	{
+-	  line = xrealloc (line, 2 * linelen);
+-	  p = line + linelen - 1;
+-	  linelen += linelen;
+-	}
+-
+-      if (q == NULL && p == line)
+-	break;
+-
+-      p = strchr (line, '\n');
+-      if (p)
+-	*p = '\0';
+-
+-      /* Because the file format does not know any form of quoting we
+-	 can search forward for the next '#' character and if found
+-	 make it terminating the line.  */
+-      p = strchr (line, '#');
+-      if (p)
+-	*p = '\0';
+-
+-      /* Remove leading whitespace.  NUL is no whitespace character.  */
+-      p = line;
+-      while (*p == ' ' || *p == '\f' || *p == '\r' || *p == '\t' || *p == '\v')
+-	++p;
+-
+-      /* If the line is blank it is ignored.  */
+-      if (p[0] == '\0')
+-	continue;
+-
+-      if (CONST_STRNEQ (p, "include") && (p[7] == ' ' || p[7] == '\t'))
+-	{
+-	  char *dir, c;
+-	  p += 8;
+-	  do
+-	    {
+-	      while (*p == ' ' || *p == '\t')
+-		++p;
+-
+-	      if (*p == '\0')
+-		break;
+-
+-	      dir = p;
+-
+-	      while (*p != ' ' && *p != '\t' && *p)
+-		++p;
+-
+-	      c = *p;
+-	      *p++ = '\0';
+-	      if (dir[0] != '\0')
+-		gld${EMULATION_NAME}_parse_ld_so_conf_include (info, filename,
+-							       dir);
+-	    }
+-	  while (c != '\0');
+-	}
+-      else
+-	{
+-	  char *dir = p;
+-	  while (*p && *p != '=' && *p != ' ' && *p != '\t' && *p != '\f'
+-		 && *p != '\r' && *p != '\v')
+-	    ++p;
+-
+-	  while (p != dir && p[-1] == '/')
+-	    --p;
+-	  if (info->path == NULL)
+-	    {
+-	      info->alloc = p - dir + 1 + 256;
+-	      info->path = xmalloc (info->alloc);
+-	      info->len = 0;
+-	    }
+-	  else
+-	    {
+-	      if (info->len + 1 + (p - dir) >= info->alloc)
+-		{
+-		  info->alloc += p - dir + 256;
+-		  info->path = xrealloc (info->path, info->alloc);
+-		}
+-	      info->path[info->len++] = config.rpath_separator;
+-	    }
+-	  memcpy (info->path + info->len, dir, p - dir);
+-	  info->len += p - dir;
+-	  info->path[info->len] = '\0';
+-	}
+-    }
+-  while (! feof (f));
+-  free (line);
+-  fclose (f);
+-  return TRUE;
+-}
+-
+-static bfd_boolean
+-gld${EMULATION_NAME}_check_ld_so_conf (const struct bfd_link_needed_list *l,
+-				       int force)
+-{
+-  static bfd_boolean initialized;
+-  static char *ld_so_conf;
+-  struct dt_needed needed;
+-
+-  if (! initialized)
+-    {
+-      char *tmppath;
+-      struct gld${EMULATION_NAME}_ld_so_conf info;
+-
+-      info.path = NULL;
+-      info.len = info.alloc = 0;
+-      tmppath = concat (ld_sysroot, "${prefix}/etc/ld.so.conf",
+-			(const char *) NULL);
+-      if (!gld${EMULATION_NAME}_parse_ld_so_conf (&info, tmppath))
+-	{
+-	  free (tmppath);
+-	  tmppath = concat (ld_sysroot, "/etc/ld.so.conf",
+-			    (const char *) NULL);
+-	  gld${EMULATION_NAME}_parse_ld_so_conf (&info, tmppath);
+-	}
+-      free (tmppath);
+-
+-      if (info.path)
+-	{
+-	  char *d = gld${EMULATION_NAME}_add_sysroot (info.path);
+-	  free (info.path);
+-	  ld_so_conf = d;
+-	}
+-      initialized = TRUE;
+-    }
+-
+-  if (ld_so_conf == NULL)
+-    return FALSE;
+-
+-
+-  needed.by = l->by;
+-  needed.name = l->name;
+-  return gld${EMULATION_NAME}_search_needed (ld_so_conf, &needed, force);
+-}
+-
+-EOF
+-    # Linux
+-    ;;
+-  esac
+-fi
+-fragment <<EOF
+-
+-/* See if an input file matches a DT_NEEDED entry by name.  */
+-
+-static void
+-gld${EMULATION_NAME}_check_needed (lang_input_statement_type *s)
+-{
+-  const char *soname;
+-
+-  /* Stop looking if we've found a loaded lib.  */
+-  if (global_found != NULL
+-      && (bfd_elf_get_dyn_lib_class (global_found->the_bfd)
+-	  & DYN_AS_NEEDED) == 0)
+-    return;
+-
+-  if (s->filename == NULL || s->the_bfd == NULL)
+-    return;
+-
+-  /* Don't look for a second non-loaded as-needed lib.  */
+-  if (global_found != NULL
+-      && (bfd_elf_get_dyn_lib_class (s->the_bfd) & DYN_AS_NEEDED) != 0)
+-    return;
+-
+-  if (filename_cmp (s->filename, global_needed->name) == 0)
+-    {
+-      global_found = s;
+-      return;
+-    }
+-
+-  if (s->flags.search_dirs)
+-    {
+-      const char *f = strrchr (s->filename, '/');
+-      if (f != NULL
+-	  && filename_cmp (f + 1, global_needed->name) == 0)
+-	{
+-	  global_found = s;
+-	  return;
+-	}
+-    }
+-
+-  soname = bfd_elf_get_dt_soname (s->the_bfd);
+-  if (soname != NULL
+-      && filename_cmp (soname, global_needed->name) == 0)
+-    {
+-      global_found = s;
+-      return;
+-    }
+-}
+-
+-EOF
+-
+-if test x"$LDEMUL_AFTER_OPEN" != xgld"$EMULATION_NAME"_after_open; then
+-fragment <<EOF
+-
+-static bfd_size_type
+-id_note_section_size (bfd *abfd ATTRIBUTE_UNUSED)
+-{
+-  const char *style = emit_note_gnu_build_id;
+-  bfd_size_type size;
+-
+-  size = offsetof (Elf_External_Note, name[sizeof "GNU"]);
+-  size = (size + 3) & -(bfd_size_type) 4;
+-
+-  if (!strcmp (style, "md5") || !strcmp (style, "uuid"))
+-    size += 128 / 8;
+-  else if (!strcmp (style, "sha1"))
+-    size += 160 / 8;
+-  else if (!strncmp (style, "0x", 2))
+-    {
+-      /* ID is in string form (hex).  Convert to bits.  */
+-      const char *id = style + 2;
+-      do
+-	{
+-	  if (ISXDIGIT (id[0]) && ISXDIGIT (id[1]))
+-	    {
+-	      ++size;
+-	      id += 2;
+-	    }
+-	  else if (*id == '-' || *id == ':')
+-	    ++id;
+-	  else
+-	    {
+-	      size = 0;
+-	      break;
+-	    }
+-	} while (*id != '\0');
+-    }
+-  else
+-    size = 0;
+-
+-  return size;
+-}
+-
+-static unsigned char
+-read_hex (const char xdigit)
+-{
+-  if (ISDIGIT (xdigit))
+-    return xdigit - '0';
+-  if (ISUPPER (xdigit))
+-    return xdigit - 'A' + 0xa;
+-  if (ISLOWER (xdigit))
+-    return xdigit - 'a' + 0xa;
+-  abort ();
+-  return 0;
+-}
+-
+-static bfd_boolean
+-write_build_id (bfd *abfd)
+-{
+-  const struct elf_backend_data *bed = get_elf_backend_data (abfd);
+-  struct elf_obj_tdata *t = elf_tdata (abfd);
+-  const char *style;
+-  asection *asec;
+-  Elf_Internal_Shdr *i_shdr;
+-  unsigned char *contents, *id_bits;
+-  bfd_size_type size;
+-  file_ptr position;
+-  Elf_External_Note *e_note;
+-  typedef void (*sum_fn) (const void *, size_t, void *);
+-
+-  style = t->o->build_id.style;
+-  asec = t->o->build_id.sec;
+-  if (bfd_is_abs_section (asec->output_section))
+-    {
+-      einfo (_("%P: warning: .note.gnu.build-id section discarded,"
+-	       " --build-id ignored.\n"));
+-      return TRUE;
+-    }
+-  i_shdr = &elf_section_data (asec->output_section)->this_hdr;
+-
+-  if (i_shdr->contents == NULL)
+-    {
+-      if (asec->contents == NULL)
+-	asec->contents = (unsigned char *) xmalloc (asec->size);
+-      contents = asec->contents;
+-    }
+-  else
+-    contents = i_shdr->contents + asec->output_offset;
+-
+-  e_note = (Elf_External_Note *) contents;
+-  size = offsetof (Elf_External_Note, name[sizeof "GNU"]);
+-  size = (size + 3) & -(bfd_size_type) 4;
+-  id_bits = contents + size;
+-  size = asec->size - size;
+-
+-  bfd_h_put_32 (abfd, sizeof "GNU", &e_note->namesz);
+-  bfd_h_put_32 (abfd, size, &e_note->descsz);
+-  bfd_h_put_32 (abfd, NT_GNU_BUILD_ID, &e_note->type);
+-  memcpy (e_note->name, "GNU", sizeof "GNU");
+-
+-  if (strcmp (style, "md5") == 0)
+-    {
+-      struct md5_ctx ctx;
+-
+-      md5_init_ctx (&ctx);
+-      if (!bed->s->checksum_contents (abfd, (sum_fn) &md5_process_bytes, &ctx))
+-	return FALSE;
+-      md5_finish_ctx (&ctx, id_bits);
+-    }
+-  else if (strcmp (style, "sha1") == 0)
+-    {
+-      struct sha1_ctx ctx;
+-
+-      sha1_init_ctx (&ctx);
+-      if (!bed->s->checksum_contents (abfd, (sum_fn) &sha1_process_bytes, &ctx))
+-	return FALSE;
+-      sha1_finish_ctx (&ctx, id_bits);
+-    }
+-  else if (strcmp (style, "uuid") == 0)
+-    {
+-      int n;
+-      int fd = open ("/dev/urandom", O_RDONLY);
+-      if (fd < 0)
+-	return FALSE;
+-      n = read (fd, id_bits, size);
+-      close (fd);
+-      if (n < (int) size)
+-	return FALSE;
+-    }
+-  else if (strncmp (style, "0x", 2) == 0)
+-    {
+-      /* ID is in string form (hex).  Convert to bits.  */
+-      const char *id = style + 2;
+-      size_t n = 0;
+-      do
+-	{
+-	  if (ISXDIGIT (id[0]) && ISXDIGIT (id[1]))
+-	    {
+-	      id_bits[n] = read_hex (*id++) << 4;
+-	      id_bits[n++] |= read_hex (*id++);
+-	    }
+-	  else if (*id == '-' || *id == ':')
+-	    ++id;
+-	  else
+-	    abort ();		/* Should have been validated earlier.  */
+-	} while (*id != '\0');
+-    }
+-  else
+-    abort ();			/* Should have been validated earlier.  */
+-
+-  position = i_shdr->sh_offset + asec->output_offset;
+-  size = asec->size;
+-  return (bfd_seek (abfd, position, SEEK_SET) == 0
+-	  && bfd_bwrite (contents, size, abfd) == size);
+-}
+-
+-/* Make .note.gnu.build-id section, and set up elf_tdata->build_id.  */
+-
+-static bfd_boolean
+-setup_build_id (bfd *ibfd)
+-{
+-  asection *s;
+-  bfd_size_type size;
+-  flagword flags;
+-
+-  size = id_note_section_size (ibfd);
+-  if (size == 0)
+-    {
+-      einfo ("%P: warning: unrecognized --build-id style ignored.\n");
+-      return FALSE;
+-    }
+-
+-  flags = (SEC_ALLOC | SEC_LOAD | SEC_IN_MEMORY
+-	   | SEC_LINKER_CREATED | SEC_READONLY | SEC_DATA);
+-  s = bfd_make_section_with_flags (ibfd, ".note.gnu.build-id", flags);
+-  if (s != NULL && bfd_set_section_alignment (ibfd, s, 2))
+-    {
+-      struct elf_obj_tdata *t = elf_tdata (link_info.output_bfd);
+-      t->o->build_id.after_write_object_contents = &write_build_id;
+-      t->o->build_id.style = emit_note_gnu_build_id;
+-      t->o->build_id.sec = s;
+-      elf_section_type (s) = SHT_NOTE;
+-      s->size = size;
+-      return TRUE;
+-    }
+-
+-  einfo ("%P: warning: Cannot create .note.gnu.build-id section,"
+-	 " --build-id ignored.\n");
+-  return FALSE;
+-}
+-
+-/* This is called after all the input files have been opened.  */
+-
+-static void
+-gld${EMULATION_NAME}_after_open (void)
+-{
+-  struct bfd_link_needed_list *needed, *l;
+-  struct elf_link_hash_table *htab;
+-
+-  after_open_default ();
+-
+-  htab = elf_hash_table (&link_info);
+-  if (!is_elf_hash_table (htab))
+-    return;
+-
+-  if (emit_note_gnu_build_id != NULL)
+-    {
+-      bfd *abfd;
+-
+-      /* Find an ELF input.  */
+-      for (abfd = link_info.input_bfds;
+-	   abfd != (bfd *) NULL; abfd = abfd->link_next)
+-	if (bfd_get_flavour (abfd) == bfd_target_elf_flavour)
+-	  break;
+-
+-      /* PR 10555: If there are no ELF input files do not try to
+-	 create a .note.gnu-build-id section.  */
+-      if (abfd == NULL
+-	  || !setup_build_id (abfd))
+-	{
+-	  free ((char *) emit_note_gnu_build_id);
+-	  emit_note_gnu_build_id = NULL;
+-	}
+-    }
+-
+-  if (link_info.relocatable)
+-    return;
+-
+-  if (link_info.eh_frame_hdr
+-      && !link_info.traditional_format)
+-    {
+-      bfd *abfd, *elfbfd = NULL;
+-      bfd_boolean warn_eh_frame = FALSE;
+-      asection *s;
+-
+-      for (abfd = link_info.input_bfds; abfd; abfd = abfd->link_next)
+-	{
+-	  if (bfd_get_flavour (abfd) == bfd_target_elf_flavour)
+-	    elfbfd = abfd;
+-	  if (!warn_eh_frame)
+-	    {
+-	      s = bfd_get_section_by_name (abfd, ".eh_frame");
+-	      while (s != NULL
+-		     && (s->size <= 8
+-			 || bfd_is_abs_section (s->output_section)))
+-		s = bfd_get_next_section_by_name (s);
+-	      warn_eh_frame = s != NULL;
+-	    }
+-	  if (elfbfd && warn_eh_frame)
+-	    break;
+-	}
+-      if (elfbfd)
+-	{
+-	  const struct elf_backend_data *bed;
+-
+-	  bed = get_elf_backend_data (elfbfd);
+-	  s = bfd_make_section_with_flags (elfbfd, ".eh_frame_hdr",
+-					   bed->dynamic_sec_flags
+-					   | SEC_READONLY);
+-	  if (s != NULL
+-	      && bfd_set_section_alignment (elfbfd, s, 2))
+-	    {
+-	      htab->eh_info.hdr_sec = s;
+-	      warn_eh_frame = FALSE;
+-	    }
+-	}
+-      if (warn_eh_frame)
+-	einfo ("%P: warning: Cannot create .eh_frame_hdr section,"
+-	       " --eh-frame-hdr ignored.\n");
+-    }
+-
+-  /* Get the list of files which appear in DT_NEEDED entries in
+-     dynamic objects included in the link (often there will be none).
+-     For each such file, we want to track down the corresponding
+-     library, and include the symbol table in the link.  This is what
+-     the runtime dynamic linker will do.  Tracking the files down here
+-     permits one dynamic object to include another without requiring
+-     special action by the person doing the link.  Note that the
+-     needed list can actually grow while we are stepping through this
+-     loop.  */
+-  needed = bfd_elf_get_needed_list (link_info.output_bfd, &link_info);
+-  for (l = needed; l != NULL; l = l->next)
+-    {
+-      struct bfd_link_needed_list *ll;
+-      struct dt_needed n, nn;
+-      int force;
+-
+-      /* If the lib that needs this one was --as-needed and wasn't
+-	 found to be needed, then this lib isn't needed either.  */
+-      if (l->by != NULL
+-	  && (bfd_elf_get_dyn_lib_class (l->by) & DYN_AS_NEEDED) != 0)
+-	continue;
+-
+-      /* Skip the lib if --no-copy-dt-needed-entries and
+-	 --allow-shlib-undefined is in effect.  */
+-      if (l->by != NULL
+-	  && link_info.unresolved_syms_in_shared_libs == RM_IGNORE
+-	  && (bfd_elf_get_dyn_lib_class (l->by) & DYN_NO_ADD_NEEDED) != 0)
+-	continue;
+-
+-      /* If we've already seen this file, skip it.  */
+-      for (ll = needed; ll != l; ll = ll->next)
+-	if ((ll->by == NULL
+-	     || (bfd_elf_get_dyn_lib_class (ll->by) & DYN_AS_NEEDED) == 0)
+-	    && strcmp (ll->name, l->name) == 0)
+-	  break;
+-      if (ll != l)
+-	continue;
+-
+-      /* See if this file was included in the link explicitly.  */
+-      global_needed = l;
+-      global_found = NULL;
+-      lang_for_each_input_file (gld${EMULATION_NAME}_check_needed);
+-      if (global_found != NULL
+-	  && (bfd_elf_get_dyn_lib_class (global_found->the_bfd)
+-	      & DYN_AS_NEEDED) == 0)
+-	continue;
+-
+-      n.by = l->by;
+-      n.name = l->name;
+-      nn.by = l->by;
+-      if (verbose)
+-	info_msg (_("%s needed by %B\n"), l->name, l->by);
+-
+-      /* As-needed libs specified on the command line (or linker script)
+-	 take priority over libs found in search dirs.  */
+-      if (global_found != NULL)
+-	{
+-	  nn.name = global_found->filename;
+-	  if (gld${EMULATION_NAME}_try_needed (&nn, TRUE))
+-	    continue;
+-	}
+-
+-      /* We need to find this file and include the symbol table.  We
+-	 want to search for the file in the same way that the dynamic
+-	 linker will search.  That means that we want to use
+-	 rpath_link, rpath, then the environment variable
+-	 LD_LIBRARY_PATH (native only), then the DT_RPATH/DT_RUNPATH
+-	 entries (native only), then the linker script LIB_SEARCH_DIRS.
+-	 We do not search using the -L arguments.
+-
+-	 We search twice.  The first time, we skip objects which may
+-	 introduce version mismatches.  The second time, we force
+-	 their use.  See gld${EMULATION_NAME}_vercheck comment.  */
+-      for (force = 0; force < 2; force++)
+-	{
+-	  size_t len;
+-	  search_dirs_type *search;
+-EOF
+-if [ "x${NATIVE}" = xyes ] ; then
+-fragment <<EOF
+-	  const char *lib_path;
+-EOF
+-fi
+-if [ "x${USE_LIBPATH}" = xyes ] ; then
+-fragment <<EOF
+-	  struct bfd_link_needed_list *rp;
+-	  int found;
+-EOF
+-fi
+-fragment <<EOF
+-
+-	  if (gld${EMULATION_NAME}_search_needed (command_line.rpath_link,
+-						  &n, force))
+-	    break;
+-EOF
+-if [ "x${USE_LIBPATH}" = xyes ] ; then
+-fragment <<EOF
+-	  if (gld${EMULATION_NAME}_search_needed (command_line.rpath,
+-						  &n, force))
+-	    break;
+-EOF
+-fi
+-if [ "x${NATIVE}" = xyes ] ; then
+-fragment <<EOF
+-	  if (command_line.rpath_link == NULL
+-	      && command_line.rpath == NULL)
+-	    {
+-	      lib_path = (const char *) getenv ("LD_RUN_PATH");
+-	      if (gld${EMULATION_NAME}_search_needed (lib_path, &n,
+-						      force))
+-		break;
+-	    }
+-	  lib_path = (const char *) getenv ("LD_LIBRARY_PATH");
+-	  if (gld${EMULATION_NAME}_search_needed (lib_path, &n, force))
+-	    break;
+-EOF
+-fi
+-if [ "x${USE_LIBPATH}" = xyes ] ; then
+-fragment <<EOF
+-	  found = 0;
+-	  rp = bfd_elf_get_runpath_list (link_info.output_bfd, &link_info);
+-	  for (; !found && rp != NULL; rp = rp->next)
+-	    {
+-	      char *tmpname = gld${EMULATION_NAME}_add_sysroot (rp->name);
+-	      found = (rp->by == l->by
+-		       && gld${EMULATION_NAME}_search_needed (tmpname,
+-							      &n,
+-							      force));
+-	      free (tmpname);
+-	    }
+-	  if (found)
+-	    break;
+-
+-EOF
+-fi
+-if [ "x${USE_LIBPATH}" = xyes ] ; then
+-  case ${target} in
+-    *-*-freebsd* | *-*-dragonfly*)
+-      fragment <<EOF
+-	  if (gld${EMULATION_NAME}_check_ld_elf_hints (l, force))
+-	    break;
+-EOF
+-    # FreeBSD
+-    ;;
+-
+-    *-*-linux-* | *-*-k*bsd*-* | *-*-gnu*)
+-      fragment <<EOF
+-	  if (gld${EMULATION_NAME}_check_ld_so_conf (l, force))
+-	    break;
+-
+-EOF
+-    # Linux
+-    ;;
+-  esac
+-fi
+-fragment <<EOF
+-	  len = strlen (l->name);
+-	  for (search = search_head; search != NULL; search = search->next)
+-	    {
+-	      char *filename;
+-
+-	      if (search->cmdline)
+-		continue;
+-	      filename = (char *) xmalloc (strlen (search->name) + len + 2);
+-	      sprintf (filename, "%s/%s", search->name, l->name);
+-	      nn.name = filename;
+-	      if (gld${EMULATION_NAME}_try_needed (&nn, force))
+-		break;
+-	      free (filename);
+-	    }
+-	  if (search != NULL)
+-	    break;
+-EOF
+-fragment <<EOF
+-	}
+-
+-      if (force < 2)
+-	continue;
+-
+-      einfo ("%P: warning: %s, needed by %B, not found (try using -rpath or -rpath-link)\n",
+-	     l->name, l->by);
+-    }
+-}
+-
+-EOF
+-fi
+-
+-fragment <<EOF
+-
+-/* Look through an expression for an assignment statement.  */
+-
+-static void
+-gld${EMULATION_NAME}_find_exp_assignment (etree_type *exp)
+-{
+-  bfd_boolean provide = FALSE;
+-
+-  switch (exp->type.node_class)
+-    {
+-    case etree_provide:
+-    case etree_provided:
+-      provide = TRUE;
+-      /* Fall thru */
+-    case etree_assign:
+-      /* We call record_link_assignment even if the symbol is defined.
+-	 This is because if it is defined by a dynamic object, we
+-	 actually want to use the value defined by the linker script,
+-	 not the value from the dynamic object (because we are setting
+-	 symbols like etext).  If the symbol is defined by a regular
+-	 object, then, as it happens, calling record_link_assignment
+-	 will do no harm.  */
+-      if (strcmp (exp->assign.dst, ".") != 0)
+-	{
+-	  if (!bfd_elf_record_link_assignment (link_info.output_bfd,
+-					       &link_info,
+-					       exp->assign.dst, provide,
+-					       exp->assign.hidden))
+-	    einfo ("%P%F: failed to record assignment to %s: %E\n",
+-		   exp->assign.dst);
+-	}
+-      gld${EMULATION_NAME}_find_exp_assignment (exp->assign.src);
+-      break;
+-
+-    case etree_binary:
+-      gld${EMULATION_NAME}_find_exp_assignment (exp->binary.lhs);
+-      gld${EMULATION_NAME}_find_exp_assignment (exp->binary.rhs);
+-      break;
+-
+-    case etree_trinary:
+-      gld${EMULATION_NAME}_find_exp_assignment (exp->trinary.cond);
+-      gld${EMULATION_NAME}_find_exp_assignment (exp->trinary.lhs);
+-      gld${EMULATION_NAME}_find_exp_assignment (exp->trinary.rhs);
+-      break;
+-
+-    case etree_unary:
+-      gld${EMULATION_NAME}_find_exp_assignment (exp->unary.child);
+-      break;
+-
+-    default:
+-      break;
+-    }
+-}
+-
+-
+-/* This is called by the before_allocation routine via
+-   lang_for_each_statement.  It locates any assignment statements, and
+-   tells the ELF backend about them, in case they are assignments to
+-   symbols which are referred to by dynamic objects.  */
+-
+-static void
+-gld${EMULATION_NAME}_find_statement_assignment (lang_statement_union_type *s)
+-{
+-  if (s->header.type == lang_assignment_statement_enum)
+-    gld${EMULATION_NAME}_find_exp_assignment (s->assignment_statement.exp);
+-}
+-
+-EOF
+-
+-if test x"$LDEMUL_BEFORE_ALLOCATION" != xgld"$EMULATION_NAME"_before_allocation; then
+-  if test x"${ELF_INTERPRETER_NAME+set}" = xset; then
+-    ELF_INTERPRETER_SET_DEFAULT="
+-  if (sinterp != NULL)
+-    {
+-      sinterp->contents = (unsigned char *) ${ELF_INTERPRETER_NAME};
+-      sinterp->size = strlen ((char *) sinterp->contents) + 1;
+-    }
+-
+-"
+-  else
+-    ELF_INTERPRETER_SET_DEFAULT=
+-  fi
+-fragment <<EOF
+-
+-/* used by before_allocation and handle_option. */
+-static void
+-gld${EMULATION_NAME}_append_to_separated_string (char **to, char *op_arg)
+-{
+-  if (*to == NULL)
+-    *to = xstrdup (op_arg);
+-  else
+-    {
+-      size_t to_len = strlen (*to);
+-      size_t op_arg_len = strlen (op_arg);
+-      char *buf;
+-      char *cp = *to;
+-
+-      /* First see whether OPTARG is already in the path.  */
+-      do
+-	{
+-	  if (strncmp (op_arg, cp, op_arg_len) == 0
+-	      && (cp[op_arg_len] == 0
+-		  || cp[op_arg_len] == config.rpath_separator))
+-	    /* We found it.  */
+-	    break;
+-
+-	  /* Not yet found.  */
+-	  cp = strchr (cp, config.rpath_separator);
+-	  if (cp != NULL)
+-	    ++cp;
+-	}
+-      while (cp != NULL);
+-
+-      if (cp == NULL)
+-	{
+-	  buf = xmalloc (to_len + op_arg_len + 2);
+-	  sprintf (buf, "%s%c%s", *to,
+-		   config.rpath_separator, op_arg);
+-	  free (*to);
+-	  *to = buf;
+-	}
+-    }
+-}
+-
+-/* This is called after the sections have been attached to output
+-   sections, but before any sizes or addresses have been set.  */
+-
+-static void
+-gld${EMULATION_NAME}_before_allocation (void)
+-{
+-  const char *rpath;
+-  asection *sinterp;
+-  bfd *abfd;
+-
+-  if (is_elf_hash_table (link_info.hash))
+-    {
+-      _bfd_elf_tls_setup (link_info.output_bfd, &link_info);
+-
+-      /* Make __ehdr_start hidden if it has been referenced, to
+-	 prevent the symbol from being dynamic.  */
+-      if (!link_info.relocatable)
+-       {
+-         struct elf_link_hash_entry *h
+-           = elf_link_hash_lookup (elf_hash_table (&link_info), "__ehdr_start",
+-                                   FALSE, FALSE, TRUE);
+-
+-         /* Only adjust the export class if the symbol was referenced
+-            and not defined, otherwise leave it alone.  */
+-         if (h != NULL
+-             && (h->root.type == bfd_link_hash_new
+-                 || h->root.type == bfd_link_hash_undefined
+-                 || h->root.type == bfd_link_hash_undefweak
+-                 || h->root.type == bfd_link_hash_common))
+-           {
+-             _bfd_elf_link_hash_hide_symbol (&link_info, h, TRUE);
+-             if (ELF_ST_VISIBILITY (h->other) != STV_INTERNAL)
+-               h->other = (h->other & ~ELF_ST_VISIBILITY (-1)) | STV_HIDDEN;
+-           }
+-       }
+-
+-      /* If we are going to make any variable assignments, we need to
+-	 let the ELF backend know about them in case the variables are
+-	 referred to by dynamic objects.  */
+-      lang_for_each_statement (gld${EMULATION_NAME}_find_statement_assignment);
+-    }
+-
+-  /* Let the ELF backend work out the sizes of any sections required
+-     by dynamic linking.  */
+-  rpath = command_line.rpath;
+-  if (rpath == NULL)
+-    rpath = (const char *) getenv ("LD_RUN_PATH");
+-
+-  for (abfd = link_info.input_bfds; abfd; abfd = abfd->link_next)
+-    if (bfd_get_flavour (abfd) == bfd_target_elf_flavour)
+-      {
+-	const char *audit_libs = elf_dt_audit (abfd);
+-
+-	/* If the input bfd contains an audit entry, we need to add it as
+-	   a dep audit entry.  */
+-	if (audit_libs && *audit_libs != '\0')
+-	  {
+-	    char *cp = xstrdup (audit_libs);
+-	    do
+-	      {
+-		int more = 0;
+-		char *cp2 = strchr (cp, config.rpath_separator);
+-
+-		if (cp2)
+-		  {
+-		    *cp2 = '\0';
+-		    more = 1;
+-		  }
+-
+-		if (cp != NULL && *cp != '\0')
+-		  gld${EMULATION_NAME}_append_to_separated_string (&depaudit, cp);
+-
+-		cp = more ? ++cp2 : NULL;
+-	      }
+-	    while (cp != NULL);
+-	  }
+-      }
+-
+-  if (! (bfd_elf_size_dynamic_sections
+-	 (link_info.output_bfd, command_line.soname, rpath,
+-	  command_line.filter_shlib, audit, depaudit,
+-	  (const char * const *) command_line.auxiliary_filters,
+-	  &link_info, &sinterp)))
+-    einfo ("%P%F: failed to set dynamic section sizes: %E\n");
+-
+-${ELF_INTERPRETER_SET_DEFAULT}
+-  /* Let the user override the dynamic linker we are using.  */
+-  if (command_line.interpreter != NULL
+-      && sinterp != NULL)
+-    {
+-      sinterp->contents = (bfd_byte *) command_line.interpreter;
+-      sinterp->size = strlen (command_line.interpreter) + 1;
+-    }
+-
+-  /* Look for any sections named .gnu.warning.  As a GNU extensions,
+-     we treat such sections as containing warning messages.  We print
+-     out the warning message, and then zero out the section size so
+-     that it does not get copied into the output file.  */
+-
+-  {
+-    LANG_FOR_EACH_INPUT_STATEMENT (is)
+-      {
+-	asection *s;
+-	bfd_size_type sz;
+-	char *msg;
+-	bfd_boolean ret;
+-
+-	if (is->flags.just_syms)
+-	  continue;
+-
+-	s = bfd_get_section_by_name (is->the_bfd, ".gnu.warning");
+-	if (s == NULL)
+-	  continue;
+-
+-	sz = s->size;
+-	msg = (char *) xmalloc ((size_t) (sz + 1));
+-	if (! bfd_get_section_contents (is->the_bfd, s,	msg,
+-					(file_ptr) 0, sz))
+-	  einfo ("%F%B: Can't read contents of section .gnu.warning: %E\n",
+-		 is->the_bfd);
+-	msg[sz] = '\0';
+-	ret = link_info.callbacks->warning (&link_info, msg,
+-					    (const char *) NULL,
+-					    is->the_bfd, (asection *) NULL,
+-					    (bfd_vma) 0);
+-	ASSERT (ret);
+-	free (msg);
+-
+-	/* Clobber the section size, so that we don't waste space
+-	   copying the warning into the output file.  If we've already
+-	   sized the output section, adjust its size.  The adjustment
+-	   is on rawsize because targets that size sections early will
+-	   have called lang_reset_memory_regions after sizing.  */
+-	if (s->output_section != NULL
+-	    && s->output_section->rawsize >= s->size)
+-	  s->output_section->rawsize -= s->size;
+-
+-	s->size = 0;
+-
+-	/* Also set SEC_EXCLUDE, so that local symbols defined in the
+-	   warning section don't get copied to the output.  */
+-	s->flags |= SEC_EXCLUDE | SEC_KEEP;
+-      }
+-  }
+-
+-  before_allocation_default ();
+-
+-  if (!bfd_elf_size_dynsym_hash_dynstr (link_info.output_bfd, &link_info))
+-    einfo ("%P%F: failed to set dynamic section sizes: %E\n");
+-}
+-
+-EOF
+-fi
+-
+-if test x"$LDEMUL_OPEN_DYNAMIC_ARCHIVE" != xgld"$EMULATION_NAME"_open_dynamic_archive; then
+-fragment <<EOF
+-
+-/* Try to open a dynamic archive.  This is where we know that ELF
+-   dynamic libraries have an extension of .so (or .sl on oddball systems
+-   like hpux).  */
+-
+-static bfd_boolean
+-gld${EMULATION_NAME}_open_dynamic_archive
+-  (const char *arch, search_dirs_type *search, lang_input_statement_type *entry)
+-{
+-  const char *filename;
+-  char *string;
+-
+-  if (! entry->flags.maybe_archive)
+-    return FALSE;
+-
+-  filename = entry->filename;
+-
+-  /* This allocates a few bytes too many when EXTRA_SHLIB_EXTENSION
+-     is defined, but it does not seem worth the headache to optimize
+-     away those two bytes of space.  */
+-  string = (char *) xmalloc (strlen (search->name)
+-			     + strlen (filename)
+-			     + strlen (arch)
+-#ifdef EXTRA_SHLIB_EXTENSION
+-			     + strlen (EXTRA_SHLIB_EXTENSION)
+-#endif
+-			     + sizeof "/lib.so");
+-
+-  sprintf (string, "%s/lib%s%s.so", search->name, filename, arch);
+-
+-#ifdef EXTRA_SHLIB_EXTENSION
+-  /* Try the .so extension first.  If that fails build a new filename
+-     using EXTRA_SHLIB_EXTENSION.  */
+-  if (! ldfile_try_open_bfd (string, entry))
+-    {
+-      sprintf (string, "%s/lib%s%s%s", search->name,
+-	       filename, arch, EXTRA_SHLIB_EXTENSION);
+-#endif
+-
+-  if (! ldfile_try_open_bfd (string, entry))
+-    {
+-      free (string);
+-      return FALSE;
+-    }
+-#ifdef EXTRA_SHLIB_EXTENSION
+-    }
+-#endif
+-
+-  entry->filename = string;
+-
+-  /* We have found a dynamic object to include in the link.  The ELF
+-     backend linker will create a DT_NEEDED entry in the .dynamic
+-     section naming this file.  If this file includes a DT_SONAME
+-     entry, it will be used.  Otherwise, the ELF linker will just use
+-     the name of the file.  For an archive found by searching, like
+-     this one, the DT_NEEDED entry should consist of just the name of
+-     the file, without the path information used to find it.  Note
+-     that we only need to do this if we have a dynamic object; an
+-     archive will never be referenced by a DT_NEEDED entry.
+-
+-     FIXME: This approach--using bfd_elf_set_dt_needed_name--is not
+-     very pretty.  I haven't been able to think of anything that is
+-     pretty, though.  */
+-  if (bfd_check_format (entry->the_bfd, bfd_object)
+-      && (entry->the_bfd->flags & DYNAMIC) != 0)
+-    {
+-      ASSERT (entry->flags.maybe_archive && entry->flags.search_dirs);
+-
+-      /* Rather than duplicating the logic above.  Just use the
+-	 filename we recorded earlier.  */
+-
+-      filename = lbasename (entry->filename);
+-      bfd_elf_set_dt_needed_name (entry->the_bfd, filename);
+-    }
+-
+-  return TRUE;
+-}
+-
+-EOF
+-fi
+-
+-if test x"$LDEMUL_PLACE_ORPHAN" != xgld"$EMULATION_NAME"_place_orphan; then
+-fragment <<EOF
+-
+-/* A variant of lang_output_section_find used by place_orphan.  */
+-
+-static lang_output_section_statement_type *
+-output_rel_find (asection *sec, int isdyn)
+-{
+-  lang_output_section_statement_type *lookup;
+-  lang_output_section_statement_type *last = NULL;
+-  lang_output_section_statement_type *last_alloc = NULL;
+-  lang_output_section_statement_type *last_ro_alloc = NULL;
+-  lang_output_section_statement_type *last_rel = NULL;
+-  lang_output_section_statement_type *last_rel_alloc = NULL;
+-  int rela = sec->name[4] == 'a';
+-
+-  for (lookup = &lang_output_section_statement.head->output_section_statement;
+-       lookup != NULL;
+-       lookup = lookup->next)
+-    {
+-      if (lookup->constraint >= 0
+-	  && CONST_STRNEQ (lookup->name, ".rel"))
+-	{
+-	  int lookrela = lookup->name[4] == 'a';
+-
+-	  /* .rel.dyn must come before all other reloc sections, to suit
+-	     GNU ld.so.  */
+-	  if (isdyn)
+-	    break;
+-
+-	  /* Don't place after .rel.plt as doing so results in wrong
+-	     dynamic tags.  */
+-	  if (strcmp (".plt", lookup->name + 4 + lookrela) == 0)
+-	    break;
+-
+-	  if (rela == lookrela || last_rel == NULL)
+-	    last_rel = lookup;
+-	  if ((rela == lookrela || last_rel_alloc == NULL)
+-	      && lookup->bfd_section != NULL
+-	      && (lookup->bfd_section->flags & SEC_ALLOC) != 0)
+-	    last_rel_alloc = lookup;
+-	}
+-
+-      last = lookup;
+-      if (lookup->bfd_section != NULL
+-	  && (lookup->bfd_section->flags & SEC_ALLOC) != 0)
+-	{
+-	  last_alloc = lookup;
+-	  if ((lookup->bfd_section->flags & SEC_READONLY) != 0)
+-	    last_ro_alloc = lookup;
+-	}
+-    }
+-
+-  if (last_rel_alloc)
+-    return last_rel_alloc;
+-
+-  if (last_rel)
+-    return last_rel;
+-
+-  if (last_ro_alloc)
+-    return last_ro_alloc;
+-
+-  if (last_alloc)
+-    return last_alloc;
+-
+-  return last;
+-}
+-
+-/* Place an orphan section.  We use this to put random SHF_ALLOC
+-   sections in the right segment.  */
+-
+-static lang_output_section_statement_type *
+-gld${EMULATION_NAME}_place_orphan (asection *s,
+-				   const char *secname,
+-				   int constraint)
+-{
+-  static struct orphan_save hold[] =
+-    {
+-      { ".text",
+-	SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_READONLY | SEC_CODE,
+-	0, 0, 0, 0 },
+-      { ".rodata",
+-	SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_READONLY | SEC_DATA,
+-	0, 0, 0, 0 },
+-      { ".data",
+-	SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_DATA,
+-	0, 0, 0, 0 },
+-      { ".bss",
+-	SEC_ALLOC,
+-	0, 0, 0, 0 },
+-      { 0,
+-	SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_READONLY | SEC_DATA,
+-	0, 0, 0, 0 },
+-      { ".interp",
+-	SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_READONLY | SEC_DATA,
+-	0, 0, 0, 0 },
+-      { ".sdata",
+-	SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_DATA | SEC_SMALL_DATA,
+-	0, 0, 0, 0 },
+-      { ".comment",
+-	SEC_HAS_CONTENTS,
+-	0, 0, 0, 0 },
+-    };
+-  enum orphan_save_index
+-    {
+-      orphan_text = 0,
+-      orphan_rodata,
+-      orphan_data,
+-      orphan_bss,
+-      orphan_rel,
+-      orphan_interp,
+-      orphan_sdata,
+-      orphan_nonalloc
+-    };
+-  static int orphan_init_done = 0;
+-  struct orphan_save *place;
+-  lang_output_section_statement_type *after;
+-  lang_output_section_statement_type *os;
+-  lang_output_section_statement_type *match_by_name = NULL;
+-  int isdyn = 0;
+-  int iself = s->owner->xvec->flavour == bfd_target_elf_flavour;
+-  unsigned int sh_type = iself ? elf_section_type (s) : SHT_NULL;
+-
+-  if (! link_info.relocatable
+-      && link_info.combreloc
+-      && (s->flags & SEC_ALLOC))
+-    {
+-      if (iself)
+-	switch (sh_type)
+-	  {
+-	  case SHT_RELA:
+-	    secname = ".rela.dyn";
+-	    isdyn = 1;
+-	    break;
+-	  case SHT_REL:
+-	    secname = ".rel.dyn";
+-	    isdyn = 1;
+-	    break;
+-	  default:
+-	    break;
+-	  }
+-      else if (CONST_STRNEQ (secname, ".rel"))
+-	{
+-	  secname = secname[4] == 'a' ? ".rela.dyn" : ".rel.dyn";
+-	  isdyn = 1;
+-	}
+-    }
+-
+-  /* Look through the script to see where to place this section.  */
+-  if (constraint == 0)
+-    for (os = lang_output_section_find (secname);
+-	 os != NULL;
+-	 os = next_matching_output_section_statement (os, 0))
+-      {
+-	/* If we don't match an existing output section, tell
+-	   lang_insert_orphan to create a new output section.  */
+-	constraint = SPECIAL;
+-
+-	if (os->bfd_section != NULL
+-	    && (os->bfd_section->flags == 0
+-		|| (_bfd_elf_match_sections_by_type (link_info.output_bfd,
+-						     os->bfd_section,
+-						     s->owner, s)
+-		    && ((s->flags ^ os->bfd_section->flags)
+-			& (SEC_LOAD | SEC_ALLOC)) == 0)))
+-	  {
+-	    /* We already have an output section statement with this
+-	       name, and its bfd section has compatible flags.
+-	       If the section already exists but does not have any flags
+-	       set, then it has been created by the linker, probably as a
+-	       result of a --section-start command line switch.  */
+-	    lang_add_section (&os->children, s, NULL, os);
+-	    return os;
+-	  }
+-
+-	/* Save unused output sections in case we can match them
+-	   against orphans later.  */
+-	if (os->bfd_section == NULL)
+-	  match_by_name = os;
+-      }
+-
+-  /* If we didn't match an active output section, see if we matched an
+-     unused one and use that.  */
+-  if (match_by_name)
+-    {
+-      lang_add_section (&match_by_name->children, s, NULL, match_by_name);
+-      return match_by_name;
+-    }
+-
+-  if (!orphan_init_done)
+-    {
+-      struct orphan_save *ho;
+-
+-      for (ho = hold; ho < hold + sizeof (hold) / sizeof (hold[0]); ++ho)
+-	if (ho->name != NULL)
+-	  {
+-	    ho->os = lang_output_section_find (ho->name);
+-	    if (ho->os != NULL && ho->os->flags == 0)
+-	      ho->os->flags = ho->flags;
+-	  }
+-      orphan_init_done = 1;
+-    }
+-
+-  /* If this is a final link, then always put .gnu.warning.SYMBOL
+-     sections into the .text section to get them out of the way.  */
+-  if (link_info.executable
+-      && ! link_info.relocatable
+-      && CONST_STRNEQ (s->name, ".gnu.warning.")
+-      && hold[orphan_text].os != NULL)
+-    {
+-      os = hold[orphan_text].os;
+-      lang_add_section (&os->children, s, NULL, os);
+-      return os;
+-    }
+-
+-  /* Decide which segment the section should go in based on the
+-     section name and section flags.  We put loadable .note sections
+-     right after the .interp section, so that the PT_NOTE segment is
+-     stored right after the program headers where the OS can read it
+-     in the first page.  */
+-
+-  place = NULL;
+-  if ((s->flags & (SEC_ALLOC | SEC_DEBUGGING)) == 0)
+-    place = &hold[orphan_nonalloc];
+-  else if ((s->flags & SEC_ALLOC) == 0)
+-    ;
+-  else if ((s->flags & SEC_LOAD) != 0
+-	   && ((iself && sh_type == SHT_NOTE)
+-	       || (!iself && CONST_STRNEQ (secname, ".note"))))
+-    place = &hold[orphan_interp];
+-  else if ((s->flags & (SEC_LOAD | SEC_HAS_CONTENTS | SEC_THREAD_LOCAL)) == 0)
+-    place = &hold[orphan_bss];
+-  else if ((s->flags & SEC_SMALL_DATA) != 0)
+-    place = &hold[orphan_sdata];
+-  else if ((s->flags & SEC_READONLY) == 0)
+-    place = &hold[orphan_data];
+-  else if (((iself && (sh_type == SHT_RELA || sh_type == SHT_REL))
+-	    || (!iself && CONST_STRNEQ (secname, ".rel")))
+-	   && (s->flags & SEC_LOAD) != 0)
+-    place = &hold[orphan_rel];
+-  else if ((s->flags & SEC_CODE) == 0)
+-    place = &hold[orphan_rodata];
+-  else
+-    place = &hold[orphan_text];
+-
+-  after = NULL;
+-  if (place != NULL)
+-    {
+-      if (place->os == NULL)
+-	{
+-	  if (place->name != NULL)
+-	    place->os = lang_output_section_find (place->name);
+-	  else
+-	    place->os = output_rel_find (s, isdyn);
+-	}
+-      after = place->os;
+-      if (after == NULL)
+-	after = lang_output_section_find_by_flags
+-	  (s, &place->os, _bfd_elf_match_sections_by_type);
+-      if (after == NULL)
+-	/* *ABS* is always the first output section statement.  */
+-	after = &lang_output_section_statement.head->output_section_statement;
+-    }
+-
+-  return lang_insert_orphan (s, secname, constraint, after, place, NULL, NULL);
+-}
+-EOF
+-fi
+-
+-if test x"$LDEMUL_AFTER_ALLOCATION" != xgld"$EMULATION_NAME"_after_allocation; then
+-fragment <<EOF
+-
+-static void
+-gld${EMULATION_NAME}_after_allocation (void)
+-{
+-  bfd_boolean need_layout = bfd_elf_discard_info (link_info.output_bfd,
+-						  &link_info);
+-  gld${EMULATION_NAME}_map_segments (need_layout);
+-}
+-EOF
+-fi
+-
+-if test x"$LDEMUL_GET_SCRIPT" != xgld"$EMULATION_NAME"_get_script; then
+-fragment <<EOF
+-
+-static char *
+-gld${EMULATION_NAME}_get_script (int *isfile)
+-EOF
+-
+-if test -n "$COMPILE_IN"
+-then
+-# Scripts compiled in.
+-
+-# sed commands to quote an ld script as a C string.
+-sc="-f stringify.sed"
+-
+-fragment <<EOF
+-{
+-  *isfile = 0;
+-
+-  if (link_info.relocatable && config.build_constructors)
+-    return
+-EOF
+-sed $sc ldscripts/${EMULATION_NAME}.xu			>> e${EMULATION_NAME}.c
+-echo '  ; else if (link_info.relocatable) return'	>> e${EMULATION_NAME}.c
+-sed $sc ldscripts/${EMULATION_NAME}.xr			>> e${EMULATION_NAME}.c
+-echo '  ; else if (!config.text_read_only) return'	>> e${EMULATION_NAME}.c
+-sed $sc ldscripts/${EMULATION_NAME}.xbn			>> e${EMULATION_NAME}.c
+-if cmp -s ldscripts/${EMULATION_NAME}.x ldscripts/${EMULATION_NAME}.xn; then : ; else
+-echo '  ; else if (!config.magic_demand_paged) return'	>> e${EMULATION_NAME}.c
+-sed $sc ldscripts/${EMULATION_NAME}.xn			>> e${EMULATION_NAME}.c
+-fi
+-if test -n "$GENERATE_PIE_SCRIPT" ; then
+-if test -n "$GENERATE_COMBRELOC_SCRIPT" ; then
+-echo '  ; else if (link_info.pie && link_info.combreloc' >> e${EMULATION_NAME}.c
+-echo '             && link_info.relro' >> e${EMULATION_NAME}.c
+-echo '             && (link_info.flags & DF_BIND_NOW)) return' >> e${EMULATION_NAME}.c
+-sed $sc ldscripts/${EMULATION_NAME}.xdw			>> e${EMULATION_NAME}.c
+-echo '  ; else if (link_info.pie && link_info.combreloc) return' >> e${EMULATION_NAME}.c
+-sed $sc ldscripts/${EMULATION_NAME}.xdc			>> e${EMULATION_NAME}.c
+-fi
+-echo '  ; else if (link_info.pie) return'		>> e${EMULATION_NAME}.c
+-sed $sc ldscripts/${EMULATION_NAME}.xd			>> e${EMULATION_NAME}.c
+-fi
+-if test -n "$GENERATE_SHLIB_SCRIPT" ; then
+-if test -n "$GENERATE_COMBRELOC_SCRIPT" ; then
+-echo '  ; else if (link_info.shared && link_info.combreloc' >> e${EMULATION_NAME}.c
+-echo '             && link_info.relro' >> e${EMULATION_NAME}.c
+-echo '             && (link_info.flags & DF_BIND_NOW)) return' >> e${EMULATION_NAME}.c
+-sed $sc ldscripts/${EMULATION_NAME}.xsw			>> e${EMULATION_NAME}.c
+-echo '  ; else if (link_info.shared && link_info.combreloc) return' >> e${EMULATION_NAME}.c
+-sed $sc ldscripts/${EMULATION_NAME}.xsc			>> e${EMULATION_NAME}.c
+-fi
+-echo '  ; else if (link_info.shared) return'		>> e${EMULATION_NAME}.c
+-sed $sc ldscripts/${EMULATION_NAME}.xs			>> e${EMULATION_NAME}.c
+-fi
+-if test -n "$GENERATE_COMBRELOC_SCRIPT" ; then
+-echo '  ; else if (link_info.combreloc && link_info.relro' >> e${EMULATION_NAME}.c
+-echo '             && (link_info.flags & DF_BIND_NOW)) return' >> e${EMULATION_NAME}.c
+-sed $sc ldscripts/${EMULATION_NAME}.xw			>> e${EMULATION_NAME}.c
+-echo '  ; else if (link_info.combreloc) return'		>> e${EMULATION_NAME}.c
+-sed $sc ldscripts/${EMULATION_NAME}.xc			>> e${EMULATION_NAME}.c
+-fi
+-echo '  ; else return'					>> e${EMULATION_NAME}.c
+-sed $sc ldscripts/${EMULATION_NAME}.x			>> e${EMULATION_NAME}.c
+-echo '; }'						>> e${EMULATION_NAME}.c
+-
+-else
+-# Scripts read from the filesystem.
+-
+-fragment <<EOF
+-{
+-  *isfile = 1;
+-
+-  if (link_info.relocatable && config.build_constructors)
+-    return "ldscripts/${EMULATION_NAME}.xu";
+-  else if (link_info.relocatable)
+-    return "ldscripts/${EMULATION_NAME}.xr";
+-  else if (!config.text_read_only)
+-    return "ldscripts/${EMULATION_NAME}.xbn";
+-EOF
+-if cmp -s ldscripts/${EMULATION_NAME}.x ldscripts/${EMULATION_NAME}.xn; then :
+-else
+-fragment <<EOF
+-  else if (!config.magic_demand_paged)
+-    return "ldscripts/${EMULATION_NAME}.xn";
+-EOF
+-fi
+-if test -n "$GENERATE_PIE_SCRIPT" ; then
+-if test -n "$GENERATE_COMBRELOC_SCRIPT" ; then
+-fragment <<EOF
+-  else if (link_info.pie && link_info.combreloc
+-	   && link_info.relro && (link_info.flags & DF_BIND_NOW))
+-    return "ldscripts/${EMULATION_NAME}.xdw";
+-  else if (link_info.pie && link_info.combreloc)
+-    return "ldscripts/${EMULATION_NAME}.xdc";
+-EOF
+-fi
+-fragment <<EOF
+-  else if (link_info.pie)
+-    return "ldscripts/${EMULATION_NAME}.xd";
+-EOF
+-fi
+-if test -n "$GENERATE_SHLIB_SCRIPT" ; then
+-if test -n "$GENERATE_COMBRELOC_SCRIPT" ; then
+-fragment <<EOF
+-  else if (link_info.shared && link_info.combreloc
+-	   && link_info.relro && (link_info.flags & DF_BIND_NOW))
+-    return "ldscripts/${EMULATION_NAME}.xsw";
+-  else if (link_info.shared && link_info.combreloc)
+-    return "ldscripts/${EMULATION_NAME}.xsc";
+-EOF
+-fi
+-fragment <<EOF
+-  else if (link_info.shared)
+-    return "ldscripts/${EMULATION_NAME}.xs";
+-EOF
+-fi
+-if test -n "$GENERATE_COMBRELOC_SCRIPT" ; then
+-fragment <<EOF
+-  else if (link_info.combreloc && link_info.relro
+-	   && (link_info.flags & DF_BIND_NOW))
+-    return "ldscripts/${EMULATION_NAME}.xw";
+-  else if (link_info.combreloc)
+-    return "ldscripts/${EMULATION_NAME}.xc";
+-EOF
+-fi
+-fragment <<EOF
+-  else
+-    return "ldscripts/${EMULATION_NAME}.x";
+-}
+-
+-EOF
+-fi
+-fi
+-
+-if test -n "$PARSE_AND_LIST_PROLOGUE" ; then
+-fragment <<EOF
+- $PARSE_AND_LIST_PROLOGUE
+-EOF
+-fi
+-
+-fragment <<EOF
+-
+-#define OPTION_DISABLE_NEW_DTAGS	(400)
+-#define OPTION_ENABLE_NEW_DTAGS		(OPTION_DISABLE_NEW_DTAGS + 1)
+-#define OPTION_GROUP			(OPTION_ENABLE_NEW_DTAGS + 1)
+-#define OPTION_EH_FRAME_HDR		(OPTION_GROUP + 1)
+-#define OPTION_EXCLUDE_LIBS		(OPTION_EH_FRAME_HDR + 1)
+-#define OPTION_HASH_STYLE		(OPTION_EXCLUDE_LIBS + 1)
+-#define OPTION_BUILD_ID			(OPTION_HASH_STYLE + 1)
+-#define OPTION_AUDIT			(OPTION_BUILD_ID + 1)
+-
+-static void
+-gld${EMULATION_NAME}_add_options
+-  (int ns, char **shortopts, int nl, struct option **longopts,
+-   int nrl ATTRIBUTE_UNUSED, struct option **really_longopts ATTRIBUTE_UNUSED)
+-{
+-EOF
+-if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
+-fragment <<EOF
+-  static const char xtra_short[] = "${PARSE_AND_LIST_SHORTOPTS}z:P:";
+-EOF
+-else
+-fragment <<EOF
+-  static const char xtra_short[] = "${PARSE_AND_LIST_SHORTOPTS}z:";
+-EOF
+-fi
+-fragment <<EOF
+-  static const struct option xtra_long[] = {
+-EOF
+-if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
+-fragment <<EOF
+-    {"audit", required_argument, NULL, OPTION_AUDIT},
+-    {"Bgroup", no_argument, NULL, OPTION_GROUP},
+-EOF
+-fi
+-fragment <<EOF
+-    {"build-id", optional_argument, NULL, OPTION_BUILD_ID},
+-EOF
+-if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
+-fragment <<EOF
+-    {"depaudit", required_argument, NULL, 'P'},
+-    {"disable-new-dtags", no_argument, NULL, OPTION_DISABLE_NEW_DTAGS},
+-    {"enable-new-dtags", no_argument, NULL, OPTION_ENABLE_NEW_DTAGS},
+-    {"eh-frame-hdr", no_argument, NULL, OPTION_EH_FRAME_HDR},
+-    {"exclude-libs", required_argument, NULL, OPTION_EXCLUDE_LIBS},
+-    {"hash-style", required_argument, NULL, OPTION_HASH_STYLE},
+-EOF
+-fi
+-if test -n "$PARSE_AND_LIST_LONGOPTS" ; then
+-fragment <<EOF
+-    $PARSE_AND_LIST_LONGOPTS
+-EOF
+-fi
+-fragment <<EOF
+-    {NULL, no_argument, NULL, 0}
+-  };
+-
+-  *shortopts = (char *) xrealloc (*shortopts, ns + sizeof (xtra_short));
+-  memcpy (*shortopts + ns, &xtra_short, sizeof (xtra_short));
+-  *longopts = (struct option *)
+-    xrealloc (*longopts, nl * sizeof (struct option) + sizeof (xtra_long));
+-  memcpy (*longopts + nl, &xtra_long, sizeof (xtra_long));
+-}
+-
+-#define DEFAULT_BUILD_ID_STYLE	"sha1"
+-
+-static bfd_boolean
+-gld${EMULATION_NAME}_handle_option (int optc)
+-{
+-  switch (optc)
+-    {
+-    default:
+-      return FALSE;
+-
+-    case OPTION_BUILD_ID:
+-      if (emit_note_gnu_build_id != NULL)
+-	{
+-	  free ((char *) emit_note_gnu_build_id);
+-	  emit_note_gnu_build_id = NULL;
+-	}
+-      if (optarg == NULL)
+-	optarg = DEFAULT_BUILD_ID_STYLE;
+-      if (strcmp (optarg, "none"))
+-	emit_note_gnu_build_id = xstrdup (optarg);
+-      break;
+-
+-EOF
+-
+-if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
+-fragment <<EOF
+-    case OPTION_AUDIT:
+-	gld${EMULATION_NAME}_append_to_separated_string (&audit, optarg);
+-	break;
+-
+-    case 'P':
+-	gld${EMULATION_NAME}_append_to_separated_string (&depaudit, optarg);
+-	break;
+-
+-    case OPTION_DISABLE_NEW_DTAGS:
+-      link_info.new_dtags = FALSE;
+-      break;
+-
+-    case OPTION_ENABLE_NEW_DTAGS:
+-      link_info.new_dtags = TRUE;
+-      break;
+-
+-    case OPTION_EH_FRAME_HDR:
+-      link_info.eh_frame_hdr = TRUE;
+-      break;
+-
+-    case OPTION_GROUP:
+-      link_info.flags_1 |= (bfd_vma) DF_1_GROUP;
+-      /* Groups must be self-contained.  */
+-      link_info.unresolved_syms_in_objects = RM_GENERATE_ERROR;
+-      link_info.unresolved_syms_in_shared_libs = RM_GENERATE_ERROR;
+-      break;
+-
+-    case OPTION_EXCLUDE_LIBS:
+-      add_excluded_libs (optarg);
+-      break;
+-
+-    case OPTION_HASH_STYLE:
+-      link_info.emit_hash = FALSE;
+-      link_info.emit_gnu_hash = FALSE;
+-      if (strcmp (optarg, "sysv") == 0)
+-	link_info.emit_hash = TRUE;
+-      else if (strcmp (optarg, "gnu") == 0)
+-	link_info.emit_gnu_hash = TRUE;
+-      else if (strcmp (optarg, "both") == 0)
+-	{
+-	  link_info.emit_hash = TRUE;
+-	  link_info.emit_gnu_hash = TRUE;
+-	}
+-      else
+-	einfo (_("%P%F: invalid hash style \`%s'\n"), optarg);
+-      break;
+-
+-EOF
+-fi
+-fragment <<EOF
+-    case 'z':
+-      if (strcmp (optarg, "defs") == 0)
+-	link_info.unresolved_syms_in_objects = RM_GENERATE_ERROR;
+-      else if (strcmp (optarg, "muldefs") == 0)
+-	link_info.allow_multiple_definition = TRUE;
+-      else if (CONST_STRNEQ (optarg, "max-page-size="))
+-	{
+-	  char *end;
+-
+-	  config.maxpagesize = strtoul (optarg + 14, &end, 0);
+-	  if (*end || (config.maxpagesize & (config.maxpagesize - 1)) != 0)
+-	    einfo (_("%P%F: invalid maxium page size \`%s'\n"),
+-		   optarg + 14);
+-	}
+-      else if (CONST_STRNEQ (optarg, "common-page-size="))
+-	{
+-	  char *end;
+-	  config.commonpagesize = strtoul (optarg + 17, &end, 0);
+-	  if (*end
+-	      || (config.commonpagesize & (config.commonpagesize - 1)) != 0)
+-	    einfo (_("%P%F: invalid common page size \`%s'\n"),
+-		   optarg + 17);
+-	}
+-      else if (CONST_STRNEQ (optarg, "stack-size="))
+-	{
+-	  char *end;
+-	  link_info.stacksize = strtoul (optarg + 11, &end, 0);
+-	  if (*end || link_info.stacksize < 0)
+-	    einfo (_("%P%F: invalid stack size \`%s'\n"), optarg + 11);
+-	  if (!link_info.stacksize)
+-	    /* Use -1 for explicit no-stack, because zero means
+-	       'default'.   */
+-	    link_info.stacksize = -1;
+-	}
+-      else if (strcmp (optarg, "execstack") == 0)
+-	{
+-	  link_info.execstack = TRUE;
+-	  link_info.noexecstack = FALSE;
+-	}
+-      else if (strcmp (optarg, "noexecstack") == 0)
+-	{
+-	  link_info.noexecstack = TRUE;
+-	  link_info.execstack = FALSE;
+-	}
+-EOF
+-if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
+-fragment <<EOF
+-      else if (strcmp (optarg, "global") == 0)
+-	link_info.flags_1 |= (bfd_vma) DF_1_GLOBAL;
+-      else if (strcmp (optarg, "initfirst") == 0)
+-	link_info.flags_1 |= (bfd_vma) DF_1_INITFIRST;
+-      else if (strcmp (optarg, "interpose") == 0)
+-	link_info.flags_1 |= (bfd_vma) DF_1_INTERPOSE;
+-      else if (strcmp (optarg, "loadfltr") == 0)
+-	link_info.flags_1 |= (bfd_vma) DF_1_LOADFLTR;
+-      else if (strcmp (optarg, "nodefaultlib") == 0)
+-	link_info.flags_1 |= (bfd_vma) DF_1_NODEFLIB;
+-      else if (strcmp (optarg, "nodelete") == 0)
+-	link_info.flags_1 |= (bfd_vma) DF_1_NODELETE;
+-      else if (strcmp (optarg, "nodlopen") == 0)
+-	link_info.flags_1 |= (bfd_vma) DF_1_NOOPEN;
+-      else if (strcmp (optarg, "nodump") == 0)
+-	link_info.flags_1 |= (bfd_vma) DF_1_NODUMP;
+-      else if (strcmp (optarg, "now") == 0)
+-	{
+-	  link_info.flags |= (bfd_vma) DF_BIND_NOW;
+-	  link_info.flags_1 |= (bfd_vma) DF_1_NOW;
+-	}
+-      else if (strcmp (optarg, "lazy") == 0)
+-	{
+-	  link_info.flags &= ~(bfd_vma) DF_BIND_NOW;
+-	  link_info.flags_1 &= ~(bfd_vma) DF_1_NOW;
+-	}
+-      else if (strcmp (optarg, "origin") == 0)
+-	{
+-	  link_info.flags |= (bfd_vma) DF_ORIGIN;
+-	  link_info.flags_1 |= (bfd_vma) DF_1_ORIGIN;
+-	}
+-      else if (strcmp (optarg, "combreloc") == 0)
+-	link_info.combreloc = TRUE;
+-      else if (strcmp (optarg, "nocombreloc") == 0)
+-	link_info.combreloc = FALSE;
+-      else if (strcmp (optarg, "nocopyreloc") == 0)
+-	link_info.nocopyreloc = TRUE;
+-      else if (strcmp (optarg, "relro") == 0)
+-	link_info.relro = TRUE;
+-      else if (strcmp (optarg, "norelro") == 0)
+-	link_info.relro = FALSE;
+-      else if (strcmp (optarg, "text") == 0)
+-	link_info.error_textrel = TRUE;
+-      else if (strcmp (optarg, "notext") == 0)
+-	link_info.error_textrel = FALSE;
+-      else if (strcmp (optarg, "textoff") == 0)
+-	link_info.error_textrel = FALSE;
+-EOF
+-fi
+-
+-fragment <<EOF
+-      else
+-	einfo (_("%P: warning: -z %s ignored.\n"), optarg);
+-      break;
+-EOF
+-
+-if test -n "$PARSE_AND_LIST_ARGS_CASES" ; then
+-fragment <<EOF
+- $PARSE_AND_LIST_ARGS_CASES
+-EOF
+-fi
+-
+-fragment <<EOF
+-    }
+-
+-  return TRUE;
+-}
+-
+-EOF
+-
+-if test x"$LDEMUL_LIST_OPTIONS" != xgld"$EMULATION_NAME"_list_options; then
+-fragment <<EOF
+-
+-static void
+-gld${EMULATION_NAME}_list_options (FILE * file)
+-{
+-EOF
+-if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
+-fragment <<EOF
+-  fprintf (file, _("\
+-  --audit=AUDITLIB            Specify a library to use for auditing\n"));
+-  fprintf (file, _("\
+-  -Bgroup                     Selects group name lookup rules for DSO\n"));
+-EOF
+-fi
+-fragment <<EOF
+-  fprintf (file, _("\
+-  --build-id[=STYLE]          Generate build ID note\n"));
+-EOF
+-if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
+-fragment <<EOF
+-  fprintf (file, _("\
+-  -P AUDITLIB, --depaudit=AUDITLIB\n" "\
+-			      Specify a library to use for auditing dependencies\n"));
+-  fprintf (file, _("\
+-  --disable-new-dtags         Disable new dynamic tags\n"));
+-  fprintf (file, _("\
+-  --enable-new-dtags          Enable new dynamic tags\n"));
+-  fprintf (file, _("\
+-  --eh-frame-hdr              Create .eh_frame_hdr section\n"));
+-  fprintf (file, _("\
+-  --exclude-libs=LIBS         Make all symbols in LIBS hidden\n"));
+-  fprintf (file, _("\
+-  --hash-style=STYLE          Set hash style to sysv, gnu or both\n"));
+-  fprintf (file, _("\
+-  -z combreloc                Merge dynamic relocs into one section and sort\n"));
+-EOF
+-fi
+-
+-fragment <<EOF
+-  fprintf (file, _("\
+-  -z common-page-size=SIZE    Set common page size to SIZE\n"));
+-  fprintf (file, _("\
+-  -z defs                     Report unresolved symbols in object files.\n"));
+-  fprintf (file, _("\
+-  -z execstack                Mark executable as requiring executable stack\n"));
+-EOF
+-
+-if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
+-fragment <<EOF
+-  fprintf (file, _("\
+-  -z global                   Make symbols in DSO available for subsequently\n\
+-			       loaded objects\n"));
+-  fprintf (file, _("\
+-  -z initfirst                Mark DSO to be initialized first at runtime\n"));
+-  fprintf (file, _("\
+-  -z interpose                Mark object to interpose all DSOs but executable\n"));
+-  fprintf (file, _("\
+-  -z lazy                     Mark object lazy runtime binding (default)\n"));
+-  fprintf (file, _("\
+-  -z loadfltr                 Mark object requiring immediate process\n"));
+-EOF
+-fi
+-
+-fragment <<EOF
+-  fprintf (file, _("\
+-  -z max-page-size=SIZE       Set maximum page size to SIZE\n"));
+-  fprintf (file, _("\
+-  -z muldefs                  Allow multiple definitions\n"));
+-EOF
+-
+-if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
+-fragment <<EOF
+-  fprintf (file, _("\
+-  -z nocombreloc              Don't merge dynamic relocs into one section\n"));
+-  fprintf (file, _("\
+-  -z nocopyreloc              Don't create copy relocs\n"));
+-  fprintf (file, _("\
+-  -z nodefaultlib             Mark object not to use default search paths\n"));
+-  fprintf (file, _("\
+-  -z nodelete                 Mark DSO non-deletable at runtime\n"));
+-  fprintf (file, _("\
+-  -z nodlopen                 Mark DSO not available to dlopen\n"));
+-  fprintf (file, _("\
+-  -z nodump                   Mark DSO not available to dldump\n"));
+-EOF
+-fi
+-fragment <<EOF
+-  fprintf (file, _("\
+-  -z noexecstack              Mark executable as not requiring executable stack\n"));
+-EOF
+-if test x"$GENERATE_SHLIB_SCRIPT" = xyes; then
+-fragment <<EOF
+-  fprintf (file, _("\
+-  -z norelro                  Don't create RELRO program header\n"));
+-  fprintf (file, _("\
+-  -z now                      Mark object non-lazy runtime binding\n"));
+-  fprintf (file, _("\
+-  -z origin                   Mark object requiring immediate \$ORIGIN\n\
+-				processing at runtime\n"));
+-  fprintf (file, _("\
+-  -z relro                    Create RELRO program header\n"));
+-  fprintf (file, _("\
+-  -z stacksize=SIZE           Set size of stack segment\n"));
+-EOF
+-fi
+-
+-if test -n "$PARSE_AND_LIST_OPTIONS" ; then
+-fragment <<EOF
+- $PARSE_AND_LIST_OPTIONS
+-EOF
+-fi
+-
+-fragment <<EOF
+-}
+-EOF
+-
+-if test -n "$PARSE_AND_LIST_EPILOGUE" ; then
+-fragment <<EOF
+- $PARSE_AND_LIST_EPILOGUE
+-EOF
+-fi
+-fi
+-
+-fragment <<EOF
+-
+-struct ld_emulation_xfer_struct ld_${EMULATION_NAME}_emulation =
+-{
+-  ${LDEMUL_BEFORE_PARSE-gld${EMULATION_NAME}_before_parse},
+-  ${LDEMUL_SYSLIB-syslib_default},
+-  ${LDEMUL_HLL-hll_default},
+-  ${LDEMUL_AFTER_PARSE-after_parse_default},
+-  ${LDEMUL_AFTER_OPEN-gld${EMULATION_NAME}_after_open},
+-  ${LDEMUL_AFTER_ALLOCATION-gld${EMULATION_NAME}_after_allocation},
+-  ${LDEMUL_SET_OUTPUT_ARCH-set_output_arch_default},
+-  ${LDEMUL_CHOOSE_TARGET-ldemul_default_target},
+-  ${LDEMUL_BEFORE_ALLOCATION-gld${EMULATION_NAME}_before_allocation},
+-  ${LDEMUL_GET_SCRIPT-gld${EMULATION_NAME}_get_script},
+-  "${EMULATION_NAME}",
+-  "${OUTPUT_FORMAT}",
+-  ${LDEMUL_FINISH-finish_default},
+-  ${LDEMUL_CREATE_OUTPUT_SECTION_STATEMENTS-NULL},
+-  ${LDEMUL_OPEN_DYNAMIC_ARCHIVE-gld${EMULATION_NAME}_open_dynamic_archive},
+-  ${LDEMUL_PLACE_ORPHAN-gld${EMULATION_NAME}_place_orphan},
+-  ${LDEMUL_SET_SYMBOLS-NULL},
+-  ${LDEMUL_PARSE_ARGS-NULL},
+-  gld${EMULATION_NAME}_add_options,
+-  gld${EMULATION_NAME}_handle_option,
+-  ${LDEMUL_UNRECOGNIZED_FILE-NULL},
+-  ${LDEMUL_LIST_OPTIONS-gld${EMULATION_NAME}_list_options},
+-  ${LDEMUL_RECOGNIZED_FILE-gld${EMULATION_NAME}_load_symbols},
+-  ${LDEMUL_FIND_POTENTIAL_LIBRARIES-NULL},
+-  ${LDEMUL_NEW_VERS_PATTERN-NULL}
+-};
+-EOF
 \ No newline at end of file
-diff --git a/ld/ldctor.c b/ld/ldctor.c
-index 2f80aa02df699a0b1f3301412b02b2da030bac01..6bdbba10074d8052e83ca858cc7e6cec21c0d772 100644
---- a/ld/ldctor.c
-+++ b/ld/ldctor.c
-@@ -29,12 +29,13 @@
- #include "ldexp.h"
- #include "ldlang.h"
- #include "ldmisc.h"
- #include <ldgram.h>
- #include "ldmain.h"
- #include "ldctor.h"
-+#include "elf-bfd.h"
- 
- /* The list of statements needed to handle constructors.  These are
-    invoked by the command CONSTRUCTORS in the linker script.  */
- lang_statement_list_type constructor_list;
- 
- /* Whether the constructors should be sorted.  Note that this is
-@@ -253,14 +254,19 @@ ldctor_build_sets (void)
-       reloc_howto_type *howto;
-       int reloc_size, size;
- 
-       /* If the symbol is defined, we may have been invoked from
- 	 collect, and the sets may already have been built, so we do
- 	 not do anything.  */
--      if (p->h->type == bfd_link_hash_defined
--	  || p->h->type == bfd_link_hash_defweak)
-+	 /* dgv -- libnix v1.1 uses absolute sets that are also explicitly
-+	 defined in the library so that the sets need to be build even
-+	 if the symbol is defined */
-+	  if (!(bfd_get_flavour (link_info.output_bfd) == bfd_target_elf_flavour &&
-+		get_elf_backend_data (link_info.output_bfd)->target_os == is_amigaos) &&
-+        (p->h->type == bfd_link_hash_defined
-+	    || p->h->type == bfd_link_hash_defweak))
- 	continue;
- 
-       /* For each set we build:
- 	   set:
- 	     .long number_of_elements
- 	     .long element0
-@@ -353,21 +359,28 @@ ldctor_build_sets (void)
- 		  len = 0;
- 		}
- 	      print_spaces (20 - len);
- 
- 	      if (e->name != NULL)
- 		minfo ("%pT\n", e->name);
--	      else
--		minfo ("%G\n", e->section->owner, e->section, e->value);
-+		  else if (e->section->owner)
-+	    minfo ("%G\n", e->section->owner, e->section, e->value);
-+		  else
-+		minfo ("%s\n", "** ABS **");
- 	    }
- 
- 	  /* Need SEC_KEEP for --gc-sections.  */
- 	  if (!bfd_is_abs_section (e->section))
- 	    e->section->flags |= SEC_KEEP;
- 
--	  if (bfd_link_relocatable (&link_info))
-+	  /* dgv -- on the amiga, we want the constructors to be relocateable
-+	     objects. However, this should be arranged somewhere else (FIXME) */
-+	  if (bfd_link_relocatable (&link_info) ||
-+		  (bfd_get_flavour (link_info.output_bfd) == bfd_target_elf_flavour &&
-+           get_elf_backend_data (link_info.output_bfd)->target_os == is_amigaos &&
-+	       e->section != bfd_abs_section_ptr))
- 	    lang_add_reloc (p->reloc, howto, e->section, e->name,
- 			    exp_intop (e->value));
- 	  else
- 	    lang_add_data (size, exp_relop (e->section, e->value));
- 	}
- 
-diff --git a/ld/ldlang.c b/ld/ldlang.c
-index b66d8c6bc1dd8c9bcb8f142c7111307513098588..2f546239ab0503fe4ba4a9318d9670e454db7349 100644
---- a/ld/ldlang.c
-+++ b/ld/ldlang.c
-@@ -3837,12 +3837,19 @@ typedef struct bfd_sym_chain ldlang_undef_chain_list_type;
- 
- #define ldlang_undef_chain_list_head entry_symbol.next
- 
- void
- ldlang_add_undef (const char *const name, bool cmdline ATTRIBUTE_UNUSED)
- {
-+#if 1
-+  /* This is a quick ugly hak of getting around the problem
-+   * with -use-dynld being passed to the linker
-+   */
-+  if (strcmp(name, "se-dynld") == 0)
-+    return;
-+#endif	
-   ldlang_undef_chain_list_type *new_undef;
- 
-   new_undef = stat_alloc (sizeof (*new_undef));
-   new_undef->next = ldlang_undef_chain_list_head;
-   ldlang_undef_chain_list_head = new_undef;
- 
-diff --git a/ld/ldmain.c b/ld/ldmain.c
-index 9290a189b0d26fbd7bbcc97624ee45fbcd188584..308928445feced047f44a99c463f6d89174f9776 100644
---- a/ld/ldmain.c
-+++ b/ld/ldmain.c
-@@ -493,18 +493,23 @@ main (int argc, char **argv)
- 	}
-       link_info.has_map_file = true;
-     }
- 
-   lang_process ();
- 
--  /* Print error messages for any missing symbols, for any warning
-+    /* Print error messages for any missing symbols, for any warning
-      symbols, and possibly multiple definitions.  */
-+#ifdef __amigaos4__
-+  /* Make all files executable, even relocatable files */
-+    link_info.output_bfd->flags |= EXEC_P;
-+#else
-   if (bfd_link_relocatable (&link_info))
-     link_info.output_bfd->flags &= ~EXEC_P;
-   else
-     link_info.output_bfd->flags |= EXEC_P;
-+#endif
- 
-   flagword flags = 0;
-   switch (config.compress_debug)
-     {
-     case COMPRESS_DEBUG_GNU_ZLIB:
-       flags = BFD_COMPRESS;
-diff --git a/ld/po/BLD-POTFILES.in b/ld/po/BLD-POTFILES.in
-index ff820172b9845f40be4fdae1df56137d3e2d65ac..018ac5d6dc7299a8dd57167b72d8851a07e075af 100644
---- a/ld/po/BLD-POTFILES.in
-+++ b/ld/po/BLD-POTFILES.in
-@@ -265,12 +265,14 @@ ends32elf16m.c
- ends32elf_linux.c
- enios2elf.c
- enios2linux.c
- ens32knbsd.c
- epc532macha.c
- epdp11.c
-+eppcamiga.c
-+eppcamiga_bss.c
- epjelf.c
- epjlelf.c
- eppcmacos.c
- epruelf.c
- escore3_elf.c
- escore7_elf.c
-diff --git a/ld/scripttempl/elf.sc b/ld/scripttempl/amigaos.sc
-similarity index 99%
-copy from ld/scripttempl/elf.sc
-copy to ld/scripttempl/amigaos.sc
-index 5d3b0d31b1bbb5903730a785c32937939931d1cf..4b2b8a1e66ed188f672ca09baba622e40eff6502 100644
---- a/ld/scripttempl/elf.sc
+diff --git a/ld/scripttempl/amigaos.sc b/ld/scripttempl/amigaos.sc
+index d472d990abc..4b2b8a1e66e 100644
+--- a/ld/scripttempl/amigaos.sc
 +++ b/ld/scripttempl/amigaos.sc
-@@ -535,13 +535,12 @@ cat <<EOF
-   {
-     ${RELOCATING+${INIT_START}}
-     KEEP (*(SORT_NONE(.init)))
-     ${RELOCATING+${INIT_END}}
-   } ${FILL}
+@@ -1,8 +1,16 @@
++# Copyright (C) 2014-2023 Free Software Foundation, Inc.
++#
++# Copying and distribution of this file, with or without modification,
++# are permitted in any medium without royalty provided the copyright
++# notice and this notice are preserved.
+ #
+ # Unusual variables checked by this code:
+-#	NOP - four byte opcode for no-op (defaults to 0)
++#	NOP - four byte opcode for no-op (defaults to none)
+ #	NO_SMALL_DATA - no .sbss/.sbss2/.sdata/.sdata2 sections if not
+ #		empty.
++#	HAVE_NOINIT - Include a .noinit output section in the script.
++#	HAVE_PERSISTENT - Include a .persistent output section in the script.
++#	HAVE_DT_RELR - Include a .relr.dyn output section in the script.
+ #	SMALL_DATA_CTOR - .ctors contains small data.
+ #	SMALL_DATA_DTOR - .dtors contains small data.
+ #	DATA_ADDR - if end-of-text-plus-one-page isn't right for data start
+@@ -10,10 +18,12 @@
+ #	OTHER_READONLY_SECTIONS - other than .text .init .rodata ...
+ #		(e.g., .PARISC.milli)
+ #	OTHER_TEXT_SECTIONS - these get put in .text when relocating
++#	INITIAL_READWRITE_SECTIONS - at start of data segment (after relro)
+ #	OTHER_READWRITE_SECTIONS - other than .data .bss .ctors .sdata ...
+ #		(e.g., .PARISC.global)
+ #	OTHER_RELRO_SECTIONS - other than .data.rel.ro ...
+ #		(e.g. PPC32 .fixup, .got[12])
++#	OTHER_RELRO_SECTIONS_2 - as above, but after .dynamic in text segment
+ #	OTHER_BSS_SECTIONS - other than .bss .sbss ...
+ #	ATTRS_SECTIONS - at the end
+ #	OTHER_SECTIONS - at the end
+@@ -30,12 +40,17 @@
+ #		writeable data sections.
+ #	OTHER_GOT_SYMBOLS - symbols defined just before .got.
+ #	OTHER_GOT_SECTIONS - sections just after .got.
++#	OTHER_PLT_SECTIONS - sections just after .plt.
+ #	OTHER_SDATA_SECTIONS - sections just after .sdata.
+ #	OTHER_BSS_SYMBOLS - symbols that appear at the start of the
+ #		.bss section besides __bss_start.
++#	PLT_NEXT_DATA - .plt next to data segment when .plt is in text segment.
+ #	DATA_PLT - .plt should be in data segment, not text segment.
+ #	PLT_BEFORE_GOT - .plt just before .got when .plt is in data segement.
+ #	BSS_PLT - .plt should be in bss segment
++#	NO_REL_RELOCS - Don't include .rel.* sections in script
++#	NO_RELA_RELOCS - Don't include .rela.* sections in script
++#	NON_ALLOC_DYN - Place dynamic sections after data segment.
+ #	TEXT_DYNAMIC - .dynamic in text segment, not data segment.
+ #	EMBEDDED - whether this is for an embedded system.
+ #	SHLIB_TEXT_START_ADDR - if set, add to SIZEOF_HEADERS to set
+@@ -43,18 +58,26 @@
+ #	INPUT_FILES - INPUT command of files to always include
+ #	WRITABLE_RODATA - if set, the .rodata section should be writable
+ #	INIT_START, INIT_END -  statements just before and just after
+-# 	combination of .init sections.
++#	combination of .init sections.
+ #	FINI_START, FINI_END - statements just before and just after
+-# 	combination of .fini sections.
++#	combination of .fini sections.
+ #	STACK_ADDR - start of a .stack section.
+ #	OTHER_SYMBOLS - symbols to place right at the end of the script.
+ #	ETEXT_NAME - name of a symbol for the end of the text section,
+ #		normally etext.
++#	ETEXT_LAST_IN_RODATA_SEGMENT - emit ETEXT_NAME after all sections in
++#		the read-only data segment (which may or may not be equal to
++#		the code segment), instead of after just the code parts.
++#	SEPARATE_CODE - if set, .text and similar sections containing
++#		actual machine instructions must be in wholly disjoint
++#		pages from any other data, including headers
+ #	SEPARATE_GOTPLT - if set, .got.plt should be separate output section,
+ #		so that .got can be in the RELRO area.  It should be set to
+ #		the number of bytes in the beginning of .got.plt which can be
+ #		in the RELRO area as well.
+ #	USER_LABEL_PREFIX - prefix to add to user-visible symbols.
++#	RODATA_NAME, SDATA_NAME, SBSS_NAME, BSS_NAME - base parts of names
++#		for standard sections, without initial "." or suffixes.
+ #
+ # When adding sections, do note that the names of some sections are used
+ # when specifying the start address of the next.
+@@ -83,91 +106,125 @@
+ #  .lrodata	.gnu.linkonce.lr.foo
+ #  .ldata	.gnu.linkonce.l.foo
+ #  .lbss	.gnu.linkonce.lb.foo
++#  .noinit	.gnu.linkonce.n.foo
++#  .persistent	.gnu.linkonce.p.foo
+ #
+ #  Each of these can also have corresponding .rel.* and .rela.* sections.
  
--  ${TEXT_PLT+${PLT_NEXT_DATA-${PLT} ${OTHER_PLT_SECTIONS}}}
+-test -z "$ENTRY" && ENTRY=_start
++if test -n "$NOP"; then
++  FILL="=$NOP"
++else
++  FILL=
++fi
++
++test -n "$CREATE_SHLIB$CREATE_PIE" && CREATE_PIC=" "
++test -z "$RODATA_NAME" && RODATA_NAME=rodata
++test -z "$SDATA_NAME" && SDATA_NAME=sdata
++test -z "$SBSS_NAME" && SBSS_NAME=sbss
++test -z "$BSS_NAME" && BSS_NAME=bss
++test -z "$ENTRY" && ENTRY=${USER_LABEL_PREFIX}_start
+ test -z "${BIG_OUTPUT_FORMAT}" && BIG_OUTPUT_FORMAT=${OUTPUT_FORMAT}
+ test -z "${LITTLE_OUTPUT_FORMAT}" && LITTLE_OUTPUT_FORMAT=${OUTPUT_FORMAT}
+ if [ -z "$MACHINE" ]; then OUTPUT_ARCH=${ARCH}; else OUTPUT_ARCH=${ARCH}:${MACHINE}; fi
+ test -z "${ELFSIZE}" && ELFSIZE=32
+ test -z "${ALIGNMENT}" && ALIGNMENT="${ELFSIZE} / 8"
+ test "$LD_FLAG" = "N" && DATA_ADDR=.
+-test -z "${ETEXT_NAME}" && ETEXT_NAME=etext
+-test -n "$CREATE_SHLIB$CREATE_PIE" && test -n "$SHLIB_DATA_ADDR" && COMMONPAGESIZE=""
+-test -z "$CREATE_SHLIB$CREATE_PIE" && test -n "$DATA_ADDR" && COMMONPAGESIZE=""
++test -z "${ETEXT_NAME}" && ETEXT_NAME=${USER_LABEL_PREFIX}etext
+ test -n "$RELRO_NOW" && unset SEPARATE_GOTPLT
+ test -z "$ATTRS_SECTIONS" && ATTRS_SECTIONS=".gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }"
+-DATA_SEGMENT_ALIGN="ALIGN(${SEGMENT_SIZE})"
+-#DATA_SEGMENT_ALIGN="ALIGN(${SEGMENT_SIZE}) + (. & (${MAXPAGESIZE} - 1))"
+-DATA_SEGMENT_RELRO_END=""
+-DATA_SEGMENT_END=""
+-if test -n "${COMMONPAGESIZE}"; then
+-  DATA_SEGMENT_ALIGN="ALIGN (${SEGMENT_SIZE}) - ((${MAXPAGESIZE} - .) & (${MAXPAGESIZE} - 1)); . = DATA_SEGMENT_ALIGN (${MAXPAGESIZE}, ${COMMONPAGESIZE})"
+-  DATA_SEGMENT_END=". = DATA_SEGMENT_END (.);"
+-  DATA_SEGMENT_RELRO_END=". = DATA_SEGMENT_RELRO_END (${SEPARATE_GOTPLT-0}, .);"
++if test -z "$DATA_SEGMENT_ALIGN"; then
++  test -n "$CREATE_SHLIB$CREATE_PIE" && test -n "$SHLIB_DATA_ADDR" && COMMONPAGESIZE=""
++  test -z "$CREATE_SHLIB$CREATE_PIE" && test -n "$DATA_ADDR" && COMMONPAGESIZE=""
++  DATA_SEGMENT_ALIGN="ALIGN(${SEGMENT_SIZE}) + (. & (${MAXPAGESIZE} - 1))"
++  DATA_SEGMENT_RELRO_END=""
++  DATA_SEGMENT_END=""
++  if test -n "${COMMONPAGESIZE}"; then
++    if test "${SEGMENT_SIZE}" != "${MAXPAGESIZE}"; then
++      DATA_SEGMENT_ALIGN="ALIGN (${SEGMENT_SIZE}) - ((${MAXPAGESIZE} - .) & (${MAXPAGESIZE} - 1)); . = DATA_SEGMENT_ALIGN (${MAXPAGESIZE}, ${COMMONPAGESIZE})"
++    else
++      DATA_SEGMENT_ALIGN="DATA_SEGMENT_ALIGN (${MAXPAGESIZE}, ${COMMONPAGESIZE})"
++    fi
++    DATA_SEGMENT_END=". = DATA_SEGMENT_END (.);"
++    DATA_SEGMENT_RELRO_END=". = DATA_SEGMENT_RELRO_END (${SEPARATE_GOTPLT-0}, .);"
++  fi
+ fi
+ if test -z "${INITIAL_READONLY_SECTIONS}${CREATE_SHLIB}"; then
+   INITIAL_READONLY_SECTIONS=".interp       ${RELOCATING-0} : { *(.interp) }"
+ fi
+ if test -z "$PLT"; then
+-  PLT=".plt          ${RELOCATING-0} : { *(.plt) }"
++  IPLT=".iplt         ${RELOCATING-0} : { *(.iplt) }"
++  PLT=".plt          ${RELOCATING-0} : { *(.plt)${RELOCATING+${IREL_IN_PLT+ *(.iplt)}} }
++  ${IREL_IN_PLT-$IPLT}"
+ fi
+-test -n "${DATA_PLT-${BSS_PLT-text}}" && TEXT_PLT=yes
++test -n "${DATA_PLT-${BSS_PLT-text}}" && TEXT_PLT=
+ if test -z "$GOT"; then
+   if test -z "$SEPARATE_GOTPLT"; then
+-    GOT=".got          ${RELOCATING-0} : { *(.got.plt) *(.got) }"
++    GOT=".got          ${RELOCATING-0} : {${RELOCATING+ *(.got.plt) *(.igot.plt)} *(.got)${RELOCATING+ *(.igot)} }"
+   else
+-    GOT=".got          ${RELOCATING-0} : { *(.got) }"
+-    GOTPLT=".got.plt      ${RELOCATING-0} : { *(.got.plt) }"
++    GOT=".got          ${RELOCATING-0} : { *(.got)${RELOCATING+ *(.igot)} }"
++    GOTPLT=".got.plt      ${RELOCATING-0} : { *(.got.plt)${RELOCATING+ *(.igot.plt)} }"
+   fi
+ fi
++REL_IFUNC=".rel.ifunc    ${RELOCATING-0} : { *(.rel.ifunc) }"
++RELA_IFUNC=".rela.ifunc   ${RELOCATING-0} : { *(.rela.ifunc) }"
++REL_IPLT=".rel.iplt     ${RELOCATING-0} :
++    {
++      ${RELOCATING+${CREATE_PIC-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__rel_iplt_start = .);}}
++      *(.rel.iplt)
++      ${RELOCATING+${CREATE_PIC-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__rel_iplt_end = .);}}
++    }"
++RELA_IPLT=".rela.iplt    ${RELOCATING-0} :
++    {
++      ${RELOCATING+${CREATE_PIC-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__rela_iplt_start = .);}}
++      *(.rela.iplt)
++      ${RELOCATING+${CREATE_PIC-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__rela_iplt_end = .);}}
++    }"
+ DYNAMIC=".dynamic      ${RELOCATING-0} : { *(.dynamic) }"
+-RODATA=".rodata       ${RELOCATING-0} : { *(.rodata${RELOCATING+ .rodata.* .gnu.linkonce.r.*}) }"
+-DATARELRO=".data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro* .gnu.linkonce.d.rel.ro.*) }"
+-DISCARDED="/DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) }"
++RODATA=".${RODATA_NAME}       ${RELOCATING-0} : { *(.${RODATA_NAME}${RELOCATING+ .${RODATA_NAME}.* .gnu.linkonce.r.*}) }"
++DATARELRO=".data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro .data.rel.ro.* .gnu.linkonce.d.rel.ro.*) }"
++DISCARDED="/DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }"
+ if test -z "${NO_SMALL_DATA}"; then
+-  SBSS=".sbss         ${RELOCATING-0} :
++  SBSS=".${SBSS_NAME}         ${RELOCATING-0} :
+   {
+     ${RELOCATING+${SBSS_START_SYMBOLS}}
+-    ${CREATE_SHLIB+*(.sbss2 .sbss2.* .gnu.linkonce.sb2.*)}
+-    *(.dynsbss)
+-    *(.sbss${RELOCATING+ .sbss.* .gnu.linkonce.sb.*})
+-    *(.scommon)
++    ${CREATE_SHLIB+*(.${SBSS_NAME}2 .${SBSS_NAME}2.* .gnu.linkonce.sb2.*)}
++    ${RELOCATING+*(.dyn${SBSS_NAME})}
++    *(.${SBSS_NAME}${RELOCATING+ .${SBSS_NAME}.* .gnu.linkonce.sb.*})
++    ${RELOCATING+*(.scommon)}
+     ${RELOCATING+${SBSS_END_SYMBOLS}}
+   }"
+-  SBSS2=".sbss2        ${RELOCATING-0} : { *(.sbss2${RELOCATING+ .sbss2.* .gnu.linkonce.sb2.*}) }"
++  SBSS2=".${SBSS_NAME}2        ${RELOCATING-0} : { *(.${SBSS_NAME}2${RELOCATING+ .${SBSS_NAME}2.* .gnu.linkonce.sb2.*}) }"
+   SDATA="/* We want the small data sections together, so single-instruction offsets
+      can access them all, and initialized data all before uninitialized, so
+      we can shorten the on-disk segment size.  */
+-  .sdata        ${RELOCATING-0} : 
++  .${SDATA_NAME}        ${RELOCATING-0} :
+   {
+     ${RELOCATING+${SDATA_START_SYMBOLS}}
+-    ${CREATE_SHLIB+*(.sdata2 .sdata2.* .gnu.linkonce.s2.*)}
+-    *(.sdata${RELOCATING+ .sdata.* .gnu.linkonce.s.*})
++    ${CREATE_SHLIB+*(.${SDATA_NAME}2 .${SDATA_NAME}2.* .gnu.linkonce.s2.*)}
++    *(.${SDATA_NAME}${RELOCATING+ .${SDATA_NAME}.* .gnu.linkonce.s.*})
+   }"
+-  SDATA2=".sdata2       ${RELOCATING-0} :
++  SDATA2=".${SDATA_NAME}2       ${RELOCATING-0} :
+   {
+     ${RELOCATING+${SDATA2_START_SYMBOLS}}
+-    *(.sdata2${RELOCATING+ .sdata2.* .gnu.linkonce.s2.*})
++    *(.${SDATA_NAME}2${RELOCATING+ .${SDATA_NAME}2.* .gnu.linkonce.s2.*})
+   }"
+-  REL_SDATA=".rel.sdata    ${RELOCATING-0} : { *(.rel.sdata${RELOCATING+ .rel.sdata.* .rel.gnu.linkonce.s.*}) }
+-  .rela.sdata   ${RELOCATING-0} : { *(.rela.sdata${RELOCATING+ .rela.sdata.* .rela.gnu.linkonce.s.*}) }"
+-  REL_SBSS=".rel.sbss     ${RELOCATING-0} : { *(.rel.sbss${RELOCATING+ .rel.sbss.* .rel.gnu.linkonce.sb.*}) }
+-  .rela.sbss    ${RELOCATING-0} : { *(.rela.sbss${RELOCATING+ .rela.sbss.* .rela.gnu.linkonce.sb.*}) }"
+-  REL_SDATA2=".rel.sdata2   ${RELOCATING-0} : { *(.rel.sdata2${RELOCATING+ .rel.sdata2.* .rel.gnu.linkonce.s2.*}) }
+-  .rela.sdata2  ${RELOCATING-0} : { *(.rela.sdata2${RELOCATING+ .rela.sdata2.* .rela.gnu.linkonce.s2.*}) }"
+-  REL_SBSS2=".rel.sbss2    ${RELOCATING-0} : { *(.rel.sbss2${RELOCATING+ .rel.sbss2.* .rel.gnu.linkonce.sb2.*}) }
+-  .rela.sbss2   ${RELOCATING-0} : { *(.rela.sbss2${RELOCATING+ .rela.sbss2.* .rela.gnu.linkonce.sb2.*}) }"
++  REL_SDATA=".rel.${SDATA_NAME}    ${RELOCATING-0} : { *(.rel.${SDATA_NAME}${RELOCATING+ .rel.${SDATA_NAME}.* .rel.gnu.linkonce.s.*}) }
++  .rela.${SDATA_NAME}   ${RELOCATING-0} : { *(.rela.${SDATA_NAME}${RELOCATING+ .rela.${SDATA_NAME}.* .rela.gnu.linkonce.s.*}) }"
++  REL_SBSS=".rel.${SBSS_NAME}     ${RELOCATING-0} : { *(.rel.${SBSS_NAME}${RELOCATING+ .rel.${SBSS_NAME}.* .rel.gnu.linkonce.sb.*}) }
++  .rela.${SBSS_NAME}    ${RELOCATING-0} : { *(.rela.${SBSS_NAME}${RELOCATING+ .rela.${SBSS_NAME}.* .rela.gnu.linkonce.sb.*}) }"
++  REL_SDATA2=".rel.${SDATA_NAME}2   ${RELOCATING-0} : { *(.rel.${SDATA_NAME}2${RELOCATING+ .rel.${SDATA_NAME}2.* .rel.gnu.linkonce.s2.*}) }
++  .rela.${SDATA_NAME}2  ${RELOCATING-0} : { *(.rela.${SDATA_NAME}2${RELOCATING+ .rela.${SDATA_NAME}2.* .rela.gnu.linkonce.s2.*}) }"
++  REL_SBSS2=".rel.${SBSS_NAME}2    ${RELOCATING-0} : { *(.rel.${SBSS_NAME}2${RELOCATING+ .rel.${SBSS_NAME}2.* .rel.gnu.linkonce.sb2.*}) }
++  .rela.${SBSS_NAME}2   ${RELOCATING-0} : { *(.rela.${SBSS_NAME}2${RELOCATING+ .rela.${SBSS_NAME}2.* .rela.gnu.linkonce.sb2.*}) }"
+ else
+   NO_SMALL_DATA=" "
+ fi
+-if test -z "${DATA_GOT}"; then
++if test -z "${SDATA_GOT}${DATA_GOT}"; then
+   if test -n "${NO_SMALL_DATA}"; then
+     DATA_GOT=" "
+   fi
+ fi
+-if test -z "${SDATA_GOT}"; then
++if test -z "${SDATA_GOT}${DATA_GOT}"; then
+   if test -z "${NO_SMALL_DATA}"; then
+     SDATA_GOT=" "
+   fi
+@@ -180,13 +237,12 @@ test "${LARGE_SECTIONS}" = "yes" && REL_LARGE="
+   .rela.lbss    ${RELOCATING-0} : { *(.rela.lbss${RELOCATING+ .rela.lbss.* .rela.gnu.linkonce.lb.*}) }
+   .rel.lrodata  ${RELOCATING-0} : { *(.rel.lrodata${RELOCATING+ .rel.lrodata.* .rel.gnu.linkonce.lr.*}) }
+   .rela.lrodata ${RELOCATING-0} : { *(.rela.lrodata${RELOCATING+ .rela.lrodata.* .rela.gnu.linkonce.lr.*}) }"
+-test "${LARGE_SECTIONS}" = "yes" && OTHER_BSS_SECTIONS="
+-  ${OTHER_BSS_SECTIONS}
++test "${LARGE_SECTIONS}" = "yes" && LARGE_BSS="
+   .lbss ${RELOCATING-0} :
+   {
+-    *(.dynlbss)
++    ${RELOCATING+*(.dynlbss)}
+     *(.lbss${RELOCATING+ .lbss.* .gnu.linkonce.lb.*})
+-    *(LARGE_COMMON)
++    ${RELOCATING+*(LARGE_COMMON)}
+   }"
+ test "${LARGE_SECTIONS}" = "yes" && LARGE_SECTIONS="
+   .lrodata ${RELOCATING-0} ${RELOCATING+ALIGN(${MAXPAGESIZE}) + (. & (${MAXPAGESIZE} - 1))} :
+@@ -198,6 +254,37 @@ test "${LARGE_SECTIONS}" = "yes" && LARGE_SECTIONS="
+     *(.ldata${RELOCATING+ .ldata.* .gnu.linkonce.l.*})
+     ${RELOCATING+. = ALIGN(. != 0 ? ${ALIGNMENT} : 1);}
+   }"
++if test "${ENABLE_INITFINI_ARRAY}" = "yes"; then
++  SORT_INIT_ARRAY="KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))"
++  SORT_FINI_ARRAY="KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))"
++  CTORS_IN_INIT_ARRAY="EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o $OTHER_EXCLUDE_FILES) .ctors"
++  DTORS_IN_FINI_ARRAY="EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o $OTHER_EXCLUDE_FILES) .dtors"
++else
++  SORT_INIT_ARRAY="KEEP (*(SORT(.init_array.*)))"
++  SORT_FINI_ARRAY="KEEP (*(SORT(.fini_array.*)))"
++  CTORS_IN_INIT_ARRAY=
++  DTORS_IN_FINI_ARRAY=
++fi
++PREINIT_ARRAY=".preinit_array    :
++  {
++    ${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__preinit_array_start = .);}
++    KEEP (*(.preinit_array))
++    ${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__preinit_array_end = .);}
++  }"
++INIT_ARRAY=".init_array    :
++  {
++    ${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__init_array_start = .);}
++    ${SORT_INIT_ARRAY}
++    KEEP (*(.init_array ${CTORS_IN_INIT_ARRAY}))
++    ${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__init_array_end = .);}
++  }"
++FINI_ARRAY=".fini_array    :
++  {
++    ${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__fini_array_start = .);}
++    ${SORT_FINI_ARRAY}
++    KEEP (*(.fini_array ${DTORS_IN_FINI_ARRAY}))
++    ${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__fini_array_end = .);}
++  }"
+ CTOR=".ctors        ${CONSTRUCTING-0} :
+   {
+     ${CONSTRUCTING+${CTOR_START}}
+@@ -234,27 +321,76 @@ DTOR=".dtors        ${CONSTRUCTING-0} :
+     KEEP (*(.dtors))
+     ${CONSTRUCTING+${DTOR_END}}
+   }"
+-STACK="  .stack        ${RELOCATING-0}${RELOCATING+${STACK_ADDR}} :
++STACK=".stack        ${RELOCATING-0}${RELOCATING+${STACK_ADDR}} :
+   {
+-    ${RELOCATING+_stack = .;}
++    ${RELOCATING+${USER_LABEL_PREFIX}_stack = .;}
+     *(.stack)
++    ${RELOCATING+${STACK_SENTINEL}}
++  }"
++test "${HAVE_NOINIT}" = "yes" && NOINIT="
++  /* This section contains data that is not initialized during load,
++     or during the application's initialization sequence.  */
++  .noinit (NOLOAD) :
++  {
++    ${RELOCATING+. = ALIGN(${ALIGNMENT});}
++    ${RELOCATING+PROVIDE (__noinit_start = .);}
++    *(.noinit${RELOCATING+ .noinit.* .gnu.linkonce.n.*})
++    ${RELOCATING+. = ALIGN(${ALIGNMENT});}
++    ${RELOCATING+PROVIDE (__noinit_end = .);}
++  }"
++test "${HAVE_PERSISTENT}" = "yes" && PERSISTENT="
++  /* This section contains data that is initialized during load,
++     but not during the application's initialization sequence.  */
++  .persistent :
++  {
++    ${RELOCATING+. = ALIGN(${ALIGNMENT});}
++    ${RELOCATING+PROVIDE (__persistent_start = .);}
++    *(.persistent${RELOCATING+ .persistent.* .gnu.linkonce.p.*})
++    ${RELOCATING+. = ALIGN(${ALIGNMENT});}
++    ${RELOCATING+PROVIDE (__persistent_end = .);}
+   }"
+ 
+-# if this is for an embedded system, don't add SIZEOF_HEADERS.
++TEXT_START_ADDR="SEGMENT_START(\"text-segment\", ${TEXT_START_ADDR})"
++SHLIB_TEXT_START_ADDR="SEGMENT_START(\"text-segment\", ${SHLIB_TEXT_START_ADDR:-0})"
++
++# Don't bother with separate code segment when there are data sections
++# between .plt and .text.
++if test -z "$TINY_READONLY_SECTION"; then
++  case "$LD_FLAG" in
++    *textonly*)
++      SEPARATE_TEXT=" "
++      TEXT_SEGMENT_ALIGN=". = ALIGN(${MAXPAGESIZE});"
++      ;;
++  esac
++fi
++
++if [ -z "$SEPARATE_CODE" ]; then
++  SIZEOF_HEADERS_CODE=" + SIZEOF_HEADERS"
++else
++  SIZEOF_HEADERS_CODE=
++fi
++
++# If this is for an embedded system, don't add SIZEOF_HEADERS.
+ if [ -z "$EMBEDDED" ]; then
+-   test -z "${TEXT_BASE_ADDRESS}" && TEXT_BASE_ADDRESS="${TEXT_START_ADDR} + SIZEOF_HEADERS"
++   test -z "${TEXT_BASE_ADDRESS}" && TEXT_BASE_ADDRESS="${TEXT_START_ADDR}${SIZEOF_HEADERS_CODE}"
+ else
+    test -z "${TEXT_BASE_ADDRESS}" && TEXT_BASE_ADDRESS="${TEXT_START_ADDR}"
+ fi
+ 
+ cat <<EOF
++/* Copyright (C) 2014-2023 Free Software Foundation, Inc.
++
++   Copying and distribution of this script, with or without modification,
++   are permitted in any medium without royalty provided the copyright
++   notice and this notice are preserved.  */
++
+ OUTPUT_FORMAT("${OUTPUT_FORMAT}", "${BIG_OUTPUT_FORMAT}",
+ 	      "${LITTLE_OUTPUT_FORMAT}")
+ OUTPUT_ARCH(${OUTPUT_ARCH})
+-ENTRY(${ENTRY})
++${RELOCATING+ENTRY(${ENTRY})}
+ 
+ ${RELOCATING+${LIB_SEARCH_DIRS}}
+-${RELOCATING+${EXECUTABLE_SYMBOLS}}
++${RELOCATING+${CREATE_SHLIB-${EXECUTABLE_SYMBOLS}}}
+ ${RELOCATING+${INPUT_FILES}}
+ ${RELOCATING- /* For some reason, the Solaris linker makes bad executables
+   if gld -r is used and the intermediate file has sections starting
+@@ -263,13 +399,25 @@ ${RELOCATING- /* For some reason, the Solaris linker makes bad executables
+ 
+ SECTIONS
+ {
+-  /* Read-only sections, merged into text segment: */
++  ${RELOCATING+${SEPARATE_TEXT-/* Read-only sections, merged into text segment: */}}
+   ${CREATE_SHLIB-${CREATE_PIE-${RELOCATING+PROVIDE (__executable_start = ${TEXT_START_ADDR}); . = ${TEXT_BASE_ADDRESS};}}}
+-  ${CREATE_SHLIB+${RELOCATING+. = ${SHLIB_TEXT_START_ADDR:-0} + SIZEOF_HEADERS;}}
+-  ${CREATE_PIE+${RELOCATING+. = ${SHLIB_TEXT_START_ADDR:-0} + SIZEOF_HEADERS;}}
++  ${CREATE_SHLIB+${RELOCATING+. = ${SHLIB_TEXT_START_ADDR}${SIZEOF_HEADERS_CODE};}}
++  ${CREATE_PIE+${RELOCATING+PROVIDE (__executable_start = ${SHLIB_TEXT_START_ADDR}); . = ${SHLIB_TEXT_START_ADDR}${SIZEOF_HEADERS_CODE};}}
++EOF
++
++emit_early_ro()
++{
++  cat <<EOF
+   ${INITIAL_READONLY_SECTIONS}
+-  .note.gnu.build-id : { *(.note.gnu.build-id) }
++  .note.gnu.build-id ${RELOCATING-0}: { *(.note.gnu.build-id) }
++EOF
++}
+ 
++test -n "${SEPARATE_CODE}" || emit_early_ro
++
++test -n "${RELOCATING+0}" || unset NON_ALLOC_DYN
++test -z "${NON_ALLOC_DYN}" || TEXT_DYNAMIC=
++cat > ldscripts/dyntmp.$$ <<EOF
+   ${TEXT_DYNAMIC+${DYNAMIC}}
+   .hash         ${RELOCATING-0} : { *(.hash) }
+   .gnu.hash     ${RELOCATING-0} : { *(.gnu.hash) }
+@@ -281,24 +429,26 @@ SECTIONS
+ EOF
+ 
+ if [ "x$COMBRELOC" = x ]; then
+-  COMBRELOCCAT=cat
++  COMBRELOCCAT="cat >> ldscripts/dyntmp.$$"
+ else
+   COMBRELOCCAT="cat > $COMBRELOC"
+ fi
+ eval $COMBRELOCCAT <<EOF
++  ${INITIAL_RELOC_SECTIONS}
+   .rel.init     ${RELOCATING-0} : { *(.rel.init) }
+   .rela.init    ${RELOCATING-0} : { *(.rela.init) }
+   .rel.text     ${RELOCATING-0} : { *(.rel.text${RELOCATING+ .rel.text.* .rel.gnu.linkonce.t.*}) }
+   .rela.text    ${RELOCATING-0} : { *(.rela.text${RELOCATING+ .rela.text.* .rela.gnu.linkonce.t.*}) }
+   .rel.fini     ${RELOCATING-0} : { *(.rel.fini) }
+   .rela.fini    ${RELOCATING-0} : { *(.rela.fini) }
+-  .rel.rodata   ${RELOCATING-0} : { *(.rel.rodata${RELOCATING+ .rel.rodata.* .rel.gnu.linkonce.r.*}) }
+-  .rela.rodata  ${RELOCATING-0} : { *(.rela.rodata${RELOCATING+ .rela.rodata.* .rela.gnu.linkonce.r.*}) }
++  .rel.${RODATA_NAME}   ${RELOCATING-0} : { *(.rel.${RODATA_NAME}${RELOCATING+ .rel.${RODATA_NAME}.* .rel.gnu.linkonce.r.*}) }
++  .rela.${RODATA_NAME}  ${RELOCATING-0} : { *(.rela.${RODATA_NAME}${RELOCATING+ .rela.${RODATA_NAME}.* .rela.gnu.linkonce.r.*}) }
+   ${OTHER_READONLY_RELOC_SECTIONS}
+-  .rel.data.rel.ro ${RELOCATING-0} : { *(.rel.data.rel.ro${RELOCATING+* .rel.gnu.linkonce.d.rel.ro.*}) }
+-  .rela.data.rel.ro ${RELOCATING-0} : { *(.rela.data.rel.ro${RELOCATING+* .rela.gnu.linkonce.d.rel.ro.*}) }
++  .rel.data.rel.ro ${RELOCATING-0} : { *(.rel.data.rel.ro${RELOCATING+ .rel.data.rel.ro.* .rel.gnu.linkonce.d.rel.ro.*}) }
++  .rela.data.rel.ro ${RELOCATING-0} : { *(.rela.data.rel.ro${RELOCATING+ .rela.data.rel.ro.* .rela.gnu.linkonce.d.rel.ro.*}) }
+   .rel.data     ${RELOCATING-0} : { *(.rel.data${RELOCATING+ .rel.data.* .rel.gnu.linkonce.d.*}) }
+   .rela.data    ${RELOCATING-0} : { *(.rela.data${RELOCATING+ .rela.data.* .rela.gnu.linkonce.d.*}) }
++  ${OTHER_READWRITE_RELOC_SECTIONS}
+   .rel.tdata	${RELOCATING-0} : { *(.rel.tdata${RELOCATING+ .rel.tdata.* .rel.gnu.linkonce.td.*}) }
+   .rela.tdata	${RELOCATING-0} : { *(.rela.tdata${RELOCATING+ .rela.tdata.* .rela.gnu.linkonce.td.*}) }
+   .rel.tbss	${RELOCATING-0} : { *(.rel.tbss${RELOCATING+ .rel.tbss.* .rel.gnu.linkonce.tb.*}) }
+@@ -314,106 +464,180 @@ eval $COMBRELOCCAT <<EOF
+   ${REL_SBSS}
+   ${REL_SDATA2}
+   ${REL_SBSS2}
+-  .rel.bss      ${RELOCATING-0} : { *(.rel.bss${RELOCATING+ .rel.bss.* .rel.gnu.linkonce.b.*}) }
+-  .rela.bss     ${RELOCATING-0} : { *(.rela.bss${RELOCATING+ .rela.bss.* .rela.gnu.linkonce.b.*}) }
++  .rel.${BSS_NAME}      ${RELOCATING-0} : { *(.rel.${BSS_NAME}${RELOCATING+ .rel.${BSS_NAME}.* .rel.gnu.linkonce.b.*}) }
++  .rela.${BSS_NAME}     ${RELOCATING-0} : { *(.rela.${BSS_NAME}${RELOCATING+ .rela.${BSS_NAME}.* .rela.gnu.linkonce.b.*}) }
+   ${REL_LARGE}
++  ${IREL_IN_PLT+$REL_IFUNC}
++  ${IREL_IN_PLT+$RELA_IFUNC}
++  ${IREL_IN_PLT-$REL_IPLT}
++  ${IREL_IN_PLT-$RELA_IPLT}
+ EOF
+ 
+ if [ -n "$COMBRELOC" ]; then
+-cat <<EOF
++cat >> ldscripts/dyntmp.$$ <<EOF
+   .rel.dyn      ${RELOCATING-0} :
+     {
+ EOF
+-sed -e '/^[ 	]*[{}][ 	]*$/d;/:[ 	]*$/d;/\.rela\./d;s/^.*: { *\(.*\)}$/      \1/' $COMBRELOC
+-cat <<EOF
++sed -e '/^[	 ]*[{}][	 ]*$/d;/:[	 ]*$/d;/\.rela\./d;/__rela_iplt_/d;s/^.*: { *\(.*\)}$/      \1/' $COMBRELOC >> ldscripts/dyntmp.$$
++cat >> ldscripts/dyntmp.$$ <<EOF
+     }
+   .rela.dyn     ${RELOCATING-0} :
+     {
+ EOF
+-sed -e '/^[ 	]*[{}][ 	]*$/d;/:[ 	]*$/d;/\.rel\./d;s/^.*: { *\(.*\)}/      \1/' $COMBRELOC
+-cat <<EOF
++sed -e '/^[	 ]*[{}][	 ]*$/d;/:[	 ]*$/d;/\.rel\./d;/__rel_iplt_/d;s/^.*: { *\(.*\)}/      \1/' $COMBRELOC >> ldscripts/dyntmp.$$
++cat >> ldscripts/dyntmp.$$ <<EOF
+     }
+ EOF
+ fi
+ 
+-cat <<EOF
+-  .rel.plt      ${RELOCATING-0} : { *(.rel.plt) }
+-  .rela.plt     ${RELOCATING-0} : { *(.rela.plt) }
++cat >> ldscripts/dyntmp.$$ <<EOF
++  .rel.plt      ${RELOCATING-0} :
++    {
++      *(.rel.plt)
++      ${IREL_IN_PLT+${RELOCATING+${CREATE_PIC-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__rel_iplt_start = .);}}}
++      ${IREL_IN_PLT+${RELOCATING+*(.rel.iplt)}}
++      ${IREL_IN_PLT+${RELOCATING+${CREATE_PIC-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__rel_iplt_end = .);}}}
++    }
++  .rela.plt     ${RELOCATING-0} :
++    {
++      *(.rela.plt)
++      ${IREL_IN_PLT+${RELOCATING+${CREATE_PIC-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__rela_iplt_start = .);}}}
++      ${IREL_IN_PLT+${RELOCATING+*(.rela.iplt)}}
++      ${IREL_IN_PLT+${RELOCATING+${CREATE_PIC-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__rela_iplt_end = .);}}}
++    }
+   ${OTHER_PLT_RELOC_SECTIONS}
++EOF
++
++emit_dyn()
++{
++  if test -z "${NO_REL_RELOCS}${NO_RELA_RELOCS}"; then
++    cat ldscripts/dyntmp.$$
++  else
++    if test -z "${NO_REL_RELOCS}"; then
++      sed -e '/^[	 ]*\.rela\.[^}]*$/,/}/d;/^[	 ]*\.rela\./d;/__rela_iplt_/d' ldscripts/dyntmp.$$
++    fi
++    if test -z "${NO_RELA_RELOCS}"; then
++      sed -e '/^[	 ]*\.rel\.[^}]*$/,/}/d;/^[	 ]*\.rel\./d;/__rel_iplt_/d' ldscripts/dyntmp.$$
++    fi
++  fi
++  rm -f ldscripts/dyntmp.$$
++  if test -n "${HAVE_DT_RELR}"; then
++    echo "  .relr.dyn : { *(.relr.dyn) }"
++  fi
++}
++
++test -n "${NON_ALLOC_DYN}${SEPARATE_CODE}" || emit_dyn
+ 
++cat <<EOF
++  ${RELOCATING+${TEXT_SEGMENT_ALIGN}}
+ 
+-  .init         ${RELOCATING-0} : 
+-  { 
++  .init         ${RELOCATING-0}${RELOCATING+${INIT_ADDR}} :
++  {
+     ${RELOCATING+${INIT_START}}
+-    KEEP (*(.init))
++    KEEP (*(SORT_NONE(.init)))
+     ${RELOCATING+${INIT_END}}
+-  } =${NOP-0}
++  } ${FILL}
+ 
    ${TINY_READONLY_SECTION}
    .text         ${RELOCATING-0} :
    {
      ${RELOCATING+${TEXT_START_SYMBOLS}}
-     ${RELOCATING+*(.text.unlikely .text.*_unlikely .text.unlikely.*)}
-     ${RELOCATING+*(.text.exit .text.exit.*)}
-@@ -550,12 +549,15 @@ cat <<EOF
-     ${RELOCATING+*(SORT(.text.sorted.*))}
++    ${RELOCATING+*(.text.unlikely .text.*_unlikely .text.unlikely.*)}
++    ${RELOCATING+*(.text.exit .text.exit.*)}
++    ${RELOCATING+*(.text.startup .text.startup.*)}
++    ${RELOCATING+*(.text.hot .text.hot.*)}
++    ${RELOCATING+*(SORT(.text.sorted.*))}
      *(.text .stub${RELOCATING+ .text.* .gnu.linkonce.t.*})
-     /* .gnu.warning sections are handled specially by elf.em.  */
+-	KEEP (*(.text.*personality*))
+-    /* .gnu.warning sections are handled specially by elf32.em.  */
++    /* .gnu.warning sections are handled specially by elf.em.  */
      *(.gnu.warning)
      ${RELOCATING+${OTHER_TEXT_SECTIONS}}
-   } ${FILL}
-+  . = ALIGN(4096);
+-  } =${NOP-0}
++  } ${FILL}
+   . = ALIGN(4096);
+-  ${TEXT_PLT+${PLT}}
 +  ${TEXT_PLT+${PLT_NEXT_DATA-${PLT} ${OTHER_PLT_SECTIONS}}}
-+  . = ALIGN(4096);
-   .fini         ${RELOCATING-0}${RELOCATING+${FINI_ADDR}} :
+   . = ALIGN(4096);
+-  .fini         ${RELOCATING-0} :
++  .fini         ${RELOCATING-0}${RELOCATING+${FINI_ADDR}} :
    {
      ${RELOCATING+${FINI_START}}
-     KEEP (*(SORT_NONE(.fini)))
+-    KEEP (*(.fini))
++    KEEP (*(SORT_NONE(.fini)))
      ${RELOCATING+${FINI_END}}
-   } ${FILL}
+-  } =${NOP-0}
+-  ${RELOCATING+PROVIDE (__${ETEXT_NAME} = .);}
+-  ${RELOCATING+PROVIDE (_${ETEXT_NAME} = .);}
+-  ${RELOCATING+PROVIDE (${ETEXT_NAME} = .);}
++  } ${FILL}
++  ${RELOCATING+${ETEXT_LAST_IN_RODATA_SEGMENT-PROVIDE (__${ETEXT_NAME} = .);}}
++  ${RELOCATING+${ETEXT_LAST_IN_RODATA_SEGMENT-PROVIDE (_${ETEXT_NAME} = .);}}
++  ${RELOCATING+${ETEXT_LAST_IN_RODATA_SEGMENT-PROVIDE (${ETEXT_NAME} = .);}}
++  ${RELOCATING+${TEXT_SEGMENT_ALIGN}}
++EOF
++
++if test -n "${SEPARATE_CODE}${SEPARATE_TEXT}"; then
++  if test -n "${RODATA_ADDR}"; then
++    RODATA_ADDR="\
++SEGMENT_START(\"rodata-segment\", ${RODATA_ADDR}) + SIZEOF_HEADERS"
++  else
++    RODATA_ADDR="ALIGN(${SEGMENT_SIZE}) + (. & (${MAXPAGESIZE} - 1))"
++    RODATA_ADDR="SEGMENT_START(\"rodata-segment\", ${RODATA_ADDR})"
++  fi
++  if test -n "${SHLIB_RODATA_ADDR}"; then
++    SHLIB_RODATA_ADDR="\
++SEGMENT_START(\"rodata-segment\", ${SHLIB_RODATA_ADDR}) + SIZEOF_HEADERS"
++  else
++    SHLIB_RODATA_ADDR="ALIGN(${SEGMENT_SIZE}) + (. & (${MAXPAGESIZE} - 1))"
++    SHLIB_RODATA_ADDR="SEGMENT_START(\"rodata-segment\", ${SHLIB_RODATA_ADDR})"
++  fi
++  cat <<EOF
++  ${RELOCATING+/* Adjust the address for the rodata segment.  We want to adjust up to
++     the same address within the page on the next page up.  */
++  ${CREATE_SHLIB-${CREATE_PIE-. = ${RODATA_ADDR};}}
++  ${CREATE_SHLIB+. = ${SHLIB_RODATA_ADDR};}
++  ${CREATE_PIE+. = ${SHLIB_RODATA_ADDR};}}
++EOF
++  if test -n "${SEPARATE_CODE}"; then
++    emit_early_ro
++    emit_dyn
++  fi
++fi
++
++cat <<EOF
+   ${WRITABLE_RODATA-${RODATA}}
+-  .rodata1      ${RELOCATING-0} : { *(.rodata1) }
++  .${RODATA_NAME}1      ${RELOCATING-0} : { *(.${RODATA_NAME}1) }
+   ${CREATE_SHLIB-${SDATA2}}
+   ${CREATE_SHLIB-${SBSS2}}
+   ${OTHER_READONLY_SECTIONS}
+-  .eh_frame_hdr : { *(.eh_frame_hdr) }
+-  .eh_frame     ${RELOCATING-0} : ONLY_IF_RO { KEEP (*(.eh_frame)) }
+-  .gcc_except_table ${RELOCATING-0} : ONLY_IF_RO { *(.gcc_except_table .gcc_except_table.*) }
++  .eh_frame_hdr ${RELOCATING-0} : { *(.eh_frame_hdr)${RELOCATING+ *(.eh_frame_entry .eh_frame_entry.*)} }
++  .eh_frame     ${RELOCATING-0} : ONLY_IF_RO { KEEP (*(.eh_frame))${RELOCATING+ *(.eh_frame.*)} }
++  .sframe       ${RELOCATING-0} : ONLY_IF_RO { *(.sframe)${RELOCATING+ *(.sframe.*)} }
++  .gcc_except_table ${RELOCATING-0} : ONLY_IF_RO { *(.gcc_except_table${RELOCATING+ .gcc_except_table.*}) }
++  .gnu_extab ${RELOCATING-0} : ONLY_IF_RO { *(.gnu_extab*) }
++  /* These sections are generated by the Sun/Oracle C++ compiler.  */
++  .exception_ranges ${RELOCATING-0} : ONLY_IF_RO { *(.exception_ranges${RELOCATING+*}) }
++  ${TEXT_PLT+${PLT_NEXT_DATA+${PLT} ${OTHER_PLT_SECTIONS}}}
+ 
+-  /* Adjust the address for the data segment.  We want to adjust up to
+-     the same address within the page on the next page up.  */
++  ${RELOCATING+${ETEXT_LAST_IN_RODATA_SEGMENT+PROVIDE (__${ETEXT_NAME} = .);}}
++  ${RELOCATING+${ETEXT_LAST_IN_RODATA_SEGMENT+PROVIDE (_${ETEXT_NAME} = .);}}
++  ${RELOCATING+${ETEXT_LAST_IN_RODATA_SEGMENT+PROVIDE (${ETEXT_NAME} = .);}}
++
++  ${RELOCATING+/* Adjust the address for the data segment.  We want to adjust up to
++     the same address within the page on the next page up.  */}
+   ${CREATE_SHLIB-${CREATE_PIE-${RELOCATING+. = ${DATA_ADDR-${DATA_SEGMENT_ALIGN}};}}}
+-  ${CREATE_SHLIB+${RELOCATING+. = ${SHLIB_DATA_ADDR-${DATA_SEGMENT_ALIGN}};}}
+-  ${CREATE_PIE+${RELOCATING+. = ${SHLIB_DATA_ADDR-${DATA_SEGMENT_ALIGN}};}}
++  ${CREATE_SHLIB+. = ${SHLIB_DATA_ADDR-${DATA_SEGMENT_ALIGN}};}
++  ${CREATE_PIE+. = ${SHLIB_DATA_ADDR-${DATA_SEGMENT_ALIGN}};}
+ 
+   /* Exception handling  */
+-  .eh_frame     ${RELOCATING-0} : ONLY_IF_RW { KEEP (*(.eh_frame)) }
+-  .gcc_except_table ${RELOCATING-0} : ONLY_IF_RW { *(.gcc_except_table .gcc_except_table.*) }
++  .eh_frame     ${RELOCATING-0} : ONLY_IF_RW { KEEP (*(.eh_frame))${RELOCATING+ *(.eh_frame.*)} }
++  .sframe       ${RELOCATING-0} : ONLY_IF_RW { *(.sframe)${RELOCATING+ *(.sframe.*)} }
++  .gnu_extab    ${RELOCATING-0} : ONLY_IF_RW { *(.gnu_extab) }
++  .gcc_except_table ${RELOCATING-0} : ONLY_IF_RW { *(.gcc_except_table${RELOCATING+ .gcc_except_table.*}) }
++  .exception_ranges ${RELOCATING-0} : ONLY_IF_RW { *(.exception_ranges${RELOCATING+*}) }
+ 
+   /* Thread Local Storage sections  */
+-  .tdata	${RELOCATING-0} : { *(.tdata${RELOCATING+ .tdata.* .gnu.linkonce.td.*}) }
++  .tdata	${RELOCATING-0} :
++   {
++     ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__tdata_start = .);}}
++     *(.tdata${RELOCATING+ .tdata.* .gnu.linkonce.td.*})
++   }
+   .tbss		${RELOCATING-0} : { *(.tbss${RELOCATING+ .tbss.* .gnu.linkonce.tb.*})${RELOCATING+ *(.tcommon)} }
+ 
+-  .preinit_array   ${RELOCATING-0} :
+-  {
+-    ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__preinit_array_start = .);}}
+-    KEEP (*(.preinit_array))
+-    ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__preinit_array_end = .);}}
+-  }
+-  .init_array   ${RELOCATING-0} :
+-  {
+-     ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__init_array_start = .);}}
+-     KEEP (*(SORT(.init_array.*)))
+-     KEEP (*(.init_array))
+-     ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__init_array_end = .);}}
+-  }
+-  .fini_array   ${RELOCATING-0} :
+-  {
+-    ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__fini_array_start = .);}}
+-    KEEP (*(.fini_array))
+-    KEEP (*(SORT(.fini_array.*)))
+-    ${RELOCATING+${CREATE_SHLIB-PROVIDE_HIDDEN (${USER_LABEL_PREFIX}__fini_array_end = .);}}
+-  }
++  ${RELOCATING+${PREINIT_ARRAY}}
++  ${RELOCATING+${INIT_ARRAY}}
++  ${RELOCATING+${FINI_ARRAY}}
+   ${SMALL_DATA_CTOR-${RELOCATING+${CTOR}}}
+   ${SMALL_DATA_DTOR-${RELOCATING+${DTOR}}}
+   .jcr          ${RELOCATING-0} : { KEEP (*(.jcr)) }
+@@ -421,10 +645,17 @@ cat <<EOF
+   ${RELOCATING+${DATARELRO}}
+   ${OTHER_RELRO_SECTIONS}
+   ${TEXT_DYNAMIC-${DYNAMIC}}
++  ${OTHER_RELRO_SECTIONS_2}
++  ${DATA_GOT+${RELRO_NOW+${DATA_PLT+${PLT_BEFORE_GOT+${PLT}}}}}
+   ${DATA_GOT+${RELRO_NOW+${GOT}}}
+   ${DATA_GOT+${RELRO_NOW+${GOTPLT}}}
+   ${DATA_GOT+${RELRO_NOW-${SEPARATE_GOTPLT+${GOT}}}}
+   ${RELOCATING+${DATA_SEGMENT_RELRO_END}}
++  ${INITIAL_READWRITE_SECTIONS}
++  ${DATA_SDATA+${SDATA}}
++  ${DATA_SDATA+${OTHER_SDATA_SECTIONS}}
++  ${DATA_SDATA+${SBSS}}
++  ${DATA_GOT+${RELRO_NOW-${DATA_PLT+${PLT_BEFORE_GOT+${PLT}}}}}
+   ${DATA_GOT+${RELRO_NOW-${SEPARATE_GOTPLT-${GOT}}}}
+   ${DATA_GOT+${RELRO_NOW-${GOTPLT}}}
+ 
+@@ -434,7 +665,6 @@ cat <<EOF
+   {
+     ${RELOCATING+${DATA_START_SYMBOLS}}
+     *(.data${RELOCATING+ .data.* .gnu.linkonce.d.*})
+-    ${RELOCATING+KEEP (*(.gnu.linkonce.d.*personality*))}
+     ${CONSTRUCTING+SORT(CONSTRUCTORS)}
+   }
+   .data1        ${RELOCATING-0} : { *(.data1) }
+@@ -442,38 +672,59 @@ cat <<EOF
+   ${OTHER_READWRITE_SECTIONS}
+   ${SMALL_DATA_CTOR+${RELOCATING+${CTOR}}}
+   ${SMALL_DATA_DTOR+${RELOCATING+${DTOR}}}
+-  ${DATA_PLT+${PLT_BEFORE_GOT+${PLT}}}
+-  ${SDATA_GOT+${RELOCATING+${OTHER_GOT_SYMBOLS}}}
++  ${SDATA_GOT+${DATA_PLT+${PLT_BEFORE_GOT+${PLT}}}}
++  ${SDATA_GOT+${RELOCATING+${OTHER_GOT_SYMBOLS+. = .; ${OTHER_GOT_SYMBOLS}}}}
+   ${SDATA_GOT+${GOT}}
+   ${SDATA_GOT+${OTHER_GOT_SECTIONS}}
+-  ${SDATA}
+-  ${OTHER_SDATA_SECTIONS}
+-  ${RELOCATING+${DATA_END_SYMBOLS-${USER_LABEL_PREFIX}_edata = .; PROVIDE (${USER_LABEL_PREFIX}edata = .);}}
+-  ${RELOCATING+__bss_start = .;}
++  ${DATA_SDATA-${SDATA}}
++  ${DATA_SDATA-${OTHER_SDATA_SECTIONS}}
++  ${RELOCATING+${DATA_END_SYMBOLS-${CREATE_SHLIB+PROVIDE (}${USER_LABEL_PREFIX}_edata = .${CREATE_SHLIB+)}; PROVIDE (${USER_LABEL_PREFIX}edata = .);}}
++  ${PERSISTENT}
++  ${RELOCATING+. = .;}
++  ${RELOCATING+${CREATE_SHLIB+PROVIDE (}${USER_LABEL_PREFIX}__bss_start = .${CREATE_SHLIB+)};}
+   ${RELOCATING+${OTHER_BSS_SYMBOLS}}
+-  ${SBSS}
++  ${DATA_SDATA-${SBSS}}
+   ${BSS_PLT+${PLT}}
+-  .bss          ${RELOCATING-0} :
++  .${BSS_NAME}          ${RELOCATING-0} :
+   {
+-   *(.dynbss)
+-   *(.bss${RELOCATING+ .bss.* .gnu.linkonce.b.*})
+-   *(COMMON)
++   ${RELOCATING+*(.dynbss)}
++   *(.${BSS_NAME}${RELOCATING+ .${BSS_NAME}.* .gnu.linkonce.b.*})
++   ${RELOCATING+*(COMMON)
+    /* Align here to ensure that the .bss section occupies space up to
+       _end.  Align after .bss to ensure correct alignment even if the
+       .bss section disappears because there are no input sections.
+-      FIXME: Why do we need it? When there is no .bss section, we don't
++      FIXME: Why do we need it? When there is no .bss section, we do not
+       pad the .data section.  */
+-   ${RELOCATING+. = ALIGN(. != 0 ? ${ALIGNMENT} : 1);}
++   . = ALIGN(. != 0 ? ${ALIGNMENT} : 1);}
+   }
+   ${OTHER_BSS_SECTIONS}
++  ${LARGE_BSS_AFTER_BSS+${LARGE_BSS}}
+   ${RELOCATING+${OTHER_BSS_END_SYMBOLS}}
++  ${NOINIT}
+   ${RELOCATING+. = ALIGN(${ALIGNMENT});}
++EOF
++
++LARGE_DATA_ADDR=". = SEGMENT_START(\"ldata-segment\", ${LARGE_DATA_ADDR-.});"
++SHLIB_LARGE_DATA_ADDR=". = SEGMENT_START(\"ldata-segment\", ${SHLIB_LARGE_DATA_ADDR-.});"
++
++cat <<EOF
++  ${RELOCATING+${CREATE_SHLIB-${CREATE_PIE-${LARGE_DATA_ADDR}}}}
++  ${CREATE_SHLIB+${SHLIB_LARGE_DATA_ADDR}}
++  ${CREATE_PIE+${SHLIB_LARGE_DATA_ADDR}}
+   ${LARGE_SECTIONS}
++  ${LARGE_BSS_AFTER_BSS-${LARGE_BSS}}
+   ${RELOCATING+. = ALIGN(${ALIGNMENT});}
+   ${RELOCATING+${OTHER_END_SYMBOLS}}
+-  ${RELOCATING+${END_SYMBOLS-${USER_LABEL_PREFIX}_end = .; PROVIDE (${USER_LABEL_PREFIX}end = .);}}
++  ${RELOCATING+${END_SYMBOLS-${CREATE_SHLIB+PROVIDE (}${USER_LABEL_PREFIX}_end = .${CREATE_SHLIB+)}; PROVIDE (${USER_LABEL_PREFIX}end = .);}}
+   ${RELOCATING+${DATA_SEGMENT_END}}
++  ${TINY_DATA_SECTION}
++  ${TINY_BSS_SECTION}
++  ${STACK_ADDR+${STACK}}
++EOF
+ 
++test -z "${NON_ALLOC_DYN}" || emit_dyn
++
++cat <<EOF
+   /* Stabs debugging sections.  */
+   .stab          0 : { *(.stab) }
+   .stabstr       0 : { *(.stabstr) }
+@@ -484,18 +735,16 @@ cat <<EOF
+ 
+   .comment       0 : { *(.comment) }
+ 
++  .gnu.build.attributes : { *(.gnu.build.attributes${RELOCATING+ .gnu.build.attributes.*}) }
++
+ EOF
+ 
+ . $srcdir/scripttempl/DWARF.sc
+ 
+ cat <<EOF
+-  ${TINY_DATA_SECTION}
+-  ${TINY_BSS_SECTION}
+-
+-  ${STACK_ADDR+${STACK}}
+   ${ATTRS_SECTIONS}
+   ${OTHER_SECTIONS}
+   ${RELOCATING+${OTHER_SYMBOLS}}
+   ${RELOCATING+${DISCARDED}}
+ }
+-EOF
+\ No newline at end of file
++EOF
+-- 
+2.43.0
+
+
+From f1f7ca965b94f18f7ac9824f44c180b509333f97 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 3 Nov 2023 12:12:42 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 14/61] 
+ Removed debug printf, close #19
+
+---
+ ld/ldmain.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/ld/ldmain.c b/ld/ldmain.c
+index 04b3322fcc3..308928445fe 100644
+--- a/ld/ldmain.c
++++ b/ld/ldmain.c
+@@ -499,7 +499,6 @@ main (int argc, char **argv)
+     /* Print error messages for any missing symbols, for any warning
+      symbols, and possibly multiple definitions.  */
+ #ifdef __amigaos4__
+-printf( "%s:%d:Make all stuff excuatbel for aos4!\n", __FILE__, __LINE__ );
+   /* Make all files executable, even relocatable files */
+     link_info.output_bfd->flags |= EXEC_P;
+ #else
+-- 
+2.43.0
+
+
+From 5aa0abed6149329d8d479cbc3b2448ceb7febdf8 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 30 Oct 2023 15:22:42 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 15/61] 
+ Added pex amiga solution
+
+---
+ libiberty/Makefile.in   |  14 +-
+ libiberty/configure     |   1 +
+ libiberty/configure.ac  |   1 +
+ libiberty/pex-amigaos.c | 325 ++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 339 insertions(+), 2 deletions(-)
+ create mode 100644 libiberty/pex-amigaos.c
+
 diff --git a/libiberty/Makefile.in b/libiberty/Makefile.in
-index f9fbba23e2c81793bb7271f069b663b52813e812..8bbad59fcc5b137a4cfeb74995a0a05e2f5e8a7b 100644
+index f9fbba23e2c..8bbad59fcc5 100644
 --- a/libiberty/Makefile.in
 +++ b/libiberty/Makefile.in
-@@ -140,13 +140,13 @@ CFILES = alloca.c argv.c asprintf.c atexit.c				\
- 	make-relative-prefix.c						\
- 	make-temp-file.c md5.c memchr.c memcmp.c memcpy.c memmem.c	\
- 	 memmove.c mempcpy.c memset.c mkstemps.c			\
+@@ -143,7 +143,7 @@ CFILES = alloca.c argv.c asprintf.c atexit.c				\
  	objalloc.c obstack.c						\
  	partition.c pexecute.c						\
  	 pex-common.c pex-djgpp.c pex-msdos.c pex-one.c			\
@@ -4178,13 +8841,7 @@ index f9fbba23e2c81793bb7271f069b663b52813e812..8bbad59fcc5b137a4cfeb74995a0a05e
           physmem.c putenv.c						\
  	random.c regex.c rename.c rindex.c				\
  	rust-demangle.c							\
- 	safe-ctype.c setenv.c setproctitle.c sha1.c sigsetmask.c        \
- 	 simple-object.c simple-object-coff.c simple-object-elf.c	\
- 	 simple-object-mach-o.c simple-object-xcoff.c			\
-@@ -213,13 +213,13 @@ CONFIGURED_OFILES = ./asprintf.$(objext) ./atexit.$(objext)		\
- 	 ./gettimeofday.$(objext)					\
- 	./index.$(objext) ./insque.$(objext)				\
- 	./memchr.$(objext) ./memcmp.$(objext) ./memcpy.$(objext) 	\
+@@ -216,7 +216,7 @@ CONFIGURED_OFILES = ./asprintf.$(objext) ./atexit.$(objext)		\
  	./memmem.$(objext) ./memmove.$(objext)				\
  	 ./mempcpy.$(objext) ./memset.$(objext) ./mkstemps.$(objext)	\
  	./pex-djgpp.$(objext) ./pex-msdos.$(objext)			\
@@ -4193,13 +8850,7 @@ index f9fbba23e2c81793bb7271f069b663b52813e812..8bbad59fcc5b137a4cfeb74995a0a05e
  	 ./putenv.$(objext)						\
  	./random.$(objext) ./rename.$(objext) ./rindex.$(objext)	\
  	./setenv.$(objext) 						\
- 	 ./setproctitle.$(objext)					\
- 	 ./sigsetmask.$(objext) ./snprintf.$(objext)			\
- 	 ./stpcpy.$(objext) ./stpncpy.$(objext) ./strcasecmp.$(objext)	\
-@@ -1162,12 +1162,22 @@ $(CONFIGURED_OFILES): stamp-picdir stamp-noasandir
- 	else true; fi
- 	if [ x"$(NOASANFLAG)" != x ]; then \
- 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/pex-unix.c -o noasan/$@; \
+@@ -1165,6 +1165,16 @@ $(CONFIGURED_OFILES): stamp-picdir stamp-noasandir
  	else true; fi
  	$(COMPILE.c) $(srcdir)/pex-unix.c $(OUTPUT_OPTION)
  
@@ -4216,144 +8867,33 @@ index f9fbba23e2c81793bb7271f069b663b52813e812..8bbad59fcc5b137a4cfeb74995a0a05e
  ./pex-win32.$(objext): $(srcdir)/pex-win32.c config.h $(INCDIR)/ansidecl.h \
  	$(INCDIR)/libiberty.h $(srcdir)/pex-common.h
  	if [ x"$(PICFLAG)" != x ]; then \
- 	  $(COMPILE.c) $(PICFLAG) $(srcdir)/pex-win32.c -o pic/$@; \
- 	else true; fi
- 	if [ x"$(NOASANFLAG)" != x ]; then \
 diff --git a/libiberty/configure b/libiberty/configure
-index 1ccfac9fb11f334926f253d284b03a8335d94b2e..e5433eda5cf3bbe9527f12bae015535938e4995f 100755
+index 1ccfac9fb11..0d5a7860758 100755
 --- a/libiberty/configure
 +++ b/libiberty/configure
-@@ -7537,12 +7537,13 @@ fi
- 
- # Figure out which version of pexecute to use.
- case "${host}" in
+@@ -7540,6 +7540,7 @@ case "${host}" in
       *-*-mingw* | *-*-winnt*)	pexecute=pex-win32  ;;
       *-*-msdosdjgpp*)		pexecute=pex-djgpp  ;;
       *-*-msdos*)		pexecute=pex-msdos  ;;
-+	 powerpc-*-amigaos*)	pexecute=pex-amigaos ;;
++	 ppc-*-amigaos*)	pexecute=pex-amigaos ;;
       *)				pexecute=pex-unix   ;;
  esac
  
- 
- 
- 
 diff --git a/libiberty/configure.ac b/libiberty/configure.ac
-index 6c1ff9c60933a95a150334652061cd649457eebc..e4aa76595652047ea04754425d5d890abb11cf64 100644
+index 6c1ff9c6093..bf6c7e749bb 100644
 --- a/libiberty/configure.ac
 +++ b/libiberty/configure.ac
-@@ -733,12 +733,13 @@ fi
- 
- # Figure out which version of pexecute to use.
- case "${host}" in
+@@ -736,6 +736,7 @@ case "${host}" in
       *-*-mingw* | *-*-winnt*)	pexecute=pex-win32  ;;
       *-*-msdosdjgpp*)		pexecute=pex-djgpp  ;;
       *-*-msdos*)		pexecute=pex-msdos  ;;
-+	 powerpc-*-amigaos*)	pexecute=pex-amigaos ;;
++	 ppc-*-amigaos*)	pexecute=pex-amigaos ;;
       *)				pexecute=pex-unix   ;;
  esac
  AC_SUBST(pexecute)
- 
- libiberty_AC_FUNC_STRNCMP
- 
-diff --git a/libiberty/fnmatch.c b/libiberty/fnmatch.c
-index 3602059ce8a5897d82fc8be62c40b37344713f0d..4b3e030d040bf102bd1f342c40f2f203338c924d 100644
---- a/libiberty/fnmatch.c
-+++ b/libiberty/fnmatch.c
-@@ -44,20 +44,23 @@ Boston, MA 02110-1301, USA.  */
- #endif
- 
- #include <errno.h>
- #include <fnmatch.h>
- #include <safe-ctype.h>
- 
-+/* Ignore all this code if targeting AmigaOS4 with clib clib4, because
-+   the clib4 clib provided it own fnmatch implementation */
-+#if !(defined(__amigaos4__) && defined(__CLIB4__))
-+
- /* Comment out all this code if we are using the GNU C Library, and are not
-    actually compiling the library itself.  This code is part of the GNU C
-    Library, but also included in many other GNU distributions.  Compiling
-    and linking in this code is a waste when using the GNU C library
-    (especially if it is a shared library).  Rather than having every GNU
-    program understand `configure --with-gnu-libc' and omit the object files,
-    it is simpler to just do this in the source for each such file.  */
--
- #if defined (_LIBC) || !defined (__GNU_LIBRARY__)
- 
- 
- #if !defined(__GNU_LIBRARY__) && !defined(STDC_HEADERS)
- extern int errno;
- #endif
-@@ -215,6 +218,7 @@ fnmatch (const char *pattern, const char *string, int flags)
-     return 0;
- 
-   return FNM_NOMATCH;
- }
- 
- #endif	/* _LIBC or not __GNU_LIBRARY__.  */
-+#endif  /* not (AMIGAOS and CLIB4) $*/
-diff --git a/libiberty/lbasename.c b/libiberty/lbasename.c
-index a7864ab2b8c44c198b210b681efbadfcf8415fbb..d1f40818b2243b317e0d4fc65ee2978297ed890c 100644
---- a/libiberty/lbasename.c
-+++ b/libiberty/lbasename.c
-@@ -70,15 +70,35 @@ dos_lbasename (const char *name)
-     if (IS_DOS_DIR_SEPARATOR (*name))
-       base = name + 1;
- 
-   return base;
- }
- 
-+const char *
-+amiga_lbasename (const char *name)
-+{
-+  const char *base = name;
-+
-+  /* Skip over a possible disk name.  */
-+  if (HAS_AMIGOS_DRIVE_SPEC (name)) {
-+    base = STRIP_DRIVE_SPEC (name);
-+  };
-+
-+  /* Strip any directories */
-+  for (; *name; name++)
-+    if (IS_AMIGOS_DIR_SEPARATOR (*name))
-+      base = name + 1;
-+
-+  return base;
-+}
-+
- const char *
- lbasename (const char *name)
- {
- #if defined (HAVE_DOS_BASED_FILE_SYSTEM)
-   return dos_lbasename (name);
-+#elif defined (HAVE_AMIGA_BASED_FILE_SYSTEM)
-+  return amiga_lbasename (name);
- #else
-   return unix_lbasename (name);
- #endif
- }
-diff --git a/libiberty/make-temp-file.c b/libiberty/make-temp-file.c
-index fae743f398539d5217bcaca5f1a3de7be9f9e547..5f66abacc55f0dde71d19e7543f7e1a6453496a9 100644
---- a/libiberty/make-temp-file.c
-+++ b/libiberty/make-temp-file.c
-@@ -153,12 +153,14 @@ choose_tmpdir (void)
-       len = strlen (base);
-       tmpdir = XNEWVEC (char, len + 2);
-       strcpy (tmpdir, base);
-       tmpdir[len] = DIR_SEPARATOR;
-       tmpdir[len+1] = '\0';
-       memoized_tmpdir = tmpdir;
-+#elif __amigaos4__
-+    memoized_tmpdir = xstrdup ("T:");
- #else /* defined(_WIN32) && !defined(__CYGWIN__) */
-       DWORD len;
- 
-       /* Figure out how much space we need.  */
-       len = GetTempPath(0, NULL);
-       if (len)
 diff --git a/libiberty/pex-amigaos.c b/libiberty/pex-amigaos.c
 new file mode 100644
-index 0000000000000000000000000000000000000000..0c61a108764c8501f8a2e9552c7c07499f402b1a
+index 00000000000..0c61a108764
 --- /dev/null
 +++ b/libiberty/pex-amigaos.c
 @@ -0,0 +1,325 @@
@@ -4682,125 +9222,106 @@ index 0000000000000000000000000000000000000000..0c61a108764c8501f8a2e9552c7c0749
 +
 +  return 0;
 +}
-diff --git a/readline/readline/bind.c b/readline/readline/bind.c
-index 87596dcec95ad161743c6adf84e25f15ba7401b3..3da2352b0675e56e2d2d8d42ed3e0b80feb6fce3 100644
---- a/readline/readline/bind.c
-+++ b/readline/readline/bind.c
-@@ -990,15 +990,19 @@ _rl_read_init_file (const char *filename, int include_level)
-   char *buffer, *openname, *line, *end;
-   size_t file_size;
+-- 
+2.43.0
+
+
+From 3225e17e4ab191dc469d402dcd1fd2158aa948bf Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 14 Jan 2024 16:06:09 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 16/61] 
+ Restore commit 546cb2d85eddba4f56dfbcb0288db68243e3a0fd for AmigaOS4 with
+ clib clib4
+
+---
+ binutils/elfcomm.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/binutils/elfcomm.c b/binutils/elfcomm.c
+index 71b595a68a9..b8c0afa8e0d 100644
+--- a/binutils/elfcomm.c
++++ b/binutils/elfcomm.c
+@@ -35,6 +35,18 @@
  
-   current_readline_init_file = filename;
-   current_readline_init_include_level = include_level;
+ extern char *program_name;
  
--  openname = tilde_expand (filename);
--  buffer = _rl_read_file (openname, &file_size);
--  xfree (openname);
-+#ifndef __amigaos4__
-+  openname = tilde_expand(filename);
-+  buffer = _rl_read_file(openname, &file_size);
-+  xfree(openname);
-+#else
-+  buffer = _rl_read_file((char *)filename, &file_size);
-+#endif
- 
-   RL_CHECK_SIGNALS ();
-   if (buffer == 0)
-     return (errno);
-   
-   if (include_level == 0 && filename != last_readline_init_file)
-diff --git a/readline/readline/input.c b/readline/readline/input.c
-index 61b0fde3c87f25644fd9ff7ec1ef0e02d14c403c..58bbd8df37642872d98a7b20a578cd80167a0c30 100644
---- a/readline/readline/input.c
-+++ b/readline/readline/input.c
-@@ -558,13 +558,17 @@ rl_getc (FILE *stream)
-       if (result == sizeof (unsigned char))
- 	return (c);
- 
-       /* If zero characters are returned, then the file that we are
- 	 reading from is empty!  Return EOF in that case. */
-       if (result == 0)
--	return (EOF);
-+#ifndef __amigaos4__
-+        return (EOF);
-+#else
-+        continue;
-+#endif
- 
- #if defined (__BEOS__)
-       if (errno == EINTR)
- 	continue;
- #endif
- 
-diff --git a/readline/readline/readline.c b/readline/readline/readline.c
-index 0e33587f23409157a784635f0c85f721dbbecbeb..8601063b71686072a22469e5bc232dcaf166535f 100644
---- a/readline/readline/readline.c
-+++ b/readline/readline/readline.c
-@@ -1333,12 +1333,23 @@ bind_arrow_keys_internal (Keymap map)
- 
- #if defined (__MSDOS__)
-   rl_bind_keyseq_if_unbound ("\033[0A", rl_get_previous_history);
-   rl_bind_keyseq_if_unbound ("\033[0B", rl_backward_char);
-   rl_bind_keyseq_if_unbound ("\033[0C", rl_forward_char);
-   rl_bind_keyseq_if_unbound ("\033[0D", rl_get_next_history);
-+#elif defined(__amigaos4__)
-+    rl_bind_keyseq_if_unbound("\233A", rl_get_previous_history);
-+    rl_bind_keyseq_if_unbound("\233B", rl_get_next_history);
-+    rl_bind_keyseq_if_unbound("\233C", rl_forward_char);
-+    rl_bind_keyseq_if_unbound("\233D", rl_backward_char);
-+    rl_bind_keyseq_if_unbound("\23344~", (rl_command_func_t *)0x0); //rl_beg_of_line); disable for now
-+    rl_bind_keyseq_if_unbound("\23345~", (rl_command_func_t *)0x0); //rl_end_of_line); disable for now
-+    rl_bind_keyseq_if_unbound("\23341~", (rl_command_func_t *)0x0); //Next Page
-+    rl_bind_keyseq_if_unbound("\23342~", (rl_command_func_t *)0x0); //Previous Page
-+    rl_bind_keyseq_if_unbound("\177", rl_delete);
-+    rl_bind_keyseq_if_unbound("\23340", rl_overwrite_mode);  
- #endif
- 
-   rl_bind_keyseq_if_unbound ("\033[A", rl_get_previous_history);
-   rl_bind_keyseq_if_unbound ("\033[B", rl_get_next_history);
-   rl_bind_keyseq_if_unbound ("\033[C", rl_forward_char);
-   rl_bind_keyseq_if_unbound ("\033[D", rl_backward_char);
-diff --git a/readline/readline/rldefs.h b/readline/readline/rldefs.h
-index dab1beba1d72fbc6288f361b8c59fe2e3c78582e..a367593d693a34b60bd9fa2de58461bb27c8f827 100644
---- a/readline/readline/rldefs.h
-+++ b/readline/readline/rldefs.h
-@@ -37,20 +37,27 @@
- #if defined (_POSIX_VERSION) && !defined (TERMIOS_MISSING)
- #  define TERMIOS_TTY_DRIVER
- #else
- #  if defined (HAVE_TERMIO_H)
- #    define TERMIO_TTY_DRIVER
- #  else
--#    if !defined (__MINGW32__)
-+#    if !defined (__MINGW32__) && !defined(__amigaos4__)
- #      define NEW_TTY_DRIVER
- #    else
- #      define NO_TTY_DRIVER
- #    endif
- #  endif
- #endif
- 
-+#ifdef __amigaos4__
-+#undef DEFAULT_INPUTRC
-+#undef SYS_INPUTRC
-+#define DEFAULT_INPUTRC "PROGDIR:inputrc"
-+#define SYS_INPUTRC "ENVARC:inputrc"
++/* Restore commit 546cb2d85eddba4f56dfbcb0288db68243e3a0fd for AmigaOS4 with clib clib4 */
++#if defined(__amigaos4__) && defined(__CLIB4__)
++/* FIXME:  This definition really ought to be in ansidecl.h.  */
++#ifndef ATTRIBUTE_WEAK
++#define ATTRIBUTE_WEAK __attribute__((weak))
 +#endif
 +
- /* Posix macro to check file in statbuf for directory-ness.
-    This requires that <sys/stat.h> be included before this test. */
- #if defined (S_IFDIR) && !defined (S_ISDIR)
- #  define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
- #endif
++/* Allow the following two functions to be overridden if desired.  */
++void error (const char *, ...) ATTRIBUTE_WEAK;
++void warn (const char *, ...) ATTRIBUTE_WEAK;
++#endif
++
+ void
+ error (const char *message, ...)
+ {
+-- 
+2.43.0
+
+
+From 319e79abd6f049c0dad317f19398cacadf2668bf Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 14 Jan 2024 16:07:13 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 17/61] 
+ Ignore fnmatch provided by binutils if using clib4 on ppc-amigaos
+
+---
+ libiberty/fnmatch.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/libiberty/fnmatch.c b/libiberty/fnmatch.c
+index 3602059ce8a..4b3e030d040 100644
+--- a/libiberty/fnmatch.c
++++ b/libiberty/fnmatch.c
+@@ -47,6 +47,10 @@ Boston, MA 02110-1301, USA.  */
+ #include <fnmatch.h>
+ #include <safe-ctype.h>
  
++/* Ignore all this code if targeting AmigaOS4 with clib clib4, because
++   the clib4 clib provided it own fnmatch implementation */
++#if !(defined(__amigaos4__) && defined(__CLIB4__))
++
+ /* Comment out all this code if we are using the GNU C Library, and are not
+    actually compiling the library itself.  This code is part of the GNU C
+    Library, but also included in many other GNU distributions.  Compiling
+@@ -54,7 +58,6 @@ Boston, MA 02110-1301, USA.  */
+    (especially if it is a shared library).  Rather than having every GNU
+    program understand `configure --with-gnu-libc' and omit the object files,
+    it is simpler to just do this in the source for each such file.  */
+-
+ #if defined (_LIBC) || !defined (__GNU_LIBRARY__)
+ 
+ 
+@@ -218,3 +221,4 @@ fnmatch (const char *pattern, const char *string, int flags)
+ }
+ 
+ #endif	/* _LIBC or not __GNU_LIBRARY__.  */
++#endif  /* not (AMIGAOS and CLIB4) $*/
+-- 
+2.43.0
+
+
+From 2483dcde9b7e4b475bb5cb3bead314516b973a19 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 14 Jan 2024 16:08:40 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 18/61] 
+ Add os4 TTY driver
+
+---
+ readline/readline/rltty.h    |  7 ++++++-
+ readline/readline/terminal.c | 10 +++++++---
+ 2 files changed, 13 insertions(+), 4 deletions(-)
+
 diff --git a/readline/readline/rltty.h b/readline/readline/rltty.h
-index 5bcc946b270a4d079c11809895073c28443e7a44..89ac7cc762f3781dfcc93924301d4a10154a8802 100644
+index 5bcc946b270..89ac7cc762f 100644
 --- a/readline/readline/rltty.h
 +++ b/readline/readline/rltty.h
-@@ -16,12 +16,17 @@
-    GNU General Public License for more details.
- 
-    You should have received a copy of the GNU General Public License
+@@ -19,6 +19,11 @@
     along with Readline.  If not, see <http://www.gnu.org/licenses/>.
  */
  
@@ -4812,13 +9333,7 @@ index 5bcc946b270a4d079c11809895073c28443e7a44..89ac7cc762f3781dfcc93924301d4a10
  #if !defined (_RLTTY_H_)
  #define _RLTTY_H_
  
- /* Posix systems use termios and the Posix signal functions. */
- #if defined (TERMIOS_TTY_DRIVER)
- #  include <termios.h>
-@@ -33,13 +38,13 @@
- #  if !defined (TCOON)
- #    define TCOON 1
- #  endif
+@@ -36,7 +41,7 @@
  #endif /* TERMIO_TTY_DRIVER */
  
  /* Other (BSD) machines use sgtty. */
@@ -4827,17 +9342,119 @@ index 5bcc946b270a4d079c11809895073c28443e7a44..89ac7cc762f3781dfcc93924301d4a10
  #  include <sgtty.h>
  #endif
  
- #include "rlwinsize.h"
+diff --git a/readline/readline/terminal.c b/readline/readline/terminal.c
+index 05415dc42de..07a64af8172 100644
+--- a/readline/readline/terminal.c
++++ b/readline/readline/terminal.c
+@@ -102,12 +102,16 @@ static char *term_string_buffer = (char *)NULL;
  
- /* Define _POSIX_VDISABLE if we are not using the `new' tty driver and
+ static int tcap_initialized;
+ 
+-#if !defined (__linux__) && !defined (NCURSES_VERSION)
++/* Ignore this code if targeting AmigaOS4 with clib clib4, because
++   the clib4 clib provided it own fnmatch implementation */
++#if !(defined(__amigaos4__) && defined(__CLIB4__))
++# if !defined (__linux__) && !defined (NCURSES_VERSION) 
+ #  if defined (__EMX__) || defined (NEED_EXTERN_PC)
+ extern 
+-#  endif /* __EMX__ || NEED_EXTERN_PC */
++#   endif /* __EMX__ || NEED_EXTERN_PC */
+ char PC, *BC, *UP;
+-#endif /* !__linux__ && !NCURSES_VERSION */
++# endif /* !__linux__ && !NCURSES_VERSION */
++#endif  /* not (AMIGAOS and CLIB4) $*/
+ 
+ /* Some strings to control terminal actions.  These are output by tputs (). */
+ char *_rl_term_clreol;
+-- 
+2.43.0
+
+
+From c60ca1d68e2e1c5d56bde37868f87eb86d688b1d Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 14 Jan 2024 16:09:52 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 19/61] 
+ https://github.com/AmigaLabs/binutils-gdb/commit/96ea7f2d89d39c32af7ce4845b95e76a481950c4
+
+---
+ libiberty/configure    | 2 +-
+ libiberty/configure.ac | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libiberty/configure b/libiberty/configure
+index 0d5a7860758..e5433eda5cf 100755
+--- a/libiberty/configure
++++ b/libiberty/configure
+@@ -7540,7 +7540,7 @@ case "${host}" in
+      *-*-mingw* | *-*-winnt*)	pexecute=pex-win32  ;;
+      *-*-msdosdjgpp*)		pexecute=pex-djgpp  ;;
+      *-*-msdos*)		pexecute=pex-msdos  ;;
+-	 ppc-*-amigaos*)	pexecute=pex-amigaos ;;
++	 powerpc-*-amigaos*)	pexecute=pex-amigaos ;;
+      *)				pexecute=pex-unix   ;;
+ esac
+ 
+diff --git a/libiberty/configure.ac b/libiberty/configure.ac
+index bf6c7e749bb..e4aa7659565 100644
+--- a/libiberty/configure.ac
++++ b/libiberty/configure.ac
+@@ -736,7 +736,7 @@ case "${host}" in
+      *-*-mingw* | *-*-winnt*)	pexecute=pex-win32  ;;
+      *-*-msdosdjgpp*)		pexecute=pex-djgpp  ;;
+      *-*-msdos*)		pexecute=pex-msdos  ;;
+-	 ppc-*-amigaos*)	pexecute=pex-amigaos ;;
++	 powerpc-*-amigaos*)	pexecute=pex-amigaos ;;
+      *)				pexecute=pex-unix   ;;
+ esac
+ AC_SUBST(pexecute)
+-- 
+2.43.0
+
+
+From dad48496c8e3b57934c292212156a3173ccf3087 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 14 Jan 2024 16:10:03 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 20/61] 
+ Updated git ignore
+
+---
+ .gitignore | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/.gitignore b/.gitignore
+index 292bcfac37e..20c25b90459 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -5,7 +5,10 @@
+ *.rej
+ 
+ cross-build/
++native-build/
+ dist/
++dist-newlib/
++dist-clib4/
+ 
+ *~
+ .#*
+-- 
+2.43.0
+
+
+From 08dad0bd1d3266b532cd05e929f2362d3d3808e1 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 12 Aug 2024 10:46:28 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 21/61] 
+ Use PROGDIR: as home dir for AmigaOS
+
+---
+ readline/readline/shell.c | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
 diff --git a/readline/readline/shell.c b/readline/readline/shell.c
-index 7fe2e97c983360641288ca4ecca254932c6bf053..80c21a20bda39836734261e26e35892eb2ba3a70 100644
+index 7fe2e97c983..80c21a20bda 100644
 --- a/readline/readline/shell.c
 +++ b/readline/readline/shell.c
-@@ -158,20 +158,25 @@ sh_get_home_dir (void)
-   struct passwd *entry;
- 
-   if (home_dir)
+@@ -161,14 +161,19 @@ sh_get_home_dir (void)
      return (home_dir);
  
    home_dir = (char *)NULL;
@@ -4861,47 +9478,2561 @@ index 7fe2e97c983360641288ca4ecca254932c6bf053..80c21a20bda39836734261e26e35892e
  #endif
  
  #if defined (HAVE_GETPWENT)
-   endpwent ();		/* some systems need this */
+-- 
+2.43.0
+
+
+From 7d1e5ed1bd0cf8854b9ce6fd201596ef201c900b Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 12 Aug 2024 11:07:40 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 22/61] 
+ For crosscompile AmigaOS guess yes
+
+---
+ gnulib/import/m4/getcwd-path-max.m4 | 2 ++
+ gnulib/import/m4/getcwd.m4          | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/gnulib/import/m4/getcwd-path-max.m4 b/gnulib/import/m4/getcwd-path-max.m4
+index e12045596b1..bddf75ed407 100644
+--- a/gnulib/import/m4/getcwd-path-max.m4
++++ b/gnulib/import/m4/getcwd-path-max.m4
+@@ -222,6 +222,8 @@ main ()
+             gl_cv_func_getcwd_path_max='guessing no, it has the AIX bug' ;;
+           gnu*) # On Hurd, it is 'yes'.
+             gl_cv_func_getcwd_path_max='guessing yes' ;;
++		  amigaos*) # On AmigaOS, it is 'yes'
++		    gl_cv_func_getcwd_path_max="guessing yes";;
+           linux* | kfreebsd*)
+             # On older Linux+glibc it's 'no, but it is partly working',
+             # on newer Linux+glibc it's 'yes'.
+diff --git a/gnulib/import/m4/getcwd.m4 b/gnulib/import/m4/getcwd.m4
+index 076ca314858..a7e0e7f9b86 100644
+--- a/gnulib/import/m4/getcwd.m4
++++ b/gnulib/import/m4/getcwd.m4
+@@ -55,6 +55,8 @@ AC_DEFUN([gl_FUNC_GETCWD_NULL],
+             *-musl*)       gl_cv_func_getcwd_null="guessing yes";;
+                            # Guess yes on Cygwin.
+             cygwin*)       gl_cv_func_getcwd_null="guessing yes";;
++						   # Guess yes on AmigaOS
++			amigaos*) 	   gl_cv_func_getcwd_null="guessing yes";;
+                            # If we don't know, obey --enable-cross-guesses.
+             *)             gl_cv_func_getcwd_null="$gl_cross_guess_normal";;
+           esac
+-- 
+2.43.0
+
+
+From 4d90728501695b9858021174b80c537969d8afc4 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 12 Aug 2024 12:32:32 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 23/61] 
+ AmigaOS arch specifc file system adaption
+
+---
+ gdb/filesystem.c      | 11 ++++++++++-
+ gdb/filesystem.h      |  4 ++++
+ gdb/gdbarch-gen.h     |  7 +++++++
+ gdb/gdbarch.c         | 26 ++++++++++++++++++++++++++
+ include/filenames.h   | 18 ++++++++++++++++++
+ include/libiberty.h   |  5 +++++
+ libiberty/lbasename.c | 20 ++++++++++++++++++++
+ 7 files changed, 90 insertions(+), 1 deletion(-)
+
+diff --git a/gdb/filesystem.c b/gdb/filesystem.c
+index f9aaeed7b40..f768d99413f 100644
+--- a/gdb/filesystem.c
++++ b/gdb/filesystem.c
+@@ -25,11 +25,13 @@
+ const char file_system_kind_auto[] = "auto";
+ const char file_system_kind_unix[] = "unix";
+ const char file_system_kind_dos_based[] = "dos-based";
++const char file_system_kind_amigaos_based[] = "amiga-based";
+ const char *const target_file_system_kinds[] =
+ {
+   file_system_kind_auto,
+   file_system_kind_unix,
+   file_system_kind_dos_based,
++  file_system_kind_amigaos_based,
+   NULL
+ };
+ const char *target_file_system_kind = file_system_kind_auto;
+@@ -41,6 +43,8 @@ effective_target_file_system_kind (void)
+     {
+       if (gdbarch_has_dos_based_file_system (target_gdbarch ()))
+ 	return file_system_kind_dos_based;
++	  else if (gdbarch_has_amiga_based_file_system (target_gdbarch ()))
++	return file_system_kind_amigaos_based;
+       else
+ 	return file_system_kind_unix;
+     }
+@@ -53,6 +57,8 @@ target_lbasename (const char *kind, const char *name)
+ {
+   if (kind == file_system_kind_dos_based)
+     return dos_lbasename (name);
++  else if (kind == file_system_kind_amigaos_based)
++    return amiga_lbasename (name);
+   else
+     return unix_lbasename (name);
+ }
+@@ -92,7 +98,10 @@ starting the forward slash (`/') character are considered absolute,\n\
+ and the directory separator character is the forward slash (`/').  If\n\
+ `dos-based', target file names starting with a drive letter followed\n\
+ by a colon (e.g., `c:'), are also considered absolute, and the\n\
+-backslash (`\\') is also considered a directory separator.  Set to\n\
++backslash (`\\') is also considered a directory separator. If\n\
++`amiga-based', target file names starting with a drive name followed\n\
++by a colon (e.g., `sys:'), are also considered absolute, and the\n\
++directory separator character is the forward slash (`/'). Set to\n\
+ `auto' (which is the default), to let GDB decide, based on its\n\
+ knowledge of the target operating system."),
+ 			NULL, /* setfunc */
+diff --git a/gdb/filesystem.h b/gdb/filesystem.h
+index 2485f6b4e35..7e2994b8183 100644
+--- a/gdb/filesystem.h
++++ b/gdb/filesystem.h
+@@ -22,6 +22,7 @@
+ extern const char file_system_kind_auto[];
+ extern const char file_system_kind_unix[];
+ extern const char file_system_kind_dos_based[];
++extern const char file_system_kind_amigaos_based[];
+ 
+ extern const char *target_file_system_kind;
+ 
+@@ -30,6 +31,7 @@ extern const char *target_file_system_kind;
+ 
+ #define IS_TARGET_DIR_SEPARATOR(kind, c)				\
+   (((kind) == file_system_kind_dos_based) ? IS_DOS_DIR_SEPARATOR (c) \
++   : ((kind) == file_system_kind_amigaos_based) ? IS_AMIGOS_DIR_SEPARATOR(c) \
+    : IS_UNIX_DIR_SEPARATOR (c))
+ 
+ /* Same as IS_ABSOLUTE_PATH but with file system kind KIND's
+@@ -37,6 +39,7 @@ extern const char *target_file_system_kind;
+ 
+ #define IS_TARGET_ABSOLUTE_PATH(kind, p)				\
+   (((kind) == file_system_kind_dos_based) ? IS_DOS_ABSOLUTE_PATH (p) \
++   : ((kind) == file_system_kind_amigaos_based) ? IS_AMIGOS_ABSOLUTE_PATH(p) \
+    : IS_UNIX_ABSOLUTE_PATH (p))
+ 
+ /* Same as HAS_DRIVE_SPEC but with file system kind KIND's semantics,
+@@ -44,6 +47,7 @@ extern const char *target_file_system_kind;
+ 
+ #define HAS_TARGET_DRIVE_SPEC(kind, p)					\
+   (((kind) == file_system_kind_dos_based) ? HAS_DOS_DRIVE_SPEC (p) \
++   : ((kind) == file_system_kind_amigaos_based) ? HAS_AMIGOS_DRIVE_SPEC(p) \
+    : 0)
+ 
+ /* Same as lbasename, but with file system kind KIND's semantics,
+diff --git a/gdb/gdbarch-gen.h b/gdb/gdbarch-gen.h
+index 5918de517ef..fdcccd70686 100644
+--- a/gdb/gdbarch-gen.h
++++ b/gdb/gdbarch-gen.h
+@@ -1485,6 +1485,13 @@ extern void set_gdbarch_solib_symbols_extension (struct gdbarch *gdbarch, const
+ extern int gdbarch_has_dos_based_file_system (struct gdbarch *gdbarch);
+ extern void set_gdbarch_has_dos_based_file_system (struct gdbarch *gdbarch, int has_dos_based_file_system);
+ 
++/* If true, the target OS has AMIGA-based file system semantics.  That
++   is, absolute paths include a drive name, and the slash is
++   considered a directory separator. */
++
++extern int gdbarch_has_amiga_based_file_system (struct gdbarch *gdbarch);
++extern void set_gdbarch_has_amiga_based_file_system (struct gdbarch *gdbarch, int has_dos_based_file_system);
++
+ /* Generate bytecodes to collect the return address in a frame.
+    Since the bytecodes run on the target, possibly with GDB not even
+    connected, the full unwinding machinery is not available, and
+diff --git a/gdb/gdbarch.c b/gdb/gdbarch.c
+index 2d4b1164e20..9dffb4931c4 100644
+--- a/gdb/gdbarch.c
++++ b/gdb/gdbarch.c
+@@ -232,6 +232,7 @@ struct gdbarch
+   gdbarch_auto_wide_charset_ftype *auto_wide_charset = default_auto_wide_charset;
+   const char * solib_symbols_extension = 0;
+   int has_dos_based_file_system = 0;
++  int has_amiga_based_file_system = 0;
+   gdbarch_gen_return_address_ftype *gen_return_address = default_gen_return_address;
+   gdbarch_info_proc_ftype *info_proc = nullptr;
+   gdbarch_core_info_proc_ftype *core_info_proc = nullptr;
+@@ -1274,6 +1275,9 @@ gdbarch_dump (struct gdbarch *gdbarch, struct ui_file *file)
+   gdb_printf (file,
+ 	      "gdbarch_dump: has_dos_based_file_system = %s\n",
+ 	      plongest (gdbarch->has_dos_based_file_system));
++  gdb_printf (file,
++	      "gdbarch_dump: has_amiga_based_file_system = %s\n",
++	      plongest (gdbarch->has_amiga_based_file_system));
+   gdb_printf (file,
+ 	      "gdbarch_dump: gen_return_address = <%s>\n",
+ 	      host_address_to_string (gdbarch->gen_return_address));
+@@ -4901,6 +4905,28 @@ set_gdbarch_has_dos_based_file_system (struct gdbarch *gdbarch,
+ 				       int has_dos_based_file_system)
+ {
+   gdbarch->has_dos_based_file_system = has_dos_based_file_system;
++
++  if( has_dos_based_file_system )
++	set_gdbarch_has_amiga_based_file_system( gdbarch,0 );
++}
++
++int gdbarch_has_amiga_based_file_system (struct gdbarch *gdbarch)
++{
++  gdb_assert (gdbarch != NULL);
++  /* Skip verify of has_amiga_based_file_system, invalid_p == 0 */
++  if (gdbarch_debug >= 2)
++    gdb_printf (gdb_stdlog, "gdbarch_has_amiga_based_file_system called\n");
++  return gdbarch->has_amiga_based_file_system;
++}
++
++void
++set_gdbarch_has_amiga_based_file_system (struct gdbarch *gdbarch,
++				       int has_amiga_based_file_system)
++{
++  gdbarch->has_amiga_based_file_system = has_amiga_based_file_system;
++
++  if( has_amiga_based_file_system )
++	set_gdbarch_has_dos_based_file_system( gdbarch,0 );
+ }
+ 
+ void
+diff --git a/include/filenames.h b/include/filenames.h
+index 444c5cc411c..3ee947df950 100644
+--- a/include/filenames.h
++++ b/include/filenames.h
+@@ -43,6 +43,16 @@ extern "C" {
+ #  define HAS_DRIVE_SPEC(f) HAS_DOS_DRIVE_SPEC (f)
+ #  define IS_DIR_SEPARATOR(c) IS_DOS_DIR_SEPARATOR (c)
+ #  define IS_ABSOLUTE_PATH(f) IS_DOS_ABSOLUTE_PATH (f)
++#elif defined(__amigaos4__)
++#  ifndef HAVE_AMIGA_BASED_FILE_SYSTEM
++#    define HAVE_AMIGA_BASED_FILE_SYSTEM 1
++#  endif
++#  ifndef HAVE_CASE_INSENSITIVE_FILE_SYSTEM
++#    define HAVE_CASE_INSENSITIVE_FILE_SYSTEM 1
++#  endif
++#  define HAS_DRIVE_SPEC(f) HAS_AMIGOS_DRIVE_SPEC (f)
++#  define IS_DIR_SEPARATOR(c) IS_AMIGOS_DIR_SEPARATOR (c)
++#  define IS_ABSOLUTE_PATH(f) IS_AMIGOS_ABSOLUTE_PATH (f)
+ #else /* not DOSish */
+ #  if defined(__APPLE__)
+ #    ifndef HAVE_CASE_INSENSITIVE_FILE_SYSTEM
+@@ -63,12 +73,20 @@ extern "C" {
+ 
+ /* Remove the drive spec from F, assuming HAS_DRIVE_SPEC (f).
+    The result is a pointer to the remainder of F.  */
++#if defined(__amigaos4__)
++#define STRIP_DRIVE_SPEC(f)	(index( &(f)[0],':') + 1 )
++#else
+ #define STRIP_DRIVE_SPEC(f)	((f) + 2)
++#endif
+ 
+ #define IS_DOS_DIR_SEPARATOR(c) IS_DIR_SEPARATOR_1 (1, c)
+ #define IS_DOS_ABSOLUTE_PATH(f) IS_ABSOLUTE_PATH_1 (1, f)
+ #define HAS_DOS_DRIVE_SPEC(f) HAS_DRIVE_SPEC_1 (1, f)
+ 
++#define IS_AMIGOS_DIR_SEPARATOR(c) IS_DIR_SEPARATOR_1 (0, c)
++#define IS_AMIGOS_ABSOLUTE_PATH(f) HAS_AMIGOS_DRIVE_SPEC(f)
++#define HAS_AMIGOS_DRIVE_SPEC(f) (index (&(f)[0], ':') != NULL ) 
++
+ #define IS_UNIX_DIR_SEPARATOR(c) IS_DIR_SEPARATOR_1 (0, c)
+ #define IS_UNIX_ABSOLUTE_PATH(f) IS_ABSOLUTE_PATH_1 (0, f)
+ 
+diff --git a/include/libiberty.h b/include/libiberty.h
+index 1d5c779fcff..e9d103d7975 100644
+--- a/include/libiberty.h
++++ b/include/libiberty.h
+@@ -127,6 +127,11 @@ extern const char *lbasename (const char *) ATTRIBUTE_RETURNS_NONNULL ATTRIBUTE_
+ 
+ extern const char *dos_lbasename (const char *) ATTRIBUTE_RETURNS_NONNULL ATTRIBUTE_NONNULL(1);
+ 
++/* Same, but assumes AMIGA semantics (drive name, slash is also a
++   dir separator) regardless of host.  */
++
++extern const char *amiga_lbasename (const char *) ATTRIBUTE_RETURNS_NONNULL ATTRIBUTE_NONNULL(1);
++
+ /* Same, but assumes Unix semantics (absolute paths always start with
+    a slash, only forward slash is accepted as dir separator)
+    regardless of host.  */
+diff --git a/libiberty/lbasename.c b/libiberty/lbasename.c
+index a7864ab2b8c..d1f40818b22 100644
+--- a/libiberty/lbasename.c
++++ b/libiberty/lbasename.c
+@@ -73,11 +73,31 @@ dos_lbasename (const char *name)
+   return base;
+ }
+ 
++const char *
++amiga_lbasename (const char *name)
++{
++  const char *base = name;
++
++  /* Skip over a possible disk name.  */
++  if (HAS_AMIGOS_DRIVE_SPEC (name)) {
++    base = STRIP_DRIVE_SPEC (name);
++  };
++
++  /* Strip any directories */
++  for (; *name; name++)
++    if (IS_AMIGOS_DIR_SEPARATOR (*name))
++      base = name + 1;
++
++  return base;
++}
++
+ const char *
+ lbasename (const char *name)
+ {
+ #if defined (HAVE_DOS_BASED_FILE_SYSTEM)
+   return dos_lbasename (name);
++#elif defined (HAVE_AMIGA_BASED_FILE_SYSTEM)
++  return amiga_lbasename (name);
+ #else
+   return unix_lbasename (name);
+ #endif
+-- 
+2.43.0
+
+
+From 83c1d201d375ed2deb2923ae30dd267d34c17ee6 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 12 Aug 2024 12:35:08 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 24/61] 
+ For crosscompile AmigaOS guess yes
+
+---
+ gnulib/configure | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/gnulib/configure b/gnulib/configure
+index cc7e8287d5a..aaa4b6c0801 100644
+--- a/gnulib/configure
++++ b/gnulib/configure
+@@ -12923,6 +12923,8 @@ else
+             *-gnu* | gnu*) gl_cv_func_getcwd_null="guessing yes";;
+                            # Guess yes on musl systems.
+             *-musl*)       gl_cv_func_getcwd_null="guessing yes";;
++						   # Guess yes on AmigaOS
++			amigaos*) 	   gl_cv_func_getcwd_null="guessing yes";;
+                            # Guess yes on Cygwin.
+             cygwin*)       gl_cv_func_getcwd_null="guessing yes";;
+                            # If we don't know, obey --enable-cross-guesses.
+@@ -25498,6 +25500,8 @@ else
+             gl_cv_func_getcwd_path_max='guessing no, it has the AIX bug' ;;
+           gnu*) # On Hurd, it is 'yes'.
+             gl_cv_func_getcwd_path_max='guessing yes' ;;
++		  amigaos*) # On AmigaOS, it is 'yes'
++		    gl_cv_func_getcwd_path_max="guessing yes";;
+           linux* | kfreebsd*)
+             # On older Linux+glibc it's 'no, but it is partly working',
+             # on newer Linux+glibc it's 'yes'.
+-- 
+2.43.0
+
+
+From 167abb6b6eb66b8969c935bf6f156c9bb914c29c Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 12 Aug 2024 12:36:48 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 25/61] 
+ Added extended version infromation about used clib
+
+---
+ binutils/version.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/binutils/version.c b/binutils/version.c
+index 08035359ad7..5752fb4cb0a 100644
+--- a/binutils/version.c
++++ b/binutils/version.c
+@@ -36,5 +36,18 @@ print_version (const char *name)
+ This program is free software; you may redistribute it under the terms of\n\
+ the GNU General Public License version 3 or (at your option) any later version.\n\
+ This program has absolutely no warranty.\n"));
++
++#if defined(__amigaos4__)
++# if defined( __NEWLIB__)
++  printf (_("AmigaOS native (ppc-amigaos,newlib).\n"));
++# elif defined( __CLIB4__)
++  printf (_("AmigaOS native (ppc-amigaos,clib4).\n"));
++# elif defined( __CLIB2__ )
++  printf (_("AmigaOS native (ppc-amigaos,clib2).\n"));
++# else
++ printf (_("AmigaOS native (ppc-amigaos,unknown).\n"));
++# endif
++#endif
++
+   exit (0);
+ }
+-- 
+2.43.0
+
+
+From e4e38a3ed283da6fb120a7e158de7ab1e49434c5 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 12 Aug 2024 12:38:34 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 26/61] 
+ Define a AmigaOS specifx SO ABI with detecting logix in elf sniffer
+
+---
+ gdb/osabi.c | 21 +++++++++++++++++++++
+ gdb/osabi.h |  1 +
+ 2 files changed, 22 insertions(+)
+
+diff --git a/gdb/osabi.c b/gdb/osabi.c
+index 57e2df6b25c..2eb227d2fc1 100644
+--- a/gdb/osabi.c
++++ b/gdb/osabi.c
+@@ -82,6 +82,7 @@ static const struct osabi_names gdb_osabi_names[] =
+   { "Newlib", NULL },
+   { "SDE", NULL },
+   { "PikeOS", NULL },
++  { "AmigaOS", NULL },
+ 
+   { "<invalid>", NULL }
+ };
+@@ -611,6 +612,26 @@ generic_elf_osabi_sniffer (bfd *abfd)
+ 	osabi = GDB_OSABI_FREEBSD;
+     }
+ 
++  if (osabi == GDB_OSABI_UNKNOWN)
++	{
++	  /* AmigaOS has a symbol __amigaos4__ which marks the ELF */
++	  if (bfd_get_symtab_upper_bound (abfd) > 0 )
++	  {
++		asymbol **symbol_table = (asymbol **)xmalloc (bfd_get_symtab_upper_bound (abfd));
++		if (symbol_table)
++		{
++		  for (int i = 0; i < bfd_canonicalize_symtab(abfd, symbol_table); i++) {
++        	if (strcmp("__amigaos4__", bfd_asymbol_name(symbol_table[i])) == 0) {
++              osabi = GDB_OSABI_AMIGAOS;
++              break;
++			}
++          }
++		  
++		  xfree (symbol_table);
++		}
++	  }
++	}
++
+   return osabi;
+ }
+ 
+diff --git a/gdb/osabi.h b/gdb/osabi.h
+index 478a418aac2..58750743b39 100644
+--- a/gdb/osabi.h
++++ b/gdb/osabi.h
+@@ -46,6 +46,7 @@ enum gdb_osabi
+   GDB_OSABI_NEWLIB,
+   GDB_OSABI_SDE,
+   GDB_OSABI_PIKEOS,
++  GDB_OSABI_AMIGAOS,
+ 
+   GDB_OSABI_INVALID		/* keep this last */
+ };
+-- 
+2.43.0
+
+
+From 3ec6aa842a1aeafb00aa67b3dcced4ba99a8445d Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 12 Aug 2024 12:41:33 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 27/61] 
+ Added ppc-amigaos target
+
+---
+ gdb/Makefile.in        |    2 +
+ gdb/configure.host     |    1 +
+ gdb/configure.nat      |    8 +
+ gdb/configure.tgt      |    7 +
+ gdb/ppc-amigaos-nat.c  | 1020 ++++++++++++++++++++++++++++++++++++++++
+ gdb/ppc-amigaos-nat.h  |   76 +++
+ gdb/ppc-amigaos-tdep.c |  153 ++++++
+ 7 files changed, 1267 insertions(+)
+ create mode 100644 gdb/ppc-amigaos-nat.c
+ create mode 100644 gdb/ppc-amigaos-nat.h
+ create mode 100644 gdb/ppc-amigaos-tdep.c
+
+diff --git a/gdb/Makefile.in b/gdb/Makefile.in
+index 9bc81cda03f..dfa148e582b 100644
+--- a/gdb/Makefile.in
++++ b/gdb/Makefile.in
+@@ -1753,6 +1753,8 @@ ALLDEPFILES = \
+ 	obsd-tdep.c \
+ 	or1k-linux-nat.c \
+ 	posix-hdep.c \
++	ppc-amigaos-nat.c \
++	ppc-amigaos-tdep.c \
+ 	ppc-fbsd-nat.c \
+ 	ppc-fbsd-tdep.c \
+ 	ppc-linux-nat.c \
+diff --git a/gdb/configure.host b/gdb/configure.host
+index da71675b201..90512728e55 100644
+--- a/gdb/configure.host
++++ b/gdb/configure.host
+@@ -137,6 +137,7 @@ or1k-*-linux*)		gdb_host=linux ;;
+ 
+ powerpc-*-aix* | rs6000-*-* | powerpc64-*-aix*)
+ 			gdb_host=aix ;;
++powerpc-*-amigaos*) gdb_host=amigaos ;;
+ powerpc*-*-freebsd*)	gdb_host=fbsd ;;
+ powerpc-*-netbsdaout* | powerpc-*-knetbsd*-gnu)
+ 			gdb_host=nbsd ;;
+diff --git a/gdb/configure.nat b/gdb/configure.nat
+index d219d6a960c..5a0b27b2097 100644
+--- a/gdb/configure.nat
++++ b/gdb/configure.nat
+@@ -112,6 +112,14 @@ case ${gdb_host} in
+ 		;;
+ 	esac
+ 	;;
++    amigaos)
++	case ${gdb_host_cpu} in
++	    powerpc)
++		# Host: Big-endian PowerPC running AmigaOS
++		NATDEPFILES="${NATDEPFILES} ppc-amigaos-nat.o"
++		;;
++	esac
++	;;
+     alpha-linux)
+ 	case ${gdb_host_cpu} in
+ 	    alpha)
+diff --git a/gdb/configure.tgt b/gdb/configure.tgt
+index e84e222ba0d..fbacf9530c9 100644
+--- a/gdb/configure.tgt
++++ b/gdb/configure.tgt
+@@ -507,6 +507,12 @@ powerpc*-*-linux*)
+ 			linux-record.o \
+ 			arch/ppc-linux-common.o"
+ 	;;
++powerpc-*-amigaos*)
++	# Target: PowerPC running AmigaOS
++	gdb_target_obs="rs6000-tdep.o ppc-sysv-tdep.o \
++			ppc-amigaos-tdep.o \
++			ravenscar-thread.o ppc-ravenscar-thread.o"
++	;;	
+ powerpc-*-lynx*178)
+ 	# Target: PowerPC running Lynx178.
+ 	gdb_target_obs="rs6000-tdep.o rs6000-lynx178-tdep.o \
+@@ -799,6 +805,7 @@ m68*-*-openbsd* | m88*-*-openbsd* | vax-*-openbsd*) ;;
+ *-*-mingw*)	gdb_osabi=GDB_OSABI_WINDOWS ;;
+ *-*-cygwin*)	gdb_osabi=GDB_OSABI_CYGWIN ;;
+ *-*-dicos*)	gdb_osabi=GDB_OSABI_DICOS ;;
++powerpc-*-amigaos*)	gdb_osabi=GDB_OSABI_AMIGAOS ;;
+ powerpc-*-aix* | rs6000-*-* | powerpc64-*-aix*)
+                 gdb_osabi=GDB_OSABI_AIX ;;
+ esac
+diff --git a/gdb/ppc-amigaos-nat.c b/gdb/ppc-amigaos-nat.c
+new file mode 100644
+index 00000000000..1a9dcc349d1
+--- /dev/null
++++ b/gdb/ppc-amigaos-nat.c
+@@ -0,0 +1,1020 @@
++
++/* Native-dependent code for PowerPC's running AmigaOS, for GDB.
++   Copyright (C) 2013-2024 Free Software Foundation, Inc.
++
++   This file is part of GDB.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++
++#include "ppc-amigaos-nat.h"
++#include "defs.h"
++#include "gdbcore.h"
++#include "objfiles.h"
++#include "symtab.h"
++#include "exec.h"
++#include "inferior.h"
++#include "regcache.h"
++#include "inf-child.h"
++#include "ppc-tdep.h"
++#include "gdbsupport/ptid.h"
++#include "gdbsupport/gdb_wait.h"
++
++#include <proto/dos.h>
++#include <proto/exec.h>
++#include <proto/elf.h>
++
++#include <exec/exec.h>
++#include <exec/execbase.h>
++#include <exec/exectags.h>
++#include <exec/tasks.h>
++#include <exec/interrupts.h>
++
++#include <dos/dos.h>
++#include <dos/dostags.h>
++#include <dos/dosextens.h>
++
++
++// From clib4 , bucket list to clear up 
++extern struct Library *ElfBase;
++extern struct ElfIFace *IElf;
++
++struct DebugIFace *IDebug = NULL;
++struct MMUIFace *IMMU = NULL;
++
++struct amigaos_debug_hook_data
++{
++    struct Process		*current_process;
++    struct Task			*debugger_task;
++    struct MsgPort		*debugger_port;
++};
++
++/* The type of Message sent by IDebug->AddDebugHook () */
++struct KernelDebugMessage
++{
++  uint32 type;
++  union
++  {
++    struct ExceptionContext *context;
++    struct Library *library;
++  } message;
++};
++
++static VOID amigaos_debug_suspend ( struct Hook *amigaos_debug_hook );
++static ULONG amigaos_debug_callback (struct Hook *, struct Task *, struct KernelDebugMessage *);
++static int trap_to_signal(struct ExceptionContext *context, uint32 flags);
++void ppc_amigaos_relocate_sections (const char *exec_file,BPTR exec_seglist);
++
++#define MAX_DEBUG_MESSAGES 20
++
++class ppc_amigaos_nat_target : public inf_child_target
++{
++private:
++
++	struct Hook *					amigaos_debug_hook;
++	void *							amigaos_debug_messages_storage = 0;
++	struct List	*					amigaos_debug_messages_list;
++
++public:
++
++	struct amigaos_debug_hook_data	amigaos_debug_hook_data;
++
++	/**
++	 * Get an empty message and initialize it.
++	 * @return
++	 */
++	struct debugger_message *
++	alloc_message ( struct Process *process )
++	{
++		struct debugger_message *message = (struct debugger_message *)IExec->RemHead(amigaos_debug_messages_list);
++
++		message->msg.mn_Node.ln_Type = NT_MESSAGE;
++		message->msg.mn_Node.ln_Name = NULL;
++		message->msg.mn_ReplyPort = NULL;
++		message->msg.mn_Length = sizeof(struct debugger_message);
++		message->process = process;
++
++		return message;
++	}
++
++	/**
++	 * Return a message to the pool. Note that we disable here so that we're not
++	 * interrupted. Can't use semaphores because get_msg_packet is called during an
++	 * exception.
++	 *
++	 * @param msg
++	 */
++	void
++	free_message( struct debugger_message *message )
++	{
++		if (message)
++		{
++			IExec->AddTail(amigaos_debug_messages_list, (struct Node *)message);
++		}
++	}
++	
++	ppc_amigaos_nat_target ();
++	~ppc_amigaos_nat_target () override;
++	
++	ptid_t wait (ptid_t, struct target_waitstatus *, target_wait_flags) override;
++
++	void fetch_registers (struct regcache *, int) override;	
++	void store_registers (struct regcache *, int) override;
++
++    enum target_xfer_status xfer_partial (enum target_object object,const char *annex,gdb_byte *readbuf,const gdb_byte *writebuf,ULONGEST offset, ULONGEST len,ULONGEST *xfered_len) override;
++
++	void attach (const char *, int) override;
++
++	bool attach_no_wait () override
++	{
++		return true;
++	}
++
++	/*
++	void post_attach (int pid) override
++	{
++		printf( "[GDB] %s (pid: %d)\n",__func__,pid );
++	}
++	
++	void detach (inferior *inf, int from_tty) override
++	{
++		printf( "[GDB] %s ( inferior: %p, from_tty: %d )\n",__func__,inf,from_tty );
++	}
++	*/
++
++	void create_inferior (const char *, const std::string &,char **, int) override;
++
++	/*
++	void mourn_inferior() override
++	{
++		printf( "[GDB] %s ()\n",__func__ );
++	}
++	*/
++	
++	// TODO: void prepare_to_store (regcache *regs) override;
++	
++	void resume (ptid_t ptid,int step,enum gdb_signal signal) override
++	{
++		struct Task *task = (struct Task *)(ptid == minus_one_ptid ? inferior_ptid.pid () : ptid.pid ());
++		
++		printf ("[GDB] %s ( step: %d, gdb_signal: %d, Task: %p  )\n",__func__,step,signal,task);
++
++		IExec->RestartTask (task,0);
++	}
++
++	/*
++	void kill () override
++	{
++		printf( "[GDB] %s ()\n",__func__ );
++	}
++	*/
++	
++	/*
++	std::string pid_to_str (ptid_t ptid) override
++	{
++		IExec->DebugPrintF ("[GDB] %s Entering\n",__func__);
++		
++		/ *
++		if( ptid != minus_one_ptid )
++		{
++			struct Task *task = (struct Task *)ptid.pid();
++
++			IExec->Forbid();
++			// ML: Should actually check that Task address is still a valid Task!?
++			std::string str = string_printf (_("Task '%s' @ %s"), task->tc_Node.ln_Name ,phex ((ULONGEST)task, sizeof (void *)));
++			IExec->Permit();
++
++			return str;
++		}
++		* /
++
++	  return normal_pid_to_str (ptid);
++	}
++	*/
++	
++	// TODO: char *pid_to_exec_file (int pid) override;
++	
++	/*
++	bool info_proc (const char *args, enum info_proc_what what) override 
++	{
++		printf ("[GDB] %s (false)\n",__func__);
++		return false;
++	}
++	*/
++};
++
++ppc_amigaos_nat_target::ppc_amigaos_nat_target ()
++{
++	ElfBase = IExec->OpenLibrary ("elf.library",0);
++	if (!ElfBase)
++	{
++		error ("Can't open elf.library. How did you run *this* program ?\n");
++	}
++
++	IElf = (struct ElfIFace *)IExec->GetInterface (ElfBase,"main",1,0);
++	if (!IElf)
++	{
++		IExec->CloseLibrary (ElfBase);
++
++		ElfBase = NULL;
++
++		error ("Can't get elf.library::main\n");
++	}
++
++	IMMU = (struct MMUIFace *)IExec->GetInterface ((struct Library *)SysBase,"mmu",1,0 );
++	if (!IMMU)
++	{
++		IExec->DropInterface ((struct Interface *)IElf);
++		IExec->CloseLibrary (ElfBase);
++
++		IElf = NULL;
++		ElfBase = NULL;
++
++		error ("Can't get MMU access\n");
++	}
++
++	IDebug = (struct DebugIFace *)IExec->GetInterface ((struct Library *)SysBase,"debug",1,0 );
++	if (!IDebug)
++	{
++		IExec->DropInterface ((struct Interface *)IMMU);
++		IExec->DropInterface ((struct Interface *)IElf);
++		IExec->CloseLibrary (ElfBase);
++
++		IMMU = NULL;
++		IElf = NULL;
++		ElfBase = NULL;
++
++		error ("Can't find kernel's debugger interface\n");
++	}
++
++	amigaos_debug_hook_data.debugger_port = (struct MsgPort *)IExec->AllocSysObjectTags (ASOT_PORT, ASOPORT_Name, "GDB", TAG_DONE);
++	if (!amigaos_debug_hook_data.debugger_port)
++	{
++		IExec->DropInterface ((struct Interface *)IDebug);
++		IExec->DropInterface ((struct Interface *)IMMU);
++		IExec->DropInterface ((struct Interface *)IElf);
++		IExec->CloseLibrary (ElfBase);
++
++		IDebug = NULL;
++		IMMU = NULL;
++		IElf = NULL;
++		ElfBase = NULL;
++
++		error ("Can't allocate message port\n");
++	}
++
++	amigaos_debug_hook_data.current_process	= 0;
++	amigaos_debug_hook_data.debugger_task	= IExec->FindTask ( NULL );
++
++	amigaos_debug_hook = (struct Hook *)IExec->AllocSysObjectTags ( ASOT_HOOK, 
++		ASOHOOK_Entry,	(HOOKFUNC)amigaos_debug_callback,
++		ASOHOOK_Data,	(APTR)this,
++		TAG_DONE);
++	if (!amigaos_debug_hook)
++	{
++		IExec->FreeSysObject (ASOT_PORT,amigaos_debug_hook_data.debugger_port);
++		IExec->DropInterface ((struct Interface *)IDebug);
++		IExec->DropInterface ((struct Interface *)IMMU);
++		IExec->DropInterface ((struct Interface *)IElf);
++		IExec->CloseLibrary (ElfBase);
++
++		IDebug = NULL;
++		IMMU = NULL;
++		IElf = NULL;
++		ElfBase = NULL;
++
++		error ("Can't allocate debugger hook\n");
++	}
++
++	if (!(amigaos_debug_messages_storage = IExec->AllocVecTags (MAX_DEBUG_MESSAGES * sizeof(struct debugger_message), AVT_Type, MEMF_SHARED, TAG_DONE)))
++	{
++		IExec->FreeSysObject (ASOT_PORT,amigaos_debug_hook);
++		IExec->FreeSysObject (ASOT_PORT,amigaos_debug_hook_data.debugger_port);
++		IExec->DropInterface ((struct Interface *)IDebug);
++		IExec->DropInterface ((struct Interface *)IMMU);
++		IExec->DropInterface ((struct Interface *)IElf);
++		IExec->CloseLibrary (ElfBase);
++
++		IDebug = NULL;
++		IMMU = NULL;
++		IElf = NULL;
++		ElfBase = NULL;
++	
++	
++		error ("Can't allocate memory for messages\n");
++	}
++
++	amigaos_debug_messages_list = (struct List *)IExec->AllocSysObjectTags ( ASOT_LIST, TAG_DONE);
++	if (!amigaos_debug_messages_list)
++	{
++		IExec->FreeVec(amigaos_debug_messages_storage);
++		IExec->FreeSysObject (ASOT_PORT,amigaos_debug_hook);
++		IExec->FreeSysObject (ASOT_PORT,amigaos_debug_hook_data.debugger_port);
++		IExec->DropInterface ((struct Interface *)IDebug);
++		IExec->DropInterface ((struct Interface *)IMMU);
++		IExec->DropInterface ((struct Interface *)IElf);
++		IExec->CloseLibrary (ElfBase);
++
++		IDebug = NULL;
++		IMMU = NULL;
++		IElf = NULL;
++		ElfBase = NULL;
++
++		error ("Can't allocate list for debug message\n");
++	}
++
++	struct debugger_message *msg = (struct debugger_message *)amigaos_debug_messages_storage;
++	for (int i = 0; i < MAX_DEBUG_MESSAGES; i++)
++	{
++		IExec->AddHead( amigaos_debug_messages_list, (struct Node *)msg);
++		msg++;
++	}
++}
++
++ppc_amigaos_nat_target::~ppc_amigaos_nat_target ()
++{
++	/* Clear the debug hook (necessary to avoid the shell reusing it) */ 
++	IDebug->AddDebugHook ((struct Task *)amigaos_debug_hook_data.current_process,NULL );
++
++	/* Free pending messages and port */
++	while (struct debugger_message *message = (struct debugger_message *)IExec->GetMsg (amigaos_debug_hook_data.debugger_port))
++		free_message (message);
++
++	if (amigaos_debug_messages_list)
++	{
++		IExec->FreeSysObject (ASOT_LIST,amigaos_debug_messages_list);
++	}
++
++	if (amigaos_debug_messages_storage)
++	{
++		IExec->FreeVec(amigaos_debug_messages_storage);
++	}
++
++	if (amigaos_debug_hook_data.debugger_port)
++	{
++		IExec->FreeSysObject (ASOT_PORT,amigaos_debug_hook_data.debugger_port);
++	}
++	amigaos_debug_hook_data.debugger_port = NULL;
++
++	if (amigaos_debug_hook)
++	{
++		IExec->FreeSysObject (ASOT_HOOK,amigaos_debug_hook);
++	}
++	amigaos_debug_hook = NULL;
++
++	if (IElf)
++	{
++		IExec->DropInterface ((struct Interface *)IElf);
++	}
++	IElf = NULL;
++
++	if (ElfBase)
++	{
++		IExec->CloseLibrary (ElfBase);
++	}
++	ElfBase = NULL;
++
++	if (IMMU)
++	{
++		IExec->DropInterface ((struct Interface *)IMMU);
++	}
++	IMMU = NULL;
++
++	if (IDebug)
++	{
++		IExec->DropInterface ((struct Interface *)IDebug);
++	}
++	IDebug = NULL;
++}
++
++ptid_t
++ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,target_wait_flags options)
++{
++	struct Process *process = (ptid == minus_one_ptid ? amigaos_debug_hook_data.current_process : (struct Process *)ptid.pid());
++
++	if( ptid == minus_one_ptid )
++		ptid = ptid_t ((int)amigaos_debug_hook_data.current_process);
++
++	while( 1 )
++	{
++		uint32 signal = IExec->Wait (SIGBREAKF_CTRL_D|SIGBREAKF_CTRL_C|1<<amigaos_debug_hook_data.debugger_port->mp_SigBit);
++
++		if( ( signal & SIGBREAKF_CTRL_D ) == SIGBREAKF_CTRL_D )
++		{
++			printf ("[GDB] %s received SIGBREAKF_CTRL_D\n",__func__);
++
++			ourstatus->set_exited (0);
++
++			return ptid;
++		}
++
++		if( ( signal & SIGBREAKF_CTRL_C ) == SIGBREAKF_CTRL_C )
++		{
++			printf ("[GDB] %s received SIGBREAKF_CTRL_C\n",__func__);
++
++			IExec->SuspendTask ((struct Task *)process,0);
++
++			ourstatus->set_stopped (GDB_SIGNAL_TRAP);
++
++			return ptid;
++		}
++
++		while (struct Message *message = IExec->GetMsg (amigaos_debug_hook_data.debugger_port) ) 		
++		{
++			printf ("[GDB] %s received message: %p\n",__func__,message);
++
++			if( message->mn_Node.ln_Name != NULL && strcmp (message->mn_Node.ln_Name,"DeathMessage") == 0)
++			{
++				struct DeathMessage *deathMesage = (struct DeathMessage *)message;
++				
++				printf ("[GDB] %s received SIGB_CHILD with dos return: %ld\n",__func__,deathMesage->dm_ReturnCode);
++
++				ourstatus->set_exited (deathMesage->dm_ReturnCode);
++
++				IExec->FreeVec (deathMesage);
++
++				return ptid;
++			}
++			else 
++			{
++				struct debugger_message *debuggerMessage = (struct debugger_message *)message;
++				if( debuggerMessage->signal == -1 )
++				{
++					switch( debuggerMessage->flags )
++					{
++						case DM_FLAGS_TASK_OPENLIB:
++						{
++							printf ("[GDB] %s received task open library\n",__func__);
++
++							break;
++						}
++						case DM_FLAGS_TASK_CLOSELIB:
++						{
++							printf ("[GDB] %s received task close library\n",__func__);
++
++							break;
++						}
++						default:
++						{
++							printf ("[GDB] %s received unknown flags for signal -1 from callback %ld\n",__func__,debuggerMessage->flags);
++		
++							break;
++						}
++					}
++
++
++					free_message (debuggerMessage);
++				}
++				else
++				{
++					printf ("[GDB] %s Inferior (%p) signaled : '%s'\n",__func__,process,gdb_signal_to_name ((enum gdb_signal)debuggerMessage->signal));
++
++					switch (debuggerMessage->signal)
++					{
++						case GDB_SIGNAL_CHLD:
++						{
++							ourstatus->set_signalled (GDB_SIGNAL_0);
++
++							break;
++						}
++						case GDB_SIGNAL_QUIT:
++						{
++							ourstatus->set_signalled (GDB_SIGNAL_QUIT);
++
++							break;
++						}
++						case GDB_SIGNAL_TRAP:
++						{
++							ourstatus->set_stopped (GDB_SIGNAL_TRAP);
++
++							break;
++						}
++						case GDB_SIGNAL_SEGV:
++						case GDB_SIGNAL_BUS:
++						case GDB_SIGNAL_INT:
++						case GDB_SIGNAL_FPE:
++						case GDB_SIGNAL_ILL:
++						case GDB_SIGNAL_ALRM:					
++						{					
++							ourstatus->set_stopped (GDB_SIGNAL_0);
++
++							break;
++						}
++						default:
++						{
++							printf ("[GDB] %s received unknown signal from callback %ld\n",__func__,debuggerMessage->signal);
++
++							break;
++						}
++					}
++
++					free_message (debuggerMessage);
++					
++					return ptid;
++				}
++			}
++		}
++	}
++
++	return ptid_t::make_minus_one ();
++}
++
++/* Fetch register REGNO from the inferior.  */
++void 
++ppc_amigaos_nat_target::fetch_registers (struct regcache *regcache, int regno) 
++{
++	struct gdbarch *gdbarch = regcache->arch ();
++	ppc_gdbarch_tdep *tdep = gdbarch_tdep<ppc_gdbarch_tdep> (gdbarch);	
++	struct Task *task = (struct Task *)regcache->ptid().pid();
++
++	printf ("[GDB] %s ( regcache: %p, regno: %d (%s), task: %p)\n",__func__,regcache,regno,gdbarch_register_name( gdbarch,regno ),task);
++
++	struct ExceptionContext context;
++	IDebug->ReadTaskContext( task,&context,RTCF_INFO | RTCF_SPECIAL | RTCF_STATE | RTCF_GENERAL | RTCF_FPU | RTCF_VECTOR );
++
++	if( regno == -1 )
++	{
++		for (int i = 0; i < 31; i++)
++			regcache->raw_supply (regno, (void*)&context.gpr[i]);
++
++		for (int i = 0; i < 31; i++)
++			regcache->raw_supply (regno, (void*)&context.fpr[i]);
++
++		regcache->raw_supply (gdbarch_pc_regnum (gdbarch), (void *)&context.ip);
++		regcache->raw_supply (tdep->ppc_ps_regnum, (void *)&context.msr);
++		regcache->raw_supply (tdep->ppc_cr_regnum, (void *)&context.cr);
++		regcache->raw_supply (tdep->ppc_lr_regnum, (void *)&context.lr);
++		regcache->raw_supply (tdep->ppc_ctr_regnum, (void *)&context.ctr);
++		regcache->raw_supply (tdep->ppc_xer_regnum, (void *)&context.xer);
++		regcache->raw_supply (tdep->ppc_fpscr_regnum, (void *)&context.fpscr);			
++	}
++	else 
++	{
++		if (regno == gdbarch_pc_regnum (gdbarch) )
++		{			
++			regcache->raw_supply (regno, (void*)&context.ip);
++		}
++		else if (regno >= 0 && regno <= 31) {
++			regcache->raw_supply (regno, (void*)&context.gpr[regno]);
++		}
++		else if (regno >= 32 && regno <= 64)
++			regcache->raw_supply (regno, (void*)&context.fpr[regno]);
++		else if (regno == tdep->ppc_ps_regnum)
++			regcache->raw_supply (regno, (void *)&context.msr);
++		else if (regno == tdep->ppc_cr_regnum)
++			regcache->raw_supply (tdep->ppc_cr_regnum, (void *)&context.cr);
++		else if (regno == tdep->ppc_lr_regnum)
++			regcache->raw_supply (tdep->ppc_lr_regnum, (void *)&context.lr);
++		else if (regno == tdep->ppc_ctr_regnum) 
++			regcache->raw_supply (tdep->ppc_ctr_regnum, (void *)&context.ctr);
++		else if (regno == tdep->ppc_xer_regnum)
++			regcache->raw_supply (tdep->ppc_xer_regnum, (void *)&context.xer);
++		else if (regno == tdep->ppc_fpscr_regnum)
++			regcache->raw_supply (tdep->ppc_fpscr_regnum, (void *)&context.fpscr);		
++		else
++		{
++			internal_error (_("fetch_registers: unexpected register: '%s'"),gdbarch_register_name ( gdbarch,regno ));
++		}
++	}
++}
++
++void
++ppc_amigaos_nat_target::store_registers (struct regcache *regcache, int regno)
++{
++	printf( "[GDB] %s Todo ( regcache: %p, regno: %d)\n",__func__,regcache,regno );
++}
++
++enum target_xfer_status
++ppc_amigaos_nat_target::xfer_partial (enum target_object object,const char *annex, gdb_byte *readbuf,const gdb_byte *writebuf,ULONGEST offset, ULONGEST len, ULONGEST *xfered_len)
++{
++	// IExec->DebugPrintF ( string_printf (_("[GDB] %s called for memory tranfser at address: 0x%s for %s bytes (readbuf: %p, writebuf: %p, annex: '%s', object: %d )\n"),__func__,phex (offset, sizeof (offset)),pulongest (len), readbuf, writebuf, annex, object).c_str());
++
++	printf ("[GDB] %s called for memory tranfser at address: 0x%016llx for %lld bytes (readbuf: %p, writebuf: %p, annex: '%s', object: %d )\n",__func__,offset,len,readbuf,writebuf,annex,object);
++
++	switch (object)
++	{
++		case TARGET_OBJECT_MEMORY:
++		{
++			if (offset == 0) 
++			{
++				// ML: Helps to unwind farme correctly
++				return TARGET_XFER_E_IO;
++			}
++			else
++			{
++				APTR user_stack = IExec->SuperState();
++
++				ULONG currentAttrs = IMMU->GetMemoryAttrs( (APTR)offset,0 );
++				IMMU->SetMemoryAttrs ( (APTR)offset,len,MEMATTRF_READ_WRITE );
++
++				if (readbuf) 
++				{
++					IExec->CopyMem( (APTR)offset,(APTR)readbuf,len );
++				}
++				else // if(writebuf)
++				{
++					IExec->CopyMem( (APTR)writebuf,(APTR)offset,len );
++					IExec->CacheClearE( (APTR)offset,len,CACRF_ClearI );
++				}
++
++				IMMU->SetMemoryAttrs( (APTR)offset,len,currentAttrs );
++
++				if (user_stack)
++				{
++					IExec->UserState( user_stack );
++				}
++			}
++
++			*xfered_len = len;
++
++			printf ("[GDB] %s tansferfed %lld bytes \n",__func__,*xfered_len);
++
++			return TARGET_XFER_OK;			
++		}
++		break;
++
++		case TARGET_OBJECT_LIBRARIES:
++		{
++				printf ("[GDB] %s tansferfed object library '%s' failed, aka not supported yet\n",__func__,annex);
++
++			return TARGET_XFER_E_IO;			
++		}
++		break;
++
++		default:
++			if (beneath()) 
++			{
++				printf ("[GDB] %s tansferfed delegated to beneath for target_object %d\n",__func__,object);
++
++				return this->beneath ()->xfer_partial (object,annex,readbuf,writebuf,offset,len,xfered_len);
++			}
++			/* This can happen when requesting the transfer of unsupported
++			 objects before a program has been started (and therefore
++			 with the current_target having no target beneath).  */
++	}
++
++	return TARGET_XFER_E_IO;
++}
++
++void
++ppc_amigaos_nat_target::attach (const char *args, int from_tty)
++{
++	printf( "[GDB] %s ( args: '%s', from_tty: %d )\n",__func__,args,from_tty );
++}
++
++void
++ppc_amigaos_relocate_sections (const char *exec_file,BPTR exec_seglist) 
++{
++	// To debug this stuff, enableing elf debug out with 'SetENV ELF.debug 1' helps alot on thr target
++	Elf32_Handle exec_elfhandle = 0;
++	if( 1 == IDOS->GetSegListInfoTags( exec_seglist,
++		GSLI_ElfHandle,		&exec_elfhandle,
++		TAG_DONE) )
++	{
++		Elf32_Handle exec_opendelf = IElf->OpenElfTags(
++			OET_ElfHandle,			exec_elfhandle,
++			OET_ReadOnlyCopy,		TRUE,
++			TAG_DONE );
++		if( exec_opendelf ) 
++		{
++			if( current_program_space->symfile_object_file ) 
++			{
++				struct objfile *symfile = current_program_space->symfile_object_file;
++				section_offsets offsets (symfile->section_offsets.size () );
++
++				struct obj_section *osect;
++				ALL_OBJFILE_OSECTIONS(symfile, osect)
++				{
++					struct bfd_section *section = osect->the_bfd_section;
++					int osect_idx = osect - symfile->sections;
++					
++					void *address = IElf->GetSectionTags( exec_opendelf,
++						GST_SectionName, section->name,
++						TAG_DONE );
++						
++					if( address )
++					{
++						printf ("[GDB] On symfile_object relocated %d section '%s' from 0x%08lx to %p, size %ld, old offset: 0x%08llx\n",section->index,section->name,section->vma,address,section->size,osect->addr() );
++						offsets[ osect_idx ] = (CORE_ADDR)address - osect->addr();
++					}
++				}
++
++				objfile_relocate(symfile, offsets);
++			}
++			else if( current_program_space->exec_bfd() )
++			{
++				/* Go through all GDB sections, and make sure they are loaded and relocated */
++				for (asection *section : gdb_bfd_sections (current_program_space->exec_bfd ())) {
++
++					void *address = IElf->GetSectionTags( exec_opendelf,
++						GST_SectionName, section->name,
++						TAG_DONE );
++								
++					if( address )
++					{
++						printf ( "[GDB] On exec_bfd relocated %d section '%s' from %08lx to %p, size %ld\n",section->index,section->name,section->vma,address,section->size);
++						
++						exec_set_section_address( exec_file,section->index,(CORE_ADDR)address );							
++					}
++				}
++			}
++
++			IElf->CloseElfTags( exec_opendelf,
++				CET_FreeUnneeded,		TRUE,
++				TAG_DONE );
++		}
++	}
++}
++
++/* Start a new inferior AmigaOS DOS process.  EXEC_FILE is the file to
++   run, ALLARGS is a string containing the arguments to the program.
++   ENV is the environment vector to pass.  */
++void ppc_amigaos_nat_target::create_inferior (const char *exec_file,const std::string &allargs,char **env, int from_tty)
++{
++	inferior *inf = current_inferior ();
++	if( !inf )
++	{
++		error ("No current inferior present" );
++	}
++
++	/* If no exec file handed to us, get it from the exec-file command -- with
++	 a good, common error message if none is specified.  */
++	if (exec_file == 0)
++	{
++	    exec_file = get_exec_file (1);
++	}
++
++	BPTR exec_seglist = IDOS->LoadSeg( exec_file );
++	if( ! exec_seglist )
++	{
++		error ("'%s': not an executable file\n",exec_file );
++	}
++
++	BPTR exec_home = ZERO;
++	BPTR exec_lock = IDOS->Lock( exec_file,SHARED_LOCK );
++	if( exec_lock )
++	{
++		exec_home = IDOS->ParentDir( exec_lock );
++
++		IDOS->UnLock( exec_lock );
++	}
++
++	struct DeathMessage *dmsg = (struct DeathMessage *)IExec->AllocVecTags( sizeof( struct DeathMessage ),AVT_Type, MEMF_SHARED, TAG_DONE );
++	if( dmsg == NULL )
++	{
++		error ("Can't allocate memory for death message\n");
++	}
++
++	dmsg->dm_Msg.mn_ReplyPort = amigaos_debug_hook_data.debugger_port;
++	dmsg->dm_Msg.mn_Length = sizeof( struct DeathMessage );
++	dmsg->dm_Msg.mn_Node.ln_Name = (char*)"DeathMessage";
++
++	amigaos_debug_hook_data.current_process = IDOS->CreateNewProcTags(
++			NP_Seglist,										exec_seglist,
++			NP_FreeSeglist,									FALSE,
++			NP_EntryCode,									amigaos_debug_suspend,
++			NP_EntryData,									amigaos_debug_hook,
++			NP_Child,										TRUE,
++			NP_NotifyOnDeathMessage,						dmsg, // Signal parent with with prepared reply msg
++			NP_Name,										lbasename( exec_file ),
++			NP_CommandName,									lbasename( exec_file ),
++			NP_Cli,											TRUE,
++			NP_Arguments,									allargs.c_str(),
++			NP_Input,										IDOS->Input(),
++			NP_CloseInput,									FALSE,
++			NP_Output,										IDOS->Output(),
++			NP_CloseOutput,									FALSE,
++			NP_Error,										IDOS->ErrorOutput(),
++			NP_CloseError,									FALSE,
++			(exec_home ? NP_ProgramDir: TAG_IGNORE),		exec_home,
++			TAG_DONE
++		);
++
++	if (! amigaos_debug_hook_data.current_process)
++	{
++		error ("Can't create AmigaOS DOS process\n");
++	}
++
++	IDebug->AddDebugHook((struct Task *)amigaos_debug_hook_data.current_process,amigaos_debug_hook);
++
++	inferior_ptid = ptid_t ((int)amigaos_debug_hook_data.current_process);
++	inferior_appeared (inf,(int)amigaos_debug_hook_data.current_process);
++	/* We have something that executes now.  We'll be running through
++	 the shell at this point (if startup-with-shell is true), but the
++	 pid shouldn't change.  */
++
++	/* Do not change either targets above or the same target if already present.
++	 The reason is the target stack is shared across multiple inferiors.  */
++	inf->unpush_target(this);
++	
++	if(!inf->target_is_pushed(this))
++		inf->push_target(this);
++
++	thread_info *thr = add_thread (this, inferior_ptid);
++	switch_to_thread (thr);
++
++	clear_proceed_status (0);
++	init_wait_for_inferior ();
++
++	ppc_amigaos_relocate_sections (exec_file,exec_seglist);
++
++	printf ("[GDB] %s inferior_ptid=0x%08x inf=%p thr=%p\n",__func__,inferior_ptid.pid(),inf,thr);
++
++	//  ML: Don't do it here, because we need to keep the exec_segliots until the task has finished
++	// IDOS->UnLoadSeg( exec_seglist );
++}
++
++static ppc_amigaos_nat_target the_ppc_amigaos_nat_target;
++
++void _initialize_ppcamigaos_nat ();
++void
++_initialize_ppcamigaos_nat ()
++{
++	add_inf_child_target (&the_ppc_amigaos_nat_target);
++}
++
++VOID amigaos_debug_suspend( struct Hook *amigaos_debug_hook ) 
++{
++	struct Task *current = IExec->FindTask (NULL);
++
++	printf ("[GDB] %s inferiorer %p started by kernel, suspending myself and installing debug hook: %p\n",__func__,current,amigaos_debug_hook);
++	
++	IExec->SuspendTask (current,0);
++
++	printf ("[GDB] %s inferiorer %p started by gdb\n",__func__,current);
++}
++
++ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct KernelDebugMessage *dbgmsg )
++{
++	class ppc_amigaos_nat_target *ppc_amigaos_nat_target = (class ppc_amigaos_nat_target *)hook->h_Data;
++	struct amigaos_debug_hook_data *data = &(ppc_amigaos_nat_target->amigaos_debug_hook_data);
++	
++	if( (struct Task *)data->current_process != currentTask )
++	{
++		printf ("[GDB] Task: %p ('%s'), task NOT under our observation\n",currentTask,currentTask->tc_Node.ln_Name);
++
++		return 0;
++	}
++	printf ("[GDB] Task: %p ('%s'), task IS under our observation\n",currentTask,currentTask->tc_Node.ln_Name);
++
++
++	switch( dbgmsg->type ) 
++	{
++		case DBHMT_EXCEPTION:
++		{
++			printf ("[GDB] Task: %p ('%s'),Exception ooccured (DBHMT_EXCEPTION)\n",currentTask,currentTask->tc_Node.ln_Name);
++
++			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);
++			message->flags	= 0;
++			message->signal	= trap_to_signal( dbgmsg->message.context,message->flags );
++			
++			IExec->PutMsg (data->debugger_port,(struct Message *)message);
++
++			return 1; // Suspend execution
++		}
++		case DBHMT_ADDTASK:
++		{
++			printf ("[GDB] Task: %p ('%s'), (DBHMT_ADDTASK), Task added\n",currentTask,currentTask->tc_Node.ln_Name);
++
++			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);	
++			message->flags	= DM_FLAGS_TASK_ATTACHED;
++			message->signal	= -1;
++			
++			IExec->PutMsg (data->debugger_port,(struct Message *)message);
++
++			break;
++		}
++		case DBHMT_REMTASK:
++		{
++			printf ("[GDB] Task: %p ('%s'), (DBHMT_REMTASK), Task removed\n",currentTask,currentTask->tc_Node.ln_Name);
++
++			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);
++			message->flags	= DM_FLAGS_TASK_TERMINATED;
++			message->signal	= -1;
++			
++			IExec->PutMsg (data->debugger_port,(struct Message *)message);
++			
++			break;
++		}
++		case DBHMT_OPENLIB:
++		{
++			printf ("[GDB] Task: %p ('%s'), (DBHMT_OPENLIB), Task opened library '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
++
++			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);
++			message->flags		= DM_FLAGS_TASK_OPENLIB;
++			message->signal		= -1;
++			message->library	= dbgmsg->message.library;
++			
++			IExec->PutMsg (data->debugger_port,(struct Message *)message);
++
++			break;
++		}
++		case DBHMT_CLOSELIB:
++		{
++			printf ("[GDB] Task: %p ('%s'), (DBHMT_CLOSELIB), Task closed library '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
++
++			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);	
++			message->flags		= DM_FLAGS_TASK_CLOSELIB;
++			message->signal		= -1;
++			message->library	= dbgmsg->message.library;
++
++			IExec->PutMsg (data->debugger_port,(struct Message *)message);
++
++			break;
++		}
++		case DBHMT_SHAREDOBJECTOPEN:
++		{
++			printf ("[GDB] Task: %p ('%s'), (DBHMT_SHAREDOBJECTOPEN), Task opened shared object '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
++			break;
++		}
++		case DBHMT_SHAREDOBJECTCLOSE:
++		{
++			printf ("[GDB] Task: %p ('%s'), (DBHMT_SHAREDOBJECTCLOSE), Task closed shared object '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
++			break;
++		}
++		default:
++		{
++			printf ("[GDB] Task: %p ('%s'), (DBHMT_UNKNOWN), Task unknown message type %lu\n",currentTask,currentTask->tc_Node.ln_Name,dbgmsg->type);
++		}
++	}
++
++	return 0; // Resume execution
++}
++
++static int
++trap_to_signal(struct ExceptionContext *context, uint32 flags)
++{
++	printf( "[GDB] trap_to_signal ( flags: 0x%lx )\n",flags );
++
++	if (!context || (flags & DM_FLAGS_TASK_TERMINATED)) {
++		printf( "[GDB] Return GDB_SIGNAL_QUIT )\n" );
++	
++		return GDB_SIGNAL_QUIT;
++	}
++
++	printf( "[GDB] traptype: 0x%lx\n",context->Traptype );
++
++	switch (context->Traptype)
++	{
++	case TRAP_MCE:
++	case TRAP_DSI:
++		printf( "[GDB] Return ( GDB_SIGNAL_SEGV )\n" );
++		return GDB_SIGNAL_SEGV;
++	case TRAP_ISI:
++	case TRAP_ALIGN:
++		printf( "[GDB] Return ( GDB_SIGNAL_BUS )\n" );
++		return GDB_SIGNAL_BUS;
++	case TRAP_EXTERN:
++		printf( "[GDB] Return ( GDB_SIGNAL_INT )\n" );
++		return GDB_SIGNAL_INT;
++	case TRAP_PROG: 
++		if (context->msr & EXC_FPE) {
++			printf( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
++			return GDB_SIGNAL_FPE;
++		}
++		else if (context->msr & EXC_ILLEGAL) {
++			printf( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
++			return GDB_SIGNAL_ILL;
++		}
++		else if (context->msr & EXC_PRIV) {
++			printf( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
++			return GDB_SIGNAL_ILL;
++		}
++		else {
++			printf( "[GDB] Return ( GDB_SIGNAL_TRAP )\n" );
++			return GDB_SIGNAL_TRAP;
++		}
++	case TRAP_FPU:
++		printf( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
++		return GDB_SIGNAL_FPE;
++	case TRAP_DEC:
++		printf( "[GDB] Return ( GDB_SIGNAL_ALRM )\n" );
++		return GDB_SIGNAL_ALRM;
++	case TRAP_RESERVEDA:
++	case TRAP_RESERVEDB:
++		printf( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
++		return GDB_SIGNAL_ILL;
++	case TRAP_SYSCALL:
++		printf( "[GDB] Return ( GDB_SIGNAL_CHLD )\n" );
++		return GDB_SIGNAL_CHLD;
++	case TRAP_TRACEI:
++		printf( "[GDB] Return ( GDB_SIGNAL_TRAP )\n" );
++		return GDB_SIGNAL_TRAP;
++	case TRAP_FPA:
++		printf( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
++		return GDB_SIGNAL_FPE;
++	default:
++		printf( "[GDB] Return ( -1 )\n" );
++		return -1;
++	}
++}
+\ No newline at end of file
+diff --git a/gdb/ppc-amigaos-nat.h b/gdb/ppc-amigaos-nat.h
+new file mode 100644
+index 00000000000..29914e7fb50
+--- /dev/null
++++ b/gdb/ppc-amigaos-nat.h
+@@ -0,0 +1,76 @@
++/* Native-dependent code for PowerPC's running AmigaOS, for GDB.
++
++   Copyright (C) 2013-2024 Free Software Foundation, Inc.
++
++   This file is part of GDB.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++
++#ifndef PPC_AMIGAOS_NAT_H
++#define PPC_AMIGAOS_NAT_H
++
++#include <exec/ports.h>
++
++// Chapter Interrupt Reference union from different ppc32 cpus
++#define TRAP_RESET 			0x0100 /* System reset */
++#define TRAP_MCE   			0x0200 /* Machine check */
++#define TRAP_DSI    		0x0300 /* Data storage */
++#define TRAP_DSEGI   		0x0380 /* Data segment (Book III v2.01) */
++#define TRAP_ISI     		0x0400 /* Instruction storage */
++#define TRAP_ISEGI   		0x0480 /* Instruction segment (Book III v2.01)*/
++#define TRAP_EXTERN   		0x0500 /* External Interrupt */
++#define TRAP_ALIGN   		0x0600 /* Alignment */
++#define TRAP_PROG    		0x0700 /* Program */
++#define TRAP_FPU			0x0800 /* FPU Disabled */
++#define TRAP_DEC			0x0900 /* Decrementer */
++#define TRAP_RESERVEDA		0x0a00 /* Reserved (Book III v2.01)*/
++#define TRAP_RESERVEDB		0x0b00 /* Reserved (Book III v2.01)*/
++#define TRAP_SYSCALL		0x0c00 /* System call */
++#define TRAP_TRACEI			0x0d00 /* Trace */
++#define TRAP_FPA			0x0e00 /* Floating-point Assist */
++#define TRAP_PMI     		0x0f00 /* Performance monitor (Book III v2.01)*/
++#define TRAP_APU			0x0f20 /* APU Unavailble */
++#define TRAP_PIT			0x1000 /* Programmable-interval timer (PIT) */
++#define TRAP_FIT			0x1010 /* Fixed-interval timer (FIT) */
++#define TRAP_WATCHDOG		0x1020 /* Watch Dog */
++#define TRAP_DTBL			0x1100 /* Data TBL error */
++#define TRAP_ITBL			0x1200 /* Instruction TBL error */
++#define TRAP_DEBUG			0x2000 /* Debug */
++
++/* MSR Bits */
++#define    MSR_TRACE_ENABLE           0x00000400
++#define    EXC_FPE                    0x00100000
++#define    EXC_ILLEGAL                0x00080000
++#define    EXC_PRIV                   0x00040000
++#define    EXC_TRAP                   0x00020000
++
++/* Message sent from debugger hook to debugger to alert debugger
++   of an event that happened */
++struct debugger_message
++{
++	struct Message msg;
++	struct Process *process;
++	uint32 flags;
++	uint32 signal;
++	struct Library *library;
++};
++
++/* Possible debuger_message flags */
++#define    DM_FLAGS_TASK_TERMINATED            0x00000001
++#define    DM_FLAGS_TASK_ATTACHED              0x00000002
++#define    DM_FLAGS_TASK_INTERRUPTED           0x00000004
++#define	   DM_FLAGS_TASK_OPENLIB               0x00000008
++#define	   DM_FLAGS_TASK_CLOSELIB              0x00000010
++
++#endif /* PPC_AMIGAOS_NAT_H */
+diff --git a/gdb/ppc-amigaos-tdep.c b/gdb/ppc-amigaos-tdep.c
+new file mode 100644
+index 00000000000..4dba12da78e
+--- /dev/null
++++ b/gdb/ppc-amigaos-tdep.c
+@@ -0,0 +1,153 @@
++/* Target-dependent code for GDB, the GNU debugger.
++
++   Copyright (C) 1986-2024 Free Software Foundation, Inc.
++
++   This file is part of GDB.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++
++#include "defs.h"
++#include "gdbcore.h"
++#include "gdbarch.h"
++#include "ppc-tdep.h"
++
++static int
++ppc_amigaos_has_shared_address_space (struct gdbarch *gdbarch)
++{
++	return true;
++}
++
++/* 1 to 1 copy from rs6000aix-tdp.c branch_dest , 
++except removed AIX_TEXT_SEGMENT_BASE checks, 
++removed byte_order */
++static CORE_ADDR
++branch_dest (struct regcache *regcache, int opcode, int instr,
++	     CORE_ADDR pc, CORE_ADDR safety)
++{
++  struct gdbarch *gdbarch = regcache->arch ();
++  ppc_gdbarch_tdep *tdep = gdbarch_tdep<ppc_gdbarch_tdep> (gdbarch);
++  CORE_ADDR dest;
++  int immediate;
++  int absolute;
++  int ext_op;
++
++  absolute = (int) ((instr >> 1) & 1);
++
++  switch (opcode)
++    {
++    case 18:
++      immediate = ((instr & ~3) << 6) >> 6;	/* br unconditional */
++      if (absolute)
++	dest = immediate;
++      else
++	dest = pc + immediate;
++      break;
++
++    case 16:
++      immediate = ((instr & ~3) << 16) >> 16;	/* br conditional */
++      if (absolute)
++	dest = immediate;
++      else
++	dest = pc + immediate;
++      break;
++
++    case 19:
++      ext_op = (instr >> 1) & 0x3ff;
++
++      if (ext_op == 16)		/* br conditional register */
++	  dest = regcache_raw_get_unsigned (regcache, tdep->ppc_lr_regnum) & ~3;
++      else if (ext_op == 528)	/* br cond to count reg */
++	  dest = regcache_raw_get_unsigned (regcache,
++					    tdep->ppc_ctr_regnum) & ~3;
++      else
++	return -1;
++      break;
++
++    default:
++      return -1;
++    }
++  return dest;
++}
++
++/* 1 to 1 copy from rs6000aix-tdp.c rs6000_software_single_step */
++static std::vector<CORE_ADDR>
++ppc_amigaos_software_single_step (struct regcache *regcache)
++{
++  struct gdbarch *gdbarch = regcache->arch ();
++  enum bfd_endian byte_order = gdbarch_byte_order (gdbarch);
++  int ii, insn;
++  CORE_ADDR loc;
++  CORE_ADDR breaks[2];
++  int opcode;
++
++  loc = regcache_read_pc (regcache);
++
++  insn = read_memory_integer (loc, 4, byte_order);
++
++  std::vector<CORE_ADDR> next_pcs = ppc_deal_with_atomic_sequence (regcache);
++  if (!next_pcs.empty ())
++    return next_pcs;
++  
++  breaks[0] = loc + PPC_INSN_SIZE;
++  opcode = insn >> 26;
++  breaks[1] = branch_dest (regcache, opcode, insn, loc, breaks[0]);
++
++  /* Don't put two breakpoints on the same address.  */
++  if (breaks[1] == breaks[0])
++    breaks[1] = -1;
++
++  for (ii = 0; ii < 2; ++ii)
++    {
++      /* ignore invalid breakpoint.  */
++      if (breaks[ii] == -1)
++	continue;
++
++      next_pcs.push_back (breaks[ii]);
++    }
++
++  errno = 0;			/* FIXME, don't ignore errors!  */
++  /* What errors?  {read,write}_memory call error().  */
++  return next_pcs;
++}
++
++static void
++ppc_amigaos_init_abi (struct gdbarch_info info, struct gdbarch *gdbarch)
++{
++	/* Canonical paths on this target look like `SYS:Utilities/Clock', for example.  */
++	set_gdbarch_has_amiga_based_file_system (gdbarch, 1);
++
++	/* Everything runs in the same address space, but might have a priveta adresse area */
++	set_gdbarch_has_shared_address_space (gdbarch, ppc_amigaos_has_shared_address_space);
++
++	// PT_STEP not supported so, need to simulate it, like rs6000-aix
++	set_gdbarch_software_single_step (gdbarch, ppc_amigaos_software_single_step);
++	/* Displaced stepping is currently not supported in combination with
++		software single-stepping.  These override the values set by
++		rs6000_gdbarch_init.  */
++	set_gdbarch_displaced_step_copy_insn (gdbarch, NULL);
++	set_gdbarch_displaced_step_fixup (gdbarch, NULL);
++	set_gdbarch_displaced_step_prepare (gdbarch, NULL);
++	set_gdbarch_displaced_step_finish (gdbarch, NULL);
++
++  	// Traget bfd name, seems to be only needed for message/debug output
++	set_gdbarch_gcore_bfd_target (gdbarch, "elf32-powerpc-amigaos");
++}
++
++void _initialize_ppc_amigaos_tdep ();
++void
++_initialize_ppc_amigaos_tdep ()
++{
++	gdbarch_register_osabi (bfd_arch_rs6000, 0, GDB_OSABI_AMIGAOS, ppc_amigaos_init_abi);
++	gdbarch_register_osabi (bfd_arch_powerpc, 0, GDB_OSABI_AMIGAOS, ppc_amigaos_init_abi);
++}
+-- 
+2.43.0
+
+
+From ff1766156cf4ee99b3384b62cdab8d42aa077a79 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 12 Aug 2024 13:01:06 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 28/61] 
+ Renamed index parameter,  to no colide with IS_ABSOLUTE_PATH expansing for
+ AmigaOS target, which used index function
+
+---
+ gdb/dwarf2/read.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/gdb/dwarf2/read.c b/gdb/dwarf2/read.c
+index b33ea6847e0..fe903d83177 100644
+--- a/gdb/dwarf2/read.c
++++ b/gdb/dwarf2/read.c
+@@ -2858,26 +2858,26 @@ dw2_get_file_names (dwarf2_per_cu_data *this_cu,
+ 
+ static const char *
+ dw2_get_real_path (dwarf2_per_objfile *per_objfile,
+-		   struct quick_file_names *qfn, int index)
++		   struct quick_file_names *qfn, int i)
+ {
+   if (qfn->real_names == NULL)
+     qfn->real_names = OBSTACK_CALLOC (&per_objfile->per_bfd->obstack,
+ 				      qfn->num_file_names, const char *);
+ 
+-  if (qfn->real_names[index] == NULL)
++  if (qfn->real_names[i] == NULL)
+     {
+       const char *dirname = nullptr;
+ 
+-      if (!IS_ABSOLUTE_PATH (qfn->file_names[index]))
++      if (!IS_ABSOLUTE_PATH (qfn->file_names[i]))
+ 	dirname = qfn->comp_dir;
+ 
+       gdb::unique_xmalloc_ptr<char> fullname;
+-      fullname = find_source_or_rewrite (qfn->file_names[index], dirname);
++      fullname = find_source_or_rewrite (qfn->file_names[i], dirname);
+ 
+-      qfn->real_names[index] = fullname.release ();
++      qfn->real_names[i] = fullname.release ();
+     }
+ 
+-  return qfn->real_names[index];
++  return qfn->real_names[i];
+ }
+ 
+ struct symtab *
+@@ -11171,13 +11171,13 @@ try_open_dwop_file (dwarf2_per_objfile *per_objfile,
+     {
+       if (!debug_file_directory.empty ())
+ 	{
+-	  search_path_holder.reset (concat (".", dirname_separator_string,
++	  search_path_holder.reset (concat ("", dirname_separator_string,
+ 					    debug_file_directory.c_str (),
+ 					    (char *) NULL));
+ 	  search_path = search_path_holder.get ();
+ 	}
+       else
+-	search_path = ".";
++	search_path = "";
+     }
+   else
+     search_path = debug_file_directory.c_str ();
+-- 
+2.43.0
+
+
+From 052ba218c1f0b4a44cad190cf6be6fbe97263afe Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 18 Aug 2024 14:23:49 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 29/61] 
+ Added hadling of amuga path shell characters
+
+---
+ gdb/source.c                  | 6 +++++-
+ gdbsupport/common-inferior.cc | 5 +++++
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/gdb/source.c b/gdb/source.c
+index d0f2d1c7635..ed5c1ae2559 100644
+--- a/gdb/source.c
++++ b/gdb/source.c
+@@ -831,7 +831,11 @@ openp (const char *path, openp_flags opts, const char *string,
+     }
+ 
+   if (!path)
++  #if defined(__amigaos4__) 
++    path = "\"\"";
++  #elif
+     path = ".";
++  #endif
+ 
+   mode |= O_BINARY;
+ 
+@@ -878,7 +882,7 @@ openp (const char *path, openp_flags opts, const char *string,
+       size_t len = strlen (dir);
+       int reg_file_errno;
+ 
+-      if (strcmp (dir, "$cwd") == 0)
++      if (strcmp (dir, "$cwd") == 0 || strcmp (dir, "") == 0)
+ 	{
+ 	  /* Name is $cwd -- insert current directory name instead.  */
+ 	  int newlen;
+diff --git a/gdbsupport/common-inferior.cc b/gdbsupport/common-inferior.cc
+index 7e1a5b6fa44..b48dc4f0639 100644
+--- a/gdbsupport/common-inferior.cc
++++ b/gdbsupport/common-inferior.cc
+@@ -39,6 +39,11 @@ construct_inferior_arguments (gdb::array_view<char * const> argv)
+ 	 Windows shells.  */
+       static const char special[] = "\"!&*|[]{}<>?`~^=;, \t\n";
+       static const char quote = '"';
++#elif __amigaos4__
++      /* This holds all the characters considered special to the
++	 Amiga shells. Currently copy of unix */
++      static const char special[] = "\"!#$&*()\\|[]{}<>?'`~^; \t\n";
++      static const char quote = '"';
+ #else
+       /* This holds all the characters considered special to the
+ 	 typical Unix shells.  We include `^' because the SunOS
+-- 
+2.43.0
+
+
+From a7bec223e006f56263de0f59f95cd22a5419155a Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 18 Aug 2024 14:27:45 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 30/61] 
+ Added amiga specif host defs/undefs, which aren't correctly detected by
+ configure
+
+---
+ gdbsupport/host-defs.h | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/gdbsupport/host-defs.h b/gdbsupport/host-defs.h
+index 4e0d71244a5..7998ad76ec0 100644
+--- a/gdbsupport/host-defs.h
++++ b/gdbsupport/host-defs.h
+@@ -50,6 +50,15 @@
+ # define DIRNAME_SEPARATOR ';'
  #endif
  
-diff --git a/readline/readline/terminal.c b/readline/readline/terminal.c
-index 05415dc42de1dca338d4047b168bc8b5aedd12ae..07a64af817298fecb6445c368d4a5ef00b15bd0d 100644
---- a/readline/readline/terminal.c
-+++ b/readline/readline/terminal.c
-@@ -99,18 +99,22 @@ int rl_change_environment = 1;
- static char *term_buffer = (char *)NULL;
- static char *term_string_buffer = (char *)NULL;
++#if defined(__amigaos4__) 
++# define CANT_FORK
++# undef HAVE_SIGPROCMASK
++# undef HAVE_SIGTIMEDWAIT
++# undef HAVE_POLL
++# undef HAVE_SOCKETPAIR
++# define DIRNAME_SEPARATOR ';'
++#endif
++
+ #ifndef DIRNAME_SEPARATOR
+ #define DIRNAME_SEPARATOR ':'
+ #endif
+-- 
+2.43.0
+
+
+From 9a06e6e41aa60e1770b200e0a465b38a0c041a59 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 18 Aug 2024 14:41:26 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 31/61] 
+ Undef Redefinition of timeval struct for amigaos4
+
+---
+ gnulib/import/sys_time.in.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/gnulib/import/sys_time.in.h b/gnulib/import/sys_time.in.h
+index 87db1a88745..93fce036d36 100644
+--- a/gnulib/import/sys_time.in.h
++++ b/gnulib/import/sys_time.in.h
+@@ -61,6 +61,7 @@
+ 
+ /* The definition of _GL_WARN_ON_USE is copied here.  */
+ 
++#ifndef __amigaos4__
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+@@ -85,6 +86,7 @@ struct timeval
+ #ifdef __cplusplus
+ }
+ #endif
++#endif
+ 
+ #if @GNULIB_GETTIMEOFDAY@
+ # if @REPLACE_GETTIMEOFDAY@
+-- 
+2.43.0
+
+
+From 4a24f24a27542fb77719090d25cebde000a38898 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 23 Aug 2024 18:29:24 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 32/61] 
+ Include host-desf so taht un def HAVE_POLL is corretly handled
+
+---
+ gdbsupport/common-defs.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gdbsupport/common-defs.h b/gdbsupport/common-defs.h
+index e4985332e3f..e92e54ef41a 100644
+--- a/gdbsupport/common-defs.h
++++ b/gdbsupport/common-defs.h
+@@ -21,6 +21,7 @@
+ #define COMMON_COMMON_DEFS_H
+ 
+ #include <gdbsupport/config.h>
++#include <gdbsupport/host-defs.h>
+ 
+ #undef PACKAGE_NAME
+ #undef PACKAGE
+-- 
+2.43.0
+
+
+From d95ede3d7682b09fa32d61f101ed750540478447 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 25 Aug 2024 20:13:13 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 33/61] 
+ Remove printf from hooks, which migth cause an deadlock
+
+---
+ gdb/ppc-amigaos-nat.c | 58 +++++++++++++++++++++----------------------
+ 1 file changed, 29 insertions(+), 29 deletions(-)
+
+diff --git a/gdb/ppc-amigaos-nat.c b/gdb/ppc-amigaos-nat.c
+index 1a9dcc349d1..c318e615c4e 100644
+--- a/gdb/ppc-amigaos-nat.c
++++ b/gdb/ppc-amigaos-nat.c
+@@ -59,7 +59,7 @@ struct amigaos_debug_hook_data
+     struct MsgPort		*debugger_port;
+ };
+ 
+-/* The type of Message sent by IDebug->AddDebugHook () */
++/* The type of Message sent by IExec->AddDebugHook () */
+ struct KernelDebugMessage
+ {
+   uint32 type;
+@@ -847,11 +847,11 @@ VOID amigaos_debug_suspend( struct Hook *amigaos_debug_hook )
+ {
+ 	struct Task *current = IExec->FindTask (NULL);
+ 
+-	printf ("[GDB] %s inferiorer %p started by kernel, suspending myself and installing debug hook: %p\n",__func__,current,amigaos_debug_hook);
++	IExec->DebugPrintF("[GDB] %s inferiorer %p started by kernel, suspending myself and installing debug hook: %p\n",__func__,current,amigaos_debug_hook);
+ 	
+ 	IExec->SuspendTask (current,0);
+ 
+-	printf ("[GDB] %s inferiorer %p started by gdb\n",__func__,current);
++	IExec->DebugPrintF("[GDB] %s inferiorer %p started by gdb\n",__func__,current);
+ }
+ 
+ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct KernelDebugMessage *dbgmsg )
+@@ -861,18 +861,18 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 	
+ 	if( (struct Task *)data->current_process != currentTask )
+ 	{
+-		printf ("[GDB] Task: %p ('%s'), task NOT under our observation\n",currentTask,currentTask->tc_Node.ln_Name);
++		IExec->DebugPrintF ("[GDB] Task: %p ('%s'), task NOT under our observation\n",currentTask,currentTask->tc_Node.ln_Name);
+ 
+ 		return 0;
+ 	}
+-	printf ("[GDB] Task: %p ('%s'), task IS under our observation\n",currentTask,currentTask->tc_Node.ln_Name);
++	IExec->DebugPrintF ("[GDB] Task: %p ('%s'), task IS under our observation\n",currentTask,currentTask->tc_Node.ln_Name);
+ 
+ 
+ 	switch( dbgmsg->type ) 
+ 	{
+ 		case DBHMT_EXCEPTION:
+ 		{
+-			printf ("[GDB] Task: %p ('%s'),Exception ooccured (DBHMT_EXCEPTION)\n",currentTask,currentTask->tc_Node.ln_Name);
++			IExec->DebugPrintF ("[GDB] Task: %p ('%s'),Exception ooccured (DBHMT_EXCEPTION)\n",currentTask,currentTask->tc_Node.ln_Name);
+ 
+ 			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);
+ 			message->flags	= 0;
+@@ -896,7 +896,7 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 		}
+ 		case DBHMT_REMTASK:
+ 		{
+-			printf ("[GDB] Task: %p ('%s'), (DBHMT_REMTASK), Task removed\n",currentTask,currentTask->tc_Node.ln_Name);
++			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_REMTASK), Task removed\n",currentTask,currentTask->tc_Node.ln_Name);
+ 
+ 			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);
+ 			message->flags	= DM_FLAGS_TASK_TERMINATED;
+@@ -908,7 +908,7 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 		}
+ 		case DBHMT_OPENLIB:
+ 		{
+-			printf ("[GDB] Task: %p ('%s'), (DBHMT_OPENLIB), Task opened library '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
++			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_OPENLIB), Task opened library '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
+ 
+ 			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);
+ 			message->flags		= DM_FLAGS_TASK_OPENLIB;
+@@ -921,7 +921,7 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 		}
+ 		case DBHMT_CLOSELIB:
+ 		{
+-			printf ("[GDB] Task: %p ('%s'), (DBHMT_CLOSELIB), Task closed library '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
++			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_CLOSELIB), Task closed library '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
+ 
+ 			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);	
+ 			message->flags		= DM_FLAGS_TASK_CLOSELIB;
+@@ -934,17 +934,17 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 		}
+ 		case DBHMT_SHAREDOBJECTOPEN:
+ 		{
+-			printf ("[GDB] Task: %p ('%s'), (DBHMT_SHAREDOBJECTOPEN), Task opened shared object '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
++			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_SHAREDOBJECTOPEN), Task opened shared object '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
+ 			break;
+ 		}
+ 		case DBHMT_SHAREDOBJECTCLOSE:
+ 		{
+-			printf ("[GDB] Task: %p ('%s'), (DBHMT_SHAREDOBJECTCLOSE), Task closed shared object '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
++			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_SHAREDOBJECTCLOSE), Task closed shared object '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
+ 			break;
+ 		}
+ 		default:
+ 		{
+-			printf ("[GDB] Task: %p ('%s'), (DBHMT_UNKNOWN), Task unknown message type %lu\n",currentTask,currentTask->tc_Node.ln_Name,dbgmsg->type);
++			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_UNKNOWN), Task unknown message type %lu\n",currentTask,currentTask->tc_Node.ln_Name,dbgmsg->type);
+ 		}
+ 	}
+ 
+@@ -954,67 +954,67 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ static int
+ trap_to_signal(struct ExceptionContext *context, uint32 flags)
+ {
+-	printf( "[GDB] trap_to_signal ( flags: 0x%lx )\n",flags );
++	IExec->DebugPrintF( "[GDB] trap_to_signal ( flags: 0x%lx )\n",flags );
+ 
+ 	if (!context || (flags & DM_FLAGS_TASK_TERMINATED)) {
+-		printf( "[GDB] Return GDB_SIGNAL_QUIT )\n" );
++		IExec->DebugPrintF( "[GDB] Return GDB_SIGNAL_QUIT )\n" );
+ 	
+ 		return GDB_SIGNAL_QUIT;
+ 	}
+ 
+-	printf( "[GDB] traptype: 0x%lx\n",context->Traptype );
++	IExec->DebugPrintF( "[GDB] traptype: 0x%lx\n",context->Traptype );
+ 
+ 	switch (context->Traptype)
+ 	{
+ 	case TRAP_MCE:
+ 	case TRAP_DSI:
+-		printf( "[GDB] Return ( GDB_SIGNAL_SEGV )\n" );
++		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_SEGV )\n" );
+ 		return GDB_SIGNAL_SEGV;
+ 	case TRAP_ISI:
+ 	case TRAP_ALIGN:
+-		printf( "[GDB] Return ( GDB_SIGNAL_BUS )\n" );
++		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_BUS )\n" );
+ 		return GDB_SIGNAL_BUS;
+ 	case TRAP_EXTERN:
+-		printf( "[GDB] Return ( GDB_SIGNAL_INT )\n" );
++		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_INT )\n" );
+ 		return GDB_SIGNAL_INT;
+ 	case TRAP_PROG: 
+ 		if (context->msr & EXC_FPE) {
+-			printf( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
++			IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
+ 			return GDB_SIGNAL_FPE;
+ 		}
+ 		else if (context->msr & EXC_ILLEGAL) {
+-			printf( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
++			IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
+ 			return GDB_SIGNAL_ILL;
+ 		}
+ 		else if (context->msr & EXC_PRIV) {
+-			printf( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
++			IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
+ 			return GDB_SIGNAL_ILL;
+ 		}
+ 		else {
+-			printf( "[GDB] Return ( GDB_SIGNAL_TRAP )\n" );
++			IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_TRAP )\n" );
+ 			return GDB_SIGNAL_TRAP;
+ 		}
+ 	case TRAP_FPU:
+-		printf( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
++		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
+ 		return GDB_SIGNAL_FPE;
+ 	case TRAP_DEC:
+-		printf( "[GDB] Return ( GDB_SIGNAL_ALRM )\n" );
++		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_ALRM )\n" );
+ 		return GDB_SIGNAL_ALRM;
+ 	case TRAP_RESERVEDA:
+ 	case TRAP_RESERVEDB:
+-		printf( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
++		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
+ 		return GDB_SIGNAL_ILL;
+ 	case TRAP_SYSCALL:
+-		printf( "[GDB] Return ( GDB_SIGNAL_CHLD )\n" );
++		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_CHLD )\n" );
+ 		return GDB_SIGNAL_CHLD;
+ 	case TRAP_TRACEI:
+-		printf( "[GDB] Return ( GDB_SIGNAL_TRAP )\n" );
++		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_TRAP )\n" );
+ 		return GDB_SIGNAL_TRAP;
+ 	case TRAP_FPA:
+-		printf( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
++		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
+ 		return GDB_SIGNAL_FPE;
+ 	default:
+-		printf( "[GDB] Return ( -1 )\n" );
++		IExec->DebugPrintF( "[GDB] Return ( -1 )\n" );
+ 		return -1;
+ 	}
+ }
+\ No newline at end of file
+-- 
+2.43.0
+
+
+From 13414a51ecfa607e822bac13aaca0363fe47372e Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 26 Aug 2024 15:20:13 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 34/61] 
+ Changed all printf to IExec->DebugPrintF
+
+---
+ gdb/ppc-amigaos-nat.c | 43 +++++++++++++++++++++----------------------
+ 1 file changed, 21 insertions(+), 22 deletions(-)
+
+diff --git a/gdb/ppc-amigaos-nat.c b/gdb/ppc-amigaos-nat.c
+index c318e615c4e..e76c9ead31d 100644
+--- a/gdb/ppc-amigaos-nat.c
++++ b/gdb/ppc-amigaos-nat.c
+@@ -59,7 +59,7 @@ struct amigaos_debug_hook_data
+     struct MsgPort		*debugger_port;
+ };
+ 
+-/* The type of Message sent by IExec->AddDebugHook () */
++/* The type of Message sent by IDebug->AddDebugHook () */
+ struct KernelDebugMessage
+ {
+   uint32 type;
+@@ -167,7 +167,7 @@ class ppc_amigaos_nat_target : public inf_child_target
+ 	{
+ 		struct Task *task = (struct Task *)(ptid == minus_one_ptid ? inferior_ptid.pid () : ptid.pid ());
+ 		
+-		printf ("[GDB] %s ( step: %d, gdb_signal: %d, Task: %p  )\n",__func__,step,signal,task);
++		IExec->DebugPrintF("[GDB] %s ( step: %d, gdb_signal: %d, Task: %p  )\n",__func__,step,signal,task);
+ 
+ 		IExec->RestartTask (task,0);
+ 	}
+@@ -207,7 +207,7 @@ class ppc_amigaos_nat_target : public inf_child_target
+ 	/*
+ 	bool info_proc (const char *args, enum info_proc_what what) override 
+ 	{
+-		printf ("[GDB] %s (false)\n",__func__);
++		IExec->DebugPrintF("[GDB] %s (false)\n",__func__);
+ 		return false;
+ 	}
+ 	*/
+@@ -411,7 +411,7 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 		if( ( signal & SIGBREAKF_CTRL_D ) == SIGBREAKF_CTRL_D )
+ 		{
+-			printf ("[GDB] %s received SIGBREAKF_CTRL_D\n",__func__);
++			IExec->DebugPrintF("[GDB] %s received SIGBREAKF_CTRL_D\n",__func__);
+ 
+ 			ourstatus->set_exited (0);
+ 
+@@ -420,7 +420,7 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 		if( ( signal & SIGBREAKF_CTRL_C ) == SIGBREAKF_CTRL_C )
+ 		{
+-			printf ("[GDB] %s received SIGBREAKF_CTRL_C\n",__func__);
++			IExec->DebugPrintF("[GDB] %s received SIGBREAKF_CTRL_C\n",__func__);
+ 
+ 			IExec->SuspendTask ((struct Task *)process,0);
+ 
+@@ -431,13 +431,13 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 		while (struct Message *message = IExec->GetMsg (amigaos_debug_hook_data.debugger_port) ) 		
+ 		{
+-			printf ("[GDB] %s received message: %p\n",__func__,message);
++			IExec->DebugPrintF("[GDB] %s received message: %p\n",__func__,message);
+ 
+ 			if( message->mn_Node.ln_Name != NULL && strcmp (message->mn_Node.ln_Name,"DeathMessage") == 0)
+ 			{
+ 				struct DeathMessage *deathMesage = (struct DeathMessage *)message;
+ 				
+-				printf ("[GDB] %s received SIGB_CHILD with dos return: %ld\n",__func__,deathMesage->dm_ReturnCode);
++				IExec->DebugPrintF("[GDB] %s received SIGB_CHILD with dos return: %ld\n",__func__,deathMesage->dm_ReturnCode);
+ 
+ 				ourstatus->set_exited (deathMesage->dm_ReturnCode);
+ 
+@@ -454,19 +454,19 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 					{
+ 						case DM_FLAGS_TASK_OPENLIB:
+ 						{
+-							printf ("[GDB] %s received task open library\n",__func__);
++							IExec->DebugPrintF("[GDB] %s received task open library\n",__func__);
+ 
+ 							break;
+ 						}
+ 						case DM_FLAGS_TASK_CLOSELIB:
+ 						{
+-							printf ("[GDB] %s received task close library\n",__func__);
++							IExec->DebugPrintF("[GDB] %s received task close library\n",__func__);
+ 
+ 							break;
+ 						}
+ 						default:
+ 						{
+-							printf ("[GDB] %s received unknown flags for signal -1 from callback %ld\n",__func__,debuggerMessage->flags);
++							IExec->DebugPrintF("[GDB] %s received unknown flags for signal -1 from callback %ld\n",__func__,debuggerMessage->flags);
+ 		
+ 							break;
+ 						}
+@@ -477,7 +477,7 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 				}
+ 				else
+ 				{
+-					printf ("[GDB] %s Inferior (%p) signaled : '%s'\n",__func__,process,gdb_signal_to_name ((enum gdb_signal)debuggerMessage->signal));
++					IExec->DebugPrintF("[GDB] %s Inferior (%p) signaled : '%s'\n",__func__,process,gdb_signal_to_name ((enum gdb_signal)debuggerMessage->signal));
+ 
+ 					switch (debuggerMessage->signal)
+ 					{
+@@ -512,7 +512,7 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 						}
+ 						default:
+ 						{
+-							printf ("[GDB] %s received unknown signal from callback %ld\n",__func__,debuggerMessage->signal);
++							IExec->DebugPrintF("[GDB] %s received unknown signal from callback %ld\n",__func__,debuggerMessage->signal);
+ 
+ 							break;
+ 						}
+@@ -537,7 +537,7 @@ ppc_amigaos_nat_target::fetch_registers (struct regcache *regcache, int regno)
+ 	ppc_gdbarch_tdep *tdep = gdbarch_tdep<ppc_gdbarch_tdep> (gdbarch);	
+ 	struct Task *task = (struct Task *)regcache->ptid().pid();
+ 
+-	printf ("[GDB] %s ( regcache: %p, regno: %d (%s), task: %p)\n",__func__,regcache,regno,gdbarch_register_name( gdbarch,regno ),task);
++	IExec->DebugPrintF("[GDB] %s ( regcache: %p, regno: %d (%s), task: %p)\n",__func__,regcache,regno,gdbarch_register_name( gdbarch,regno ),task);
+ 
+ 	struct ExceptionContext context;
+ 	IDebug->ReadTaskContext( task,&context,RTCF_INFO | RTCF_SPECIAL | RTCF_STATE | RTCF_GENERAL | RTCF_FPU | RTCF_VECTOR );
+@@ -597,9 +597,7 @@ ppc_amigaos_nat_target::store_registers (struct regcache *regcache, int regno)
+ enum target_xfer_status
+ ppc_amigaos_nat_target::xfer_partial (enum target_object object,const char *annex, gdb_byte *readbuf,const gdb_byte *writebuf,ULONGEST offset, ULONGEST len, ULONGEST *xfered_len)
+ {
+-	// IExec->DebugPrintF ( string_printf (_("[GDB] %s called for memory tranfser at address: 0x%s for %s bytes (readbuf: %p, writebuf: %p, annex: '%s', object: %d )\n"),__func__,phex (offset, sizeof (offset)),pulongest (len), readbuf, writebuf, annex, object).c_str());
+-
+-	printf ("[GDB] %s called for memory tranfser at address: 0x%016llx for %lld bytes (readbuf: %p, writebuf: %p, annex: '%s', object: %d )\n",__func__,offset,len,readbuf,writebuf,annex,object);
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s called for memory tranfser at address: 0x%s for %s bytes (readbuf: %p, writebuf: %p, annex: '%s', object: %d )\n"),__func__,phex (offset, sizeof (offset)),pulongest (len), readbuf, writebuf, annex, object).c_str());
+ 
+ 	switch (object)
+ 	{
+@@ -637,7 +635,7 @@ ppc_amigaos_nat_target::xfer_partial (enum target_object object,const char *anne
+ 
+ 			*xfered_len = len;
+ 
+-			printf ("[GDB] %s tansferfed %lld bytes \n",__func__,*xfered_len);
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s tansferfed %s bytes\n"),__func__,pulongest (*xfered_len)).c_str());
+ 
+ 			return TARGET_XFER_OK;			
+ 		}
+@@ -645,7 +643,7 @@ ppc_amigaos_nat_target::xfer_partial (enum target_object object,const char *anne
+ 
+ 		case TARGET_OBJECT_LIBRARIES:
+ 		{
+-				printf ("[GDB] %s tansferfed object library '%s' failed, aka not supported yet\n",__func__,annex);
++			IExec->DebugPrintF("[GDB] %s tansferfed object library '%s' failed, aka not supported yet\n",__func__,annex);
+ 
+ 			return TARGET_XFER_E_IO;			
+ 		}
+@@ -654,7 +652,7 @@ ppc_amigaos_nat_target::xfer_partial (enum target_object object,const char *anne
+ 		default:
+ 			if (beneath()) 
+ 			{
+-				printf ("[GDB] %s tansferfed delegated to beneath for target_object %d\n",__func__,object);
++				IExec->DebugPrintF("[GDB] %s tansferfed delegated to beneath for target_object %d\n",__func__,object);
+ 
+ 				return this->beneath ()->xfer_partial (object,annex,readbuf,writebuf,offset,len,xfered_len);
+ 			}
+@@ -704,7 +702,8 @@ ppc_amigaos_relocate_sections (const char *exec_file,BPTR exec_seglist)
+ 						
+ 					if( address )
+ 					{
+-						printf ("[GDB] On symfile_object relocated %d section '%s' from 0x%08lx to %p, size %ld, old offset: 0x%08llx\n",section->index,section->name,section->vma,address,section->size,osect->addr() );
++						IExec->DebugPrintF ( string_printf (_("[GDB] On symfile_object relocated %d section '%s' from 0x%08lx to %p, size %ld, old offset: 0x%s\n"),section->index,section->name,section->vma,address,section->size,phex ( osect->addr(), sizeof (osect->addr()))).c_str());
++						
+ 						offsets[ osect_idx ] = (CORE_ADDR)address - osect->addr();
+ 					}
+ 				}
+@@ -828,7 +827,7 @@ void ppc_amigaos_nat_target::create_inferior (const char *exec_file,const std::s
+ 
+ 	ppc_amigaos_relocate_sections (exec_file,exec_seglist);
+ 
+-	printf ("[GDB] %s inferior_ptid=0x%08x inf=%p thr=%p\n",__func__,inferior_ptid.pid(),inf,thr);
++	IExec->DebugPrintF("[GDB] %s inferior_ptid=0x%08x inf=%p thr=%p\n",__func__,inferior_ptid.pid(),inf,thr);
+ 
+ 	//  ML: Don't do it here, because we need to keep the exec_segliots until the task has finished
+ 	// IDOS->UnLoadSeg( exec_seglist );
+@@ -884,7 +883,7 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 		}
+ 		case DBHMT_ADDTASK:
+ 		{
+-			printf ("[GDB] Task: %p ('%s'), (DBHMT_ADDTASK), Task added\n",currentTask,currentTask->tc_Node.ln_Name);
++			IExec->DebugPrintF("[GDB] Task: %p ('%s'), (DBHMT_ADDTASK), Task added\n",currentTask,currentTask->tc_Node.ln_Name);
+ 
+ 			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);	
+ 			message->flags	= DM_FLAGS_TASK_ATTACHED;
+-- 
+2.43.0
+
+
+From 9509ee6026171af94bcd31ba2136e274ba62202b Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Tue, 27 Aug 2024 08:27:08 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 35/61] 
+ Changed Folders sepration on AUTO_LOAD... to ';' for AmigaOS
+
+---
+ gdb/auto-load.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/gdb/auto-load.c b/gdb/auto-load.c
+index 198bb073a1b..4a577f88219 100644
+--- a/gdb/auto-load.c
++++ b/gdb/auto-load.c
+@@ -43,6 +43,11 @@
+ #include "gdbsupport/pathstuff.h"
+ #include "cli/cli-style.h"
+ 
++#ifdef __amigaos4__
++#define AUTO_LOAD_DIR "$debugdir;$datadir/auto-load"
++#define AUTO_LOAD_SAFE_PATH AUTO_LOAD_DIR
++#endif
++
+ /* The section to look in for auto-loaded scripts (in file formats that
+    support sections).
+    Each entry in this section is a record that begins with a leading byte
+-- 
+2.43.0
+
+
+From e9292818bcbddb78729e5c503a3861349688ccfc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andrea=20Palmat=C3=A8?= <andrea@animasystems.com>
+Date: Sat, 17 Aug 2024 19:54:58 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 36/61] 
+ Specific OS4 changes
+
+---
+ .gitignore                   |  5 ++++-
+ readline/readline/bind.c     | 10 +++++++---
+ readline/readline/readline.c | 11 +++++++++++
+ readline/readline/rldefs.h   |  9 ++++++++-
+ readline/readline/text.c     |  6 +++++-
+ 5 files changed, 35 insertions(+), 6 deletions(-)
+
+diff --git a/.gitignore b/.gitignore
+index 20c25b90459..d1fafcda72d 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -78,4 +78,7 @@ stamp-*
+ /mpfr*
+ /mpc*
+ /gmp*
+-/isl*
+\ No newline at end of file
++/isl*
++
++.vscode
++.idea
+diff --git a/readline/readline/bind.c b/readline/readline/bind.c
+index 87596dcec95..3da2352b067 100644
+--- a/readline/readline/bind.c
++++ b/readline/readline/bind.c
+@@ -993,9 +993,13 @@ _rl_read_init_file (const char *filename, int include_level)
+   current_readline_init_file = filename;
+   current_readline_init_include_level = include_level;
+ 
+-  openname = tilde_expand (filename);
+-  buffer = _rl_read_file (openname, &file_size);
+-  xfree (openname);
++#ifndef __amigaos4__
++  openname = tilde_expand(filename);
++  buffer = _rl_read_file(openname, &file_size);
++  xfree(openname);
++#else
++  buffer = _rl_read_file((char *)filename, &file_size);
++#endif
+ 
+   RL_CHECK_SIGNALS ();
+   if (buffer == 0)
+diff --git a/readline/readline/readline.c b/readline/readline/readline.c
+index 0e33587f234..8601063b716 100644
+--- a/readline/readline/readline.c
++++ b/readline/readline/readline.c
+@@ -1336,6 +1336,17 @@ bind_arrow_keys_internal (Keymap map)
+   rl_bind_keyseq_if_unbound ("\033[0B", rl_backward_char);
+   rl_bind_keyseq_if_unbound ("\033[0C", rl_forward_char);
+   rl_bind_keyseq_if_unbound ("\033[0D", rl_get_next_history);
++#elif defined(__amigaos4__)
++    rl_bind_keyseq_if_unbound("\233A", rl_get_previous_history);
++    rl_bind_keyseq_if_unbound("\233B", rl_get_next_history);
++    rl_bind_keyseq_if_unbound("\233C", rl_forward_char);
++    rl_bind_keyseq_if_unbound("\233D", rl_backward_char);
++    rl_bind_keyseq_if_unbound("\23344~", (rl_command_func_t *)0x0); //rl_beg_of_line); disable for now
++    rl_bind_keyseq_if_unbound("\23345~", (rl_command_func_t *)0x0); //rl_end_of_line); disable for now
++    rl_bind_keyseq_if_unbound("\23341~", (rl_command_func_t *)0x0); //Next Page
++    rl_bind_keyseq_if_unbound("\23342~", (rl_command_func_t *)0x0); //Previous Page
++    rl_bind_keyseq_if_unbound("\177", rl_delete);
++    rl_bind_keyseq_if_unbound("\23340", rl_overwrite_mode);  
  #endif
  
- static int tcap_initialized;
+   rl_bind_keyseq_if_unbound ("\033[A", rl_get_previous_history);
+diff --git a/readline/readline/rldefs.h b/readline/readline/rldefs.h
+index dab1beba1d7..a367593d693 100644
+--- a/readline/readline/rldefs.h
++++ b/readline/readline/rldefs.h
+@@ -40,7 +40,7 @@
+ #  if defined (HAVE_TERMIO_H)
+ #    define TERMIO_TTY_DRIVER
+ #  else
+-#    if !defined (__MINGW32__)
++#    if !defined (__MINGW32__) && !defined(__amigaos4__)
+ #      define NEW_TTY_DRIVER
+ #    else
+ #      define NO_TTY_DRIVER
+@@ -48,6 +48,13 @@
+ #  endif
+ #endif
  
--#if !defined (__linux__) && !defined (NCURSES_VERSION)
-+/* Ignore this code if targeting AmigaOS4 with clib clib4, because
-+   the clib4 clib provided it own fnmatch implementation */
-+#if !(defined(__amigaos4__) && defined(__CLIB4__))
-+# if !defined (__linux__) && !defined (NCURSES_VERSION) 
- #  if defined (__EMX__) || defined (NEED_EXTERN_PC)
- extern 
--#  endif /* __EMX__ || NEED_EXTERN_PC */
-+#   endif /* __EMX__ || NEED_EXTERN_PC */
- char PC, *BC, *UP;
--#endif /* !__linux__ && !NCURSES_VERSION */
-+# endif /* !__linux__ && !NCURSES_VERSION */
-+#endif  /* not (AMIGAOS and CLIB4) $*/
- 
- /* Some strings to control terminal actions.  These are output by tputs (). */
- char *_rl_term_clreol;
- char *_rl_term_clrpag;
- char *_rl_term_clrscroll;
- char *_rl_term_cr;
++#ifdef __amigaos4__
++#undef DEFAULT_INPUTRC
++#undef SYS_INPUTRC
++#define DEFAULT_INPUTRC "PROGDIR:inputrc"
++#define SYS_INPUTRC "ENVARC:inputrc"
++#endif
++
+ /* Posix macro to check file in statbuf for directory-ness.
+    This requires that <sys/stat.h> be included before this test. */
+ #if defined (S_IFDIR) && !defined (S_ISDIR)
 diff --git a/readline/readline/text.c b/readline/readline/text.c
-index 2567dea268ae2412dda65d9c9fbd898e1ac11e86..b363745db6a73f5c790a7d53feb21675d907be9e 100644
+index 2567dea268a..b363745db6a 100644
 --- a/readline/readline/text.c
 +++ b/readline/readline/text.c
-@@ -68,13 +68,17 @@ static int _rl_char_search_callback PARAMS((_rl_callback_generic_arg *));
- #endif
- 
- /* The largest chunk of text that can be inserted in one call to
+@@ -71,7 +71,11 @@ static int _rl_char_search_callback PARAMS((_rl_callback_generic_arg *));
     rl_insert_text.  Text blocks larger than this are divided. */
  #define TEXT_COUNT_MAX	1024
  
@@ -4914,9 +12045,2989 @@ index 2567dea268ae2412dda65d9c9fbd898e1ac11e86..b363745db6a73f5c790a7d53feb21675
  
  /* **************************************************************** */
  /*								    */
- /*			Insert and Delete			    */
- /*								    */
- /* **************************************************************** */
+-- 
+2.43.0
+
+
+From d2ff20fac002508cc81afa59e1e0aa503a02cb16 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 30 Aug 2024 14:42:42 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 37/61] 
+ Added explict undef HAVE_SOCKETPAIR, beacuse include config-h overwrites it
+ from previous common-defs.h include
+
+---
+ gdb/defs.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/gdb/defs.h b/gdb/defs.h
+index 4771d02a92a..b73f1a823f8 100644
+--- a/gdb/defs.h
++++ b/gdb/defs.h
+@@ -34,6 +34,9 @@
+ #undef PACKAGE_TARNAME
+ 
+ #include <config.h>
++#if defined(__amigaos4__) 
++# undef HAVE_SOCKETPAIR
++#endif
+ #include "bfd.h"
+ 
+ #include <sys/types.h>
+-- 
+2.43.0
+
+
+From 46434fa70c30490125c60f45d7ff1bf95256c918 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 30 Aug 2024 16:14:42 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 38/61] 
+ With latest clib4/sigtimedwait we have the methdos needed
+
+---
+ gdbsupport/host-defs.h | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/gdbsupport/host-defs.h b/gdbsupport/host-defs.h
+index 7998ad76ec0..e7deafff6a7 100644
+--- a/gdbsupport/host-defs.h
++++ b/gdbsupport/host-defs.h
+@@ -52,8 +52,6 @@
+ 
+ #if defined(__amigaos4__) 
+ # define CANT_FORK
+-# undef HAVE_SIGPROCMASK
+-# undef HAVE_SIGTIMEDWAIT
+ # undef HAVE_POLL
+ # undef HAVE_SOCKETPAIR
+ # define DIRNAME_SEPARATOR ';'
+-- 
+2.43.0
+
+
+From 8ab8d2145da63725a6ae44cbdd4b17429d61a4cb Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 9 Sep 2024 16:00:18 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 39/61] 
+ Resolves #24 GDB: "info regs" bring "fetch_registers: unexpected register :
+ vscr"
+
+---
+ gdb/ppc-amigaos-nat.c | 32 +++++++++++++++++++++++++++++++-
+ gdb/ppc-amigaos-nat.h |  2 ++
+ 2 files changed, 33 insertions(+), 1 deletion(-)
+
+diff --git a/gdb/ppc-amigaos-nat.c b/gdb/ppc-amigaos-nat.c
+index e76c9ead31d..64c863c951a 100644
+--- a/gdb/ppc-amigaos-nat.c
++++ b/gdb/ppc-amigaos-nat.c
+@@ -24,6 +24,7 @@
+ #include "symtab.h"
+ #include "exec.h"
+ #include "inferior.h"
++#include "regset.h"
+ #include "regcache.h"
+ #include "inf-child.h"
+ #include "ppc-tdep.h"
+@@ -45,6 +46,21 @@
+ #include <dos/dosextens.h>
+ 
+ 
++struct regcache_map_entry ppc_amigaos_vrregmap[] =
++{
++	{ 1,	PPC_VSCR_REGNUM,	16 },
++	{ 32,	PPC_VR0_REGNUM,		16 },
++	{ 1,	PPC_VRSAVE_REGNUM,	 4 },
++	{ 0 }
++};
++
++const struct regset ppc_amigaos_vrregset = 
++{
++	ppc_amigaos_vrregmap,
++	regcache_supply_regset,
++	regcache_collect_regset
++};
++
+ // From clib4 , bucket list to clear up 
+ extern struct Library *ElfBase;
+ extern struct ElfIFace *IElf;
+@@ -557,6 +573,11 @@ ppc_amigaos_nat_target::fetch_registers (struct regcache *regcache, int regno)
+ 		regcache->raw_supply (tdep->ppc_ctr_regnum, (void *)&context.ctr);
+ 		regcache->raw_supply (tdep->ppc_xer_regnum, (void *)&context.xer);
+ 		regcache->raw_supply (tdep->ppc_fpscr_regnum, (void *)&context.fpscr);			
++
++		if (tdep->ppc_vr0_regnum != -1 && tdep->ppc_vrsave_regnum != -1)
++		{
++			ppc_amigaos_vrregset.supply_regset( &ppc_amigaos_vrregset,regcache,regno,(void *)&context.vscr,PPC_AMIGAOS_SIZEOF_VRREGSET );
++		}
+ 	}
+ 	else 
+ 	{
+@@ -564,9 +585,14 @@ ppc_amigaos_nat_target::fetch_registers (struct regcache *regcache, int regno)
+ 		{			
+ 			regcache->raw_supply (regno, (void*)&context.ip);
+ 		}
+-		else if (regno >= 0 && regno <= 31) {
++		else if (regno >= 0 && regno <= 31) 
++		{
+ 			regcache->raw_supply (regno, (void*)&context.gpr[regno]);
+ 		}
++		else if (altivec_register_p (gdbarch, regno))
++		{
++			ppc_amigaos_vrregset.supply_regset( &ppc_amigaos_vrregset,regcache,regno,(void *)&context.vscr,PPC_AMIGAOS_SIZEOF_VRREGSET );
++		}
+ 		else if (regno >= 32 && regno <= 64)
+ 			regcache->raw_supply (regno, (void*)&context.fpr[regno]);
+ 		else if (regno == tdep->ppc_ps_regnum)
+@@ -581,6 +607,10 @@ ppc_amigaos_nat_target::fetch_registers (struct regcache *regcache, int regno)
+ 			regcache->raw_supply (tdep->ppc_xer_regnum, (void *)&context.xer);
+ 		else if (regno == tdep->ppc_fpscr_regnum)
+ 			regcache->raw_supply (tdep->ppc_fpscr_regnum, (void *)&context.fpscr);		
++		else if (regno == tdep->ppc_vr0_regnum)
++			regcache->raw_supply (tdep->ppc_vr0_regnum, (void *)&context.vr );		
++		else if (regno == tdep->ppc_vrsave_regnum)
++			regcache->raw_supply (tdep->ppc_vrsave_regnum, (void *)&context.vrsave );		
+ 		else
+ 		{
+ 			internal_error (_("fetch_registers: unexpected register: '%s'"),gdbarch_register_name ( gdbarch,regno ));
+diff --git a/gdb/ppc-amigaos-nat.h b/gdb/ppc-amigaos-nat.h
+index 29914e7fb50..c7e4e3731c4 100644
+--- a/gdb/ppc-amigaos-nat.h
++++ b/gdb/ppc-amigaos-nat.h
+@@ -22,6 +22,8 @@
+ 
+ #include <exec/ports.h>
+ 
++#define PPC_AMIGAOS_SIZEOF_VRREGSET 532
++
+ // Chapter Interrupt Reference union from different ppc32 cpus
+ #define TRAP_RESET 			0x0100 /* System reset */
+ #define TRAP_MCE   			0x0200 /* Machine check */
+-- 
+2.43.0
+
+
+From 1880b2316705d155a8bf26bea96f3952e29e7e4e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andrea=20Palmat=C3=A8?= <info@papersoft.it>
+Date: Sat, 14 Sep 2024 10:50:42 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 40/61] 
+ Small fix to make clib4 works with latest changes
+
+---
+ readline/readline/input.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/readline/readline/input.c b/readline/readline/input.c
+index 61b0fde3c87..58bbd8df376 100644
+--- a/readline/readline/input.c
++++ b/readline/readline/input.c
+@@ -561,7 +561,11 @@ rl_getc (FILE *stream)
+       /* If zero characters are returned, then the file that we are
+ 	 reading from is empty!  Return EOF in that case. */
+       if (result == 0)
+-	return (EOF);
++#ifndef __amigaos4__
++        return (EOF);
++#else
++        continue;
++#endif
+ 
+ #if defined (__BEOS__)
+       if (errno == EINTR)
+-- 
+2.43.0
+
+
+From 15fbefab07598fdc1124cf0a38e7d4ba293e904b Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Wed, 18 Sep 2024 14:51:53 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 41/61] 
+ #26 Fixed stuff in path handling for AmigaOS specific habits
+
+---
+ gdbsupport/pathstuff.cc | 9 +++++++++
+ include/filenames.h     | 2 +-
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/gdbsupport/pathstuff.cc b/gdbsupport/pathstuff.cc
+index 390f10b1b5e..6fd07a59070 100644
+--- a/gdbsupport/pathstuff.cc
++++ b/gdbsupport/pathstuff.cc
+@@ -232,6 +232,8 @@ get_standard_cache_dir ()
+ {
+ #ifdef __APPLE__
+ #define HOME_CACHE_DIR "Library/Caches"
++#elif __amigaos4__
++#define HOME_CACHE_DIR "cache"
+ #else
+ #define HOME_CACHE_DIR ".cache"
+ #endif
+@@ -264,7 +266,14 @@ get_standard_cache_dir ()
+     }
+ #endif
+ 
++#ifdef __amigaos4__
++  // Its always PROGDIR: on AmigaOS
++  /* Make sure the path is absolute and tilde-expanded.  */
++  std::string abs = gdb_abspath ("PROGDIR:");
++  return path_join (abs.c_str (), HOME_CACHE_DIR, "gdb");
++#else
+   return {};
++#endif
+ }
+ 
+ /* See gdbsupport/pathstuff.h.  */
+diff --git a/include/filenames.h b/include/filenames.h
+index 3ee947df950..3a12e2d025d 100644
+--- a/include/filenames.h
++++ b/include/filenames.h
+@@ -83,7 +83,7 @@ extern "C" {
+ #define IS_DOS_ABSOLUTE_PATH(f) IS_ABSOLUTE_PATH_1 (1, f)
+ #define HAS_DOS_DRIVE_SPEC(f) HAS_DRIVE_SPEC_1 (1, f)
+ 
+-#define IS_AMIGOS_DIR_SEPARATOR(c) IS_DIR_SEPARATOR_1 (0, c)
++#define IS_AMIGOS_DIR_SEPARATOR(c) ( ((c) == '/') || ((c) == ':') )
+ #define IS_AMIGOS_ABSOLUTE_PATH(f) HAS_AMIGOS_DRIVE_SPEC(f)
+ #define HAS_AMIGOS_DRIVE_SPEC(f) (index (&(f)[0], ':') != NULL ) 
+ 
+-- 
+2.43.0
+
+
+From 83081a8d0e9795d5cb0f12db3875645e82c7c5b3 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Wed, 18 Sep 2024 15:53:25 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 42/61] 
+ Added additional some AmigaOS specifc paths
+
+---
+ gdbsupport/pathstuff.cc    | 10 +++++++++-
+ libiberty/make-temp-file.c |  2 ++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/gdbsupport/pathstuff.cc b/gdbsupport/pathstuff.cc
+index 6fd07a59070..4a8f4719324 100644
+--- a/gdbsupport/pathstuff.cc
++++ b/gdbsupport/pathstuff.cc
+@@ -291,7 +291,8 @@ get_standard_temp_dir ()
+     return tmp;
+ 
+   error (_("Couldn't find temp dir path, both TMP and TEMP are unset."));
+-
++#elif __amigaos4__
++  return "T:";
+ #else
+   const char *tmp = getenv ("TMPDIR");
+   if (tmp != nullptr)
+@@ -330,7 +331,14 @@ get_standard_config_dir ()
+       return path_join (abs.c_str (), HOME_CONFIG_DIR, "gdb");
+     }
+ 
++#ifdef __amigaos4__
++  // Its always ENVARC: on AmigaOS
++  /* Make sure the path is absolute and tilde-expanded.  */
++  std::string abs = gdb_abspath ("ENVARC:");
++  return path_join (abs.c_str (), HOME_CONFIG_DIR, "gdb");
++#else
+   return {};
++#endif
+ }
+ 
+ /* See pathstuff.h. */
+diff --git a/libiberty/make-temp-file.c b/libiberty/make-temp-file.c
+index fae743f3985..5f66abacc55 100644
+--- a/libiberty/make-temp-file.c
++++ b/libiberty/make-temp-file.c
+@@ -156,6 +156,8 @@ choose_tmpdir (void)
+       tmpdir[len] = DIR_SEPARATOR;
+       tmpdir[len+1] = '\0';
+       memoized_tmpdir = tmpdir;
++#elif __amigaos4__
++    memoized_tmpdir = xstrdup ("T:");
+ #else /* defined(_WIN32) && !defined(__CYGWIN__) */
+       DWORD len;
+ 
+-- 
+2.43.0
+
+
+From 9b65ec89421bd509e1db69f6b5188c8038eefec7 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Thu, 19 Sep 2024 17:17:57 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 43/61] 
+ #31 Added kill implementation in target
+
+---
+ gdb/ppc-amigaos-nat.c | 26 ++++++++++++++++++++------
+ 1 file changed, 20 insertions(+), 6 deletions(-)
+
+diff --git a/gdb/ppc-amigaos-nat.c b/gdb/ppc-amigaos-nat.c
+index 64c863c951a..ccbffa4a49e 100644
+--- a/gdb/ppc-amigaos-nat.c
++++ b/gdb/ppc-amigaos-nat.c
+@@ -188,12 +188,29 @@ class ppc_amigaos_nat_target : public inf_child_target
+ 		IExec->RestartTask (task,0);
+ 	}
+ 
+-	/*
+ 	void kill () override
+ 	{
+-		printf( "[GDB] %s ()\n",__func__ );
++		struct inferior *inf = current_inferior ();
++
++		if (inferior_ptid == null_ptid)
++			return;
++
++		gdb_assert (inf != NULL);
++
++		struct Task *task = (struct Task *)inf->pid;
++
++		IExec->DebugPrintF( "[GDB] %s ( task: %p )\n",__func__,task );
++
++		if( task ) 
++		{
++			/* Clear the debug hook (necessary to avoid the shell reusing it) */ 
++			IDebug->AddDebugHook ( task,NULL );
++
++			IExec->DeleteTask ( task );		
++		}
++
++		target_mourn_inferior(inferior_ptid);		
+ 	}
+-	*/
+ 	
+ 	/*
+ 	std::string pid_to_str (ptid_t ptid) override
+@@ -359,9 +376,6 @@ ppc_amigaos_nat_target::ppc_amigaos_nat_target ()
+ 
+ ppc_amigaos_nat_target::~ppc_amigaos_nat_target ()
+ {
+-	/* Clear the debug hook (necessary to avoid the shell reusing it) */ 
+-	IDebug->AddDebugHook ((struct Task *)amigaos_debug_hook_data.current_process,NULL );
+-
+ 	/* Free pending messages and port */
+ 	while (struct debugger_message *message = (struct debugger_message *)IExec->GetMsg (amigaos_debug_hook_data.debugger_port))
+ 		free_message (message);
+-- 
+2.43.0
+
+
+From 70995d86d4fb5c1bf671ea6c21bd0346090f4f2e Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 22 Sep 2024 13:08:13 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 44/61] 
+ #27 Reworked detection of killed inferiors
+
+---
+ gdb/ppc-amigaos-nat.c | 208 +++++++++++++++++++++++++++---------------
+ gdb/ppc-amigaos-nat.h |  12 ++-
+ 2 files changed, 140 insertions(+), 80 deletions(-)
+
+diff --git a/gdb/ppc-amigaos-nat.c b/gdb/ppc-amigaos-nat.c
+index ccbffa4a49e..95c3ddeae29 100644
+--- a/gdb/ppc-amigaos-nat.c
++++ b/gdb/ppc-amigaos-nat.c
+@@ -87,6 +87,7 @@ struct KernelDebugMessage
+ };
+ 
+ static VOID amigaos_debug_suspend ( struct Hook *amigaos_debug_hook );
++static VOID amigaos_debug_kill ( int32 return_code,struct debugger_message *dmsg );
+ static ULONG amigaos_debug_callback (struct Hook *, struct Task *, struct KernelDebugMessage *);
+ static int trap_to_signal(struct ExceptionContext *context, uint32 flags);
+ void ppc_amigaos_relocate_sections (const char *exec_file,BPTR exec_seglist);
+@@ -206,6 +207,7 @@ class ppc_amigaos_nat_target : public inf_child_target
+ 			/* Clear the debug hook (necessary to avoid the shell reusing it) */ 
+ 			IDebug->AddDebugHook ( task,NULL );
+ 
++			// ML: According to the dos Autodoc DeleteTask/RemTask shouldn't be used on Process, but no other API avaiblle
+ 			IExec->DeleteTask ( task );		
+ 		}
+ 
+@@ -437,6 +439,8 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 	while( 1 )
+ 	{
++		IExec->DebugPrintF("[GDB] %s Entering wait loop\n",__func__);
++
+ 		uint32 signal = IExec->Wait (SIGBREAKF_CTRL_D|SIGBREAKF_CTRL_C|1<<amigaos_debug_hook_data.debugger_port->mp_SigBit);
+ 
+ 		if( ( signal & SIGBREAKF_CTRL_D ) == SIGBREAKF_CTRL_D )
+@@ -445,6 +449,8 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 			ourstatus->set_exited (0);
+ 
++			IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
++
+ 			return ptid;
+ 		}
+ 
+@@ -456,106 +462,134 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 			ourstatus->set_stopped (GDB_SIGNAL_TRAP);
+ 
++			IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
++
+ 			return ptid;
+ 		}
+ 
+ 		while (struct Message *message = IExec->GetMsg (amigaos_debug_hook_data.debugger_port) ) 		
+ 		{
+-			IExec->DebugPrintF("[GDB] %s received message: %p\n",__func__,message);
++			IExec->DebugPrintF("[GDB] %s received message: %p\n",__func__,message );
+ 
+-			if( message->mn_Node.ln_Name != NULL && strcmp (message->mn_Node.ln_Name,"DeathMessage") == 0)
+-			{
+-				struct DeathMessage *deathMesage = (struct DeathMessage *)message;
+-				
+-				IExec->DebugPrintF("[GDB] %s received SIGB_CHILD with dos return: %ld\n",__func__,deathMesage->dm_ReturnCode);
++			struct debugger_message *debuggerMessage = (struct debugger_message *)message;
+ 
+-				ourstatus->set_exited (deathMesage->dm_ReturnCode);
++			IExec->DebugPrintF("[GDB] %s received debug message for task: %p\n",__func__,debuggerMessage->process );
+ 
+-				IExec->FreeVec (deathMesage);
+-
+-				return ptid;
+-			}
+-			else 
++			if( debuggerMessage->signal == -1 )
+ 			{
+-				struct debugger_message *debuggerMessage = (struct debugger_message *)message;
+-				if( debuggerMessage->signal == -1 )
++				switch( debuggerMessage->flags )
+ 				{
+-					switch( debuggerMessage->flags )
++					case DM_FLAGS_TASK_OPENLIB:
++					{
++						IExec->DebugPrintF("[GDB] %s received task open library\n",__func__);
++
++						break;
++					}
++					case DM_FLAGS_TASK_CLOSELIB:
++					{
++						IExec->DebugPrintF("[GDB] %s received task close library\n",__func__);
++
++						break;
++					}
++					case DM_FLAGS_TASK_TERMINATED:
+ 					{
+-						case DM_FLAGS_TASK_OPENLIB:
++						IExec->DebugPrintF("[GDB] %s received task terminated\n",__func__);
++
++						if( process == debuggerMessage->process) 
+ 						{
+-							IExec->DebugPrintF("[GDB] %s received task open library\n",__func__);
++							ourstatus->set_exited (0);
+ 
+-							break;
++							kill();
+ 						}
+-						case DM_FLAGS_TASK_CLOSELIB:
+-						{
+-							IExec->DebugPrintF("[GDB] %s received task close library\n",__func__);
+ 
+-							break;
++						break;
++					}
++					case DM_FLAGS_TASK_FINAL:
++					{
++						IExec->DebugPrintF("[GDB] %s received SIGB_CHILD of Process %p with dos return: %ld\n",__func__,debuggerMessage->process,debuggerMessage->ReturnCode);
++
++						if( debuggerMessage->process == process ) {
++							ourstatus->set_exited (debuggerMessage->ReturnCode);
++
++							kill();
++
++							free_message (debuggerMessage);
++
++							IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
++
++							return ptid;
+ 						}
+-						default:
++						else
+ 						{
+-							IExec->DebugPrintF("[GDB] %s received unknown flags for signal -1 from callback %ld\n",__func__,debuggerMessage->flags);
+-		
+-							break;
++							IExec->DebugPrintF("[GDB] Process %p already killed\n",__func__,__LINE__,debuggerMessage->process );
+ 						}
++
++						break;
++					}
++					default:
++					{
++						IExec->DebugPrintF("[GDB] %s received unknown flags for signal -1 from callback %ld\n",__func__,debuggerMessage->flags);
++	
++						break;
+ 					}
++				}
+ 
++				free_message (debuggerMessage);
++			}
++			else
++			{
++				IExec->DebugPrintF("[GDB] %s Inferior (%p) signaled : '%s'\n",__func__,process,gdb_signal_to_name ((enum gdb_signal)debuggerMessage->signal));
+ 
+-					free_message (debuggerMessage);
+-				}
+-				else
++				switch (debuggerMessage->signal)
+ 				{
+-					IExec->DebugPrintF("[GDB] %s Inferior (%p) signaled : '%s'\n",__func__,process,gdb_signal_to_name ((enum gdb_signal)debuggerMessage->signal));
+-
+-					switch (debuggerMessage->signal)
++					case GDB_SIGNAL_CHLD:
+ 					{
+-						case GDB_SIGNAL_CHLD:
+-						{
+-							ourstatus->set_signalled (GDB_SIGNAL_0);
+-
+-							break;
+-						}
+-						case GDB_SIGNAL_QUIT:
+-						{
+-							ourstatus->set_signalled (GDB_SIGNAL_QUIT);
++						ourstatus->set_signalled (GDB_SIGNAL_0);
+ 
+-							break;
+-						}
+-						case GDB_SIGNAL_TRAP:
+-						{
+-							ourstatus->set_stopped (GDB_SIGNAL_TRAP);
++						break;
++					}
++					case GDB_SIGNAL_QUIT:
++					{
++						ourstatus->set_signalled (GDB_SIGNAL_QUIT);
+ 
+-							break;
+-						}
+-						case GDB_SIGNAL_SEGV:
+-						case GDB_SIGNAL_BUS:
+-						case GDB_SIGNAL_INT:
+-						case GDB_SIGNAL_FPE:
+-						case GDB_SIGNAL_ILL:
+-						case GDB_SIGNAL_ALRM:					
+-						{					
+-							ourstatus->set_stopped (GDB_SIGNAL_0);
+-
+-							break;
+-						}
+-						default:
+-						{
+-							IExec->DebugPrintF("[GDB] %s received unknown signal from callback %ld\n",__func__,debuggerMessage->signal);
++						break;
++					}
++					case GDB_SIGNAL_TRAP:
++					{
++						ourstatus->set_stopped (GDB_SIGNAL_TRAP);
+ 
+-							break;
+-						}
++						break;
+ 					}
++					case GDB_SIGNAL_SEGV:
++					case GDB_SIGNAL_BUS:
++					case GDB_SIGNAL_INT:
++					case GDB_SIGNAL_FPE:
++					case GDB_SIGNAL_ILL:
++					case GDB_SIGNAL_ALRM:					
++					{					
++						ourstatus->set_stopped (GDB_SIGNAL_0);
++
++						break;
++					}
++					default:
++					{
++						IExec->DebugPrintF("[GDB] %s received unknown signal from callback %ld\n",__func__,debuggerMessage->signal);
+ 
+-					free_message (debuggerMessage);
+-					
+-					return ptid;
++						break;
++					}
+ 				}
+-			}
++
++				free_message (debuggerMessage);
++				
++				IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
++
++				return ptid;
++			}		
+ 		}
+ 	}
+ 
++	IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid_t::make_minus_one () );
++
+ 	return ptid_t::make_minus_one ();
+ }
+ 
+@@ -812,23 +846,24 @@ void ppc_amigaos_nat_target::create_inferior (const char *exec_file,const std::s
+ 		IDOS->UnLock( exec_lock );
+ 	}
+ 
+-	struct DeathMessage *dmsg = (struct DeathMessage *)IExec->AllocVecTags( sizeof( struct DeathMessage ),AVT_Type, MEMF_SHARED, TAG_DONE );
++	struct debugger_message *dmsg = alloc_message( NULL );
+ 	if( dmsg == NULL )
+ 	{
+ 		error ("Can't allocate memory for death message\n");
+ 	}
++	dmsg->msg.mn_Node.ln_Name	= (char*)"DeathMessage";
++	dmsg->msg.mn_ReplyPort		= amigaos_debug_hook_data.debugger_port;
++	dmsg->flags					= DM_FLAGS_TASK_FINAL;
++	dmsg->signal				= -1; 	
+ 
+-	dmsg->dm_Msg.mn_ReplyPort = amigaos_debug_hook_data.debugger_port;
+-	dmsg->dm_Msg.mn_Length = sizeof( struct DeathMessage );
+-	dmsg->dm_Msg.mn_Node.ln_Name = (char*)"DeathMessage";
+-
+-	amigaos_debug_hook_data.current_process = IDOS->CreateNewProcTags(
++	dmsg->process = amigaos_debug_hook_data.current_process = IDOS->CreateNewProcTags(
+ 			NP_Seglist,										exec_seglist,
+ 			NP_FreeSeglist,									FALSE,
+ 			NP_EntryCode,									amigaos_debug_suspend,
+ 			NP_EntryData,									amigaos_debug_hook,
+ 			NP_Child,										TRUE,
+-			NP_NotifyOnDeathMessage,						dmsg, // Signal parent with with prepared reply msg
++			NP_FinalCode,									amigaos_debug_kill,
++			NP_FinalData,									dmsg,
+ 			NP_Name,										lbasename( exec_file ),
+ 			NP_CommandName,									lbasename( exec_file ),
+ 			NP_Cli,											TRUE,
+@@ -843,6 +878,8 @@ void ppc_amigaos_nat_target::create_inferior (const char *exec_file,const std::s
+ 			TAG_DONE
+ 		);
+ 
++	IExec->DebugPrintF ( "[GDB] Process %p has debug message %p\n",amigaos_debug_hook_data.current_process,dmsg );
++
+ 	if (! amigaos_debug_hook_data.current_process)
+ 	{
+ 		error ("Can't create AmigaOS DOS process\n");
+@@ -897,6 +934,17 @@ VOID amigaos_debug_suspend( struct Hook *amigaos_debug_hook )
+ 	IExec->DebugPrintF("[GDB] %s inferiorer %p started by gdb\n",__func__,current);
+ }
+ 
++VOID amigaos_debug_kill( int32 return_code,struct debugger_message *dmsg ) 
++{
++	struct Task *current = IExec->FindTask (NULL);
++
++	dmsg->ReturnCode = return_code;
++
++	IExec->DebugPrintF("[GDB] %s inferiorer %p killed by kernel, sending death message: %p\n",__func__,current,dmsg);
++
++	IExec->PutMsg( dmsg->msg.mn_ReplyPort,(struct Message *)dmsg );	
++}
++
+ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct KernelDebugMessage *dbgmsg )
+ {
+ 	class ppc_amigaos_nat_target *ppc_amigaos_nat_target = (class ppc_amigaos_nat_target *)hook->h_Data;
+@@ -921,6 +969,8 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 			message->flags	= 0;
+ 			message->signal	= trap_to_signal( dbgmsg->message.context,message->flags );
+ 			
++			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
++
+ 			IExec->PutMsg (data->debugger_port,(struct Message *)message);
+ 
+ 			return 1; // Suspend execution
+@@ -933,6 +983,8 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 			message->flags	= DM_FLAGS_TASK_ATTACHED;
+ 			message->signal	= -1;
+ 			
++			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
++
+ 			IExec->PutMsg (data->debugger_port,(struct Message *)message);
+ 
+ 			break;
+@@ -945,6 +997,8 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 			message->flags	= DM_FLAGS_TASK_TERMINATED;
+ 			message->signal	= -1;
+ 			
++			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
++
+ 			IExec->PutMsg (data->debugger_port,(struct Message *)message);
+ 			
+ 			break;
+@@ -958,6 +1012,8 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 			message->signal		= -1;
+ 			message->library	= dbgmsg->message.library;
+ 			
++			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
++
+ 			IExec->PutMsg (data->debugger_port,(struct Message *)message);
+ 
+ 			break;
+@@ -971,6 +1027,8 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 			message->signal		= -1;
+ 			message->library	= dbgmsg->message.library;
+ 
++			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
++
+ 			IExec->PutMsg (data->debugger_port,(struct Message *)message);
+ 
+ 			break;
+diff --git a/gdb/ppc-amigaos-nat.h b/gdb/ppc-amigaos-nat.h
+index c7e4e3731c4..4aadbbca13f 100644
+--- a/gdb/ppc-amigaos-nat.h
++++ b/gdb/ppc-amigaos-nat.h
+@@ -66,13 +66,15 @@ struct debugger_message
+ 	uint32 flags;
+ 	uint32 signal;
+ 	struct Library *library;
++	int32 ReturnCode;
+ };
+ 
+ /* Possible debuger_message flags */
+-#define    DM_FLAGS_TASK_TERMINATED            0x00000001
+-#define    DM_FLAGS_TASK_ATTACHED              0x00000002
+-#define    DM_FLAGS_TASK_INTERRUPTED           0x00000004
+-#define	   DM_FLAGS_TASK_OPENLIB               0x00000008
+-#define	   DM_FLAGS_TASK_CLOSELIB              0x00000010
++#define    DM_FLAGS_TASK_TERMINATED				0x00000001
++#define    DM_FLAGS_TASK_ATTACHED				0x00000002
++#define    DM_FLAGS_TASK_INTERRUPTED			0x00000004
++#define	   DM_FLAGS_TASK_OPENLIB				0x00000008
++#define	   DM_FLAGS_TASK_CLOSELIB				0x00000010
++#define    DM_FLAGS_TASK_FINAL					0x10000000
+ 
+ #endif /* PPC_AMIGAOS_NAT_H */
+-- 
+2.43.0
+
+
+From f9a9753cd5f8a123c5a949546852ba07104c00f3 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 23 Sep 2024 09:48:53 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 45/61] 
+ #33 Unloading of seglist implemented
+
+---
+ gdb/ppc-amigaos-nat.c | 37 +++++++++++++++++++------------------
+ gdb/ppc-amigaos-nat.h |  1 +
+ 2 files changed, 20 insertions(+), 18 deletions(-)
+
+diff --git a/gdb/ppc-amigaos-nat.c b/gdb/ppc-amigaos-nat.c
+index 95c3ddeae29..576cc0ee91d 100644
+--- a/gdb/ppc-amigaos-nat.c
++++ b/gdb/ppc-amigaos-nat.c
+@@ -178,7 +178,8 @@ class ppc_amigaos_nat_target : public inf_child_target
+ 	}
+ 	*/
+ 	
+-	// TODO: void prepare_to_store (regcache *regs) override;
++	// TODO: ? void prepare_to_store (regcache *regs) override;
++	// TODO: ? int async_wait_fd () override
+ 	
+ 	void resume (ptid_t ptid,int step,enum gdb_signal signal) override
+ 	{
+@@ -513,6 +514,8 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 							kill();
+ 
++							IDOS->UnLoadSeg( (BPTR)debuggerMessage->seglist );
++
+ 							free_message (debuggerMessage);
+ 
+ 							IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
+@@ -831,8 +834,19 @@ void ppc_amigaos_nat_target::create_inferior (const char *exec_file,const std::s
+ 	    exec_file = get_exec_file (1);
+ 	}
+ 
+-	BPTR exec_seglist = IDOS->LoadSeg( exec_file );
+-	if( ! exec_seglist )
++	struct debugger_message *dmsg = alloc_message( NULL );
++	if( dmsg == NULL )
++	{
++		error ("Can't allocate memory for death message\n");
++	}
++
++	dmsg->msg.mn_Node.ln_Name	= (char*)"DeathMessage";
++	dmsg->msg.mn_ReplyPort		= amigaos_debug_hook_data.debugger_port;
++	dmsg->flags					= DM_FLAGS_TASK_FINAL;
++	dmsg->signal				= -1; 	
++
++	dmsg->seglist = (void*)IDOS->LoadSeg( exec_file );
++	if( ! dmsg->seglist )
+ 	{
+ 		error ("'%s': not an executable file\n",exec_file );
+ 	}
+@@ -846,18 +860,8 @@ void ppc_amigaos_nat_target::create_inferior (const char *exec_file,const std::s
+ 		IDOS->UnLock( exec_lock );
+ 	}
+ 
+-	struct debugger_message *dmsg = alloc_message( NULL );
+-	if( dmsg == NULL )
+-	{
+-		error ("Can't allocate memory for death message\n");
+-	}
+-	dmsg->msg.mn_Node.ln_Name	= (char*)"DeathMessage";
+-	dmsg->msg.mn_ReplyPort		= amigaos_debug_hook_data.debugger_port;
+-	dmsg->flags					= DM_FLAGS_TASK_FINAL;
+-	dmsg->signal				= -1; 	
+-
+ 	dmsg->process = amigaos_debug_hook_data.current_process = IDOS->CreateNewProcTags(
+-			NP_Seglist,										exec_seglist,
++			NP_Seglist,										dmsg->seglist,
+ 			NP_FreeSeglist,									FALSE,
+ 			NP_EntryCode,									amigaos_debug_suspend,
+ 			NP_EntryData,									amigaos_debug_hook,
+@@ -906,12 +910,9 @@ void ppc_amigaos_nat_target::create_inferior (const char *exec_file,const std::s
+ 	clear_proceed_status (0);
+ 	init_wait_for_inferior ();
+ 
+-	ppc_amigaos_relocate_sections (exec_file,exec_seglist);
++	ppc_amigaos_relocate_sections (exec_file,(BPTR)dmsg->seglist);
+ 
+ 	IExec->DebugPrintF("[GDB] %s inferior_ptid=0x%08x inf=%p thr=%p\n",__func__,inferior_ptid.pid(),inf,thr);
+-
+-	//  ML: Don't do it here, because we need to keep the exec_segliots until the task has finished
+-	// IDOS->UnLoadSeg( exec_seglist );
+ }
+ 
+ static ppc_amigaos_nat_target the_ppc_amigaos_nat_target;
+diff --git a/gdb/ppc-amigaos-nat.h b/gdb/ppc-amigaos-nat.h
+index 4aadbbca13f..e0796f44cf4 100644
+--- a/gdb/ppc-amigaos-nat.h
++++ b/gdb/ppc-amigaos-nat.h
+@@ -66,6 +66,7 @@ struct debugger_message
+ 	uint32 flags;
+ 	uint32 signal;
+ 	struct Library *library;
++	void* seglist;
+ 	int32 ReturnCode;
+ };
+ 
+-- 
+2.43.0
+
+
+From 3014c89f7486a5586e6d700b609ef34d80de723c Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 6 Oct 2024 12:06:22 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 46/61] 
+ #12 Added missing information about Amiga baserel relocation
+
+---
+ gas/config/tc-ppc.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/gas/config/tc-ppc.c b/gas/config/tc-ppc.c
+index 745733b24f5..e0b2efad031 100644
+--- a/gas/config/tc-ppc.c
++++ b/gas/config/tc-ppc.c
+@@ -3119,6 +3119,9 @@ fixup_size (bfd_reloc_code_real_type reloc, bool *pc_relative)
+     case BFD_RELOC_PPC_TPREL16_HA:
+     case BFD_RELOC_PPC_TPREL16_HI:
+     case BFD_RELOC_PPC_TPREL16_LO:
++	case R_PPC_AMIGAOS_BREL_LO:
++	case R_PPC_AMIGAOS_BREL_HI:
++	case R_PPC_AMIGAOS_BREL_HA:
+       size = 2;
+       break;
+ 
+@@ -3183,6 +3186,7 @@ fixup_size (bfd_reloc_code_real_type reloc, bool *pc_relative)
+     case BFD_RELOC_PPC_VLE_SDAREL_LO16D:
+     case BFD_RELOC_PPC64_TLS_PCREL:
+     case BFD_RELOC_RVA:
++	case R_PPC_AMIGAOS_BREL:
+       size = 4;
+       break;
+ 
+@@ -7678,6 +7682,10 @@ md_apply_fix (fixS *fixP, valueT *valP, segT seg)
+ 	case BFD_RELOC_16:
+ 	case BFD_RELOC_16_PCREL:
+ 	case BFD_RELOC_8:
++	case R_PPC_AMIGAOS_BREL:
++	case R_PPC_AMIGAOS_BREL_LO:
++	case R_PPC_AMIGAOS_BREL_HI:
++	case R_PPC_AMIGAOS_BREL_HA:
+ 	  break;
+ 
+ 	default:
+-- 
+2.43.0
+
+
+From 8773ac2a09022717fdbb9bdcf0e76020d7e795bd Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 7 Oct 2024 10:44:31 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 47/61] 
+ #12 Fixed names of of switch casses
+
+---
+ gas/config/tc-ppc.c | 12 ++++--------
+ 1 file changed, 4 insertions(+), 8 deletions(-)
+
+diff --git a/gas/config/tc-ppc.c b/gas/config/tc-ppc.c
+index e0b2efad031..cb5da74ab47 100644
+--- a/gas/config/tc-ppc.c
++++ b/gas/config/tc-ppc.c
+@@ -3119,9 +3119,9 @@ fixup_size (bfd_reloc_code_real_type reloc, bool *pc_relative)
+     case BFD_RELOC_PPC_TPREL16_HA:
+     case BFD_RELOC_PPC_TPREL16_HI:
+     case BFD_RELOC_PPC_TPREL16_LO:
+-	case R_PPC_AMIGAOS_BREL_LO:
+-	case R_PPC_AMIGAOS_BREL_HI:
+-	case R_PPC_AMIGAOS_BREL_HA:
++	case BFD_RELOC_PPC_AMIGAOS_BREL_LO:
++	case BFD_RELOC_PPC_AMIGAOS_BREL_HI:
++	case BFD_RELOC_PPC_AMIGAOS_BREL_HA:
+       size = 2;
+       break;
+ 
+@@ -3186,7 +3186,7 @@ fixup_size (bfd_reloc_code_real_type reloc, bool *pc_relative)
+     case BFD_RELOC_PPC_VLE_SDAREL_LO16D:
+     case BFD_RELOC_PPC64_TLS_PCREL:
+     case BFD_RELOC_RVA:
+-	case R_PPC_AMIGAOS_BREL:
++	case BFD_RELOC_PPC_AMIGAOS_BREL:
+       size = 4;
+       break;
+ 
+@@ -7682,10 +7682,6 @@ md_apply_fix (fixS *fixP, valueT *valP, segT seg)
+ 	case BFD_RELOC_16:
+ 	case BFD_RELOC_16_PCREL:
+ 	case BFD_RELOC_8:
+-	case R_PPC_AMIGAOS_BREL:
+-	case R_PPC_AMIGAOS_BREL_LO:
+-	case R_PPC_AMIGAOS_BREL_HI:
+-	case R_PPC_AMIGAOS_BREL_HA:
+ 	  break;
+ 
+ 	default:
+-- 
+2.43.0
+
+
+From 3048dd30ec6f115b37ecaa4f839ef6d79aeca08b Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 14 Feb 2025 13:38:19 +0000
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 48/61] 
+ Deleted file from repo, which fails build
+
+---
+ gas/doc/.dirstamp | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+ delete mode 100644 gas/doc/.dirstamp
+
+diff --git a/gas/doc/.dirstamp b/gas/doc/.dirstamp
+deleted file mode 100644
+index e69de29bb2d..00000000000
+-- 
+2.43.0
+
+
+From afd714e7662ba0c7010f24d986eac9017ca54e7b Mon Sep 17 00:00:00 2001
+From: migthymax <59331342+migthymax@users.noreply.github.com>
+Date: Fri, 14 Feb 2025 15:01:36 +0100
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 49/61] 
+ Fixed wrong #elif
+
+---
+ gdb/source.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdb/source.c b/gdb/source.c
+index ed5c1ae2559..fabe869802b 100644
+--- a/gdb/source.c
++++ b/gdb/source.c
+@@ -833,7 +833,7 @@ openp (const char *path, openp_flags opts, const char *string,
+   if (!path)
+   #if defined(__amigaos4__) 
+     path = "\"\"";
+-  #elif
++  #else
+     path = ".";
+   #endif
+ 
+-- 
+2.43.0
+
+
+From 314cbd72d537c4c678ac733d8ab87f44c8d747e3 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 14 Apr 2025 11:07:45 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 50/61] 
+ #23 Optimized memory consumption
+
+---
+ gdb/osabi.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/gdb/osabi.c b/gdb/osabi.c
+index 2eb227d2fc1..5e6c92ac428 100644
+--- a/gdb/osabi.c
++++ b/gdb/osabi.c
+@@ -620,7 +620,10 @@ generic_elf_osabi_sniffer (bfd *abfd)
+ 		asymbol **symbol_table = (asymbol **)xmalloc (bfd_get_symtab_upper_bound (abfd));
+ 		if (symbol_table)
+ 		{
+-		  for (int i = 0; i < bfd_canonicalize_symtab(abfd, symbol_table); i++) {
++		  // Keep it out of the for loop for performence/memory optimization
++		  int symbol_count = bfd_canonicalize_symtab(abfd, symbol_table);
++
++		  for (int i = 0; i < symbol_count; i++) {
+         	if (strcmp("__amigaos4__", bfd_asymbol_name(symbol_table[i])) == 0) {
+               osabi = GDB_OSABI_AMIGAOS;
+               break;
+-- 
+2.43.0
+
+
+From fbcea9413450c2b0a99da8d704abb46b2eb9fb09 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 16 May 2025 16:10:07 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 51/61] 
+ Give a better error when a breakpoint can't be placed in a PIE
+
+---
+ gdb/breakpoint.c | 65 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 65 insertions(+)
+
+diff --git a/gdb/breakpoint.c b/gdb/breakpoint.c
+index 67ed3b82f05..a7a0e56083a 100644
+--- a/gdb/breakpoint.c
++++ b/gdb/breakpoint.c
+@@ -2683,6 +2683,69 @@ rethrow_on_target_close_error (const gdb_exception &e)
+   throw;
+ }
+ 
++/* This should be called when we fail to insert a breakpoint, with ADDRESS
++   set to the location at which we tried to insert the breakpoint.
++
++   This function checks to see if it is possible the user tried to place
++   the breakpoint within an executable section of an object file that has
++   been relocated at run time.  If this is the case then an extra warning
++   is printed to TMP_ERROR_STREAM.  */
++
++static void
++pic_code_error_check (struct ui_file *tmp_error_stream,
++		      CORE_ADDR address)
++{
++  for (objfile *objfile : current_program_space->objfiles ())
++    {
++      struct obj_section *osect;
++
++      /* If the primary text section is not relocated then nothing should
++	 be relocated - maybe?  */
++      if (objfile->text_section_offset () == 0)
++	continue;
++
++      /* We know this object file was relocated, but was the breakpoint
++	 inside one of the code sections before relocation?  */
++      ALL_OBJFILE_OSECTIONS (objfile, osect)
++	{
++	  /* Ignore non-code sections.  */
++	  if ((bfd_section_flags (osect->the_bfd_section) & SEC_CODE) == 0)
++	    continue;
++
++	  /* Was ADDRESS within this section before relocation?  */
++	  if (!(address >= bfd_section_vma (osect->the_bfd_section)
++		&& address < (bfd_section_vma (osect->the_bfd_section)
++			      + bfd_section_size (osect->the_bfd_section))))
++	    continue;
++
++	  /* Final check that this section was relocated.  */
++	  int idx = osect - objfile->sections;
++	  CORE_ADDR offset = objfile->section_offsets[idx];
++	  if (offset == 0)
++	    continue;
++
++	  /* Let the user know that they may have made a mistake.  One
++	     final check that it might be nice to do is to only give this
++	     warning if the user placed the breakpoint by address, that is
++	     using 'break *0x.......', if they did anything else and we
++	     still have this issue then I'm not sure what the user could
++	     reasonably do about it.  However, for now, we just always
++	     give this error.  */
++	  CORE_ADDR len = bfd_section_size (osect->the_bfd_section);
++	  CORE_ADDR start = bfd_section_vma (osect->the_bfd_section);
++	  gdb_printf (tmp_error_stream, "\
++The address is located within a code region of `%s' which was dynamically\n\
++relocated at run time.  The code region `%s ... %s' is now located\n\
++at `%s ... %s', you may need to adjust your breakpoints.\n",
++			      objfile_name (objfile),
++			      core_addr_to_string (start),
++			      core_addr_to_string (start + len),
++			      core_addr_to_string (offset + start),
++			      core_addr_to_string (offset + start + len));
++	}
++    }
++}
++
+ /* Insert a low-level "breakpoint" of some type.  BL is the breakpoint
+    location.  Any error messages are printed to TMP_ERROR_STREAM; and
+    DISABLED_BREAKS, and HW_BREAKPOINT_ERROR are used to report problems.
+@@ -2911,6 +2974,8 @@ insert_bp_location (struct bp_location *bl,
+ 				  "Cannot insert breakpoint %d.\n"
+ 				  "%s\n",
+ 				  bl->owner->number, message.c_str ());
++
++			  pic_code_error_check (tmp_error_stream, bl->address);  
+ 		    }
+ 		  else
+ 		    {
+-- 
+2.43.0
+
+
+From d4326f5c00c26dca7ec5e845e08cb426797ccd81 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Wed, 21 May 2025 11:56:38 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 52/61] 
+ Avoid DSI if memory cannot be written to
+
+---
+ gdb/ppc-amigaos-nat.c | 174 +++++++++++++++++++++++-------------------
+ 1 file changed, 96 insertions(+), 78 deletions(-)
+
+diff --git a/gdb/ppc-amigaos-nat.c b/gdb/ppc-amigaos-nat.c
+index 576cc0ee91d..9c405b93910 100644
+--- a/gdb/ppc-amigaos-nat.c
++++ b/gdb/ppc-amigaos-nat.c
+@@ -30,7 +30,7 @@
+ #include "ppc-tdep.h"
+ #include "gdbsupport/ptid.h"
+ #include "gdbsupport/gdb_wait.h"
+-
++ 
+ #include <proto/dos.h>
+ #include <proto/exec.h>
+ #include <proto/elf.h>
+@@ -142,7 +142,7 @@ class ppc_amigaos_nat_target : public inf_child_target
+ 	
+ 	ppc_amigaos_nat_target ();
+ 	~ppc_amigaos_nat_target () override;
+-	
++
+ 	ptid_t wait (ptid_t, struct target_waitstatus *, target_wait_flags) override;
+ 
+ 	void fetch_registers (struct regcache *, int) override;	
+@@ -185,7 +185,7 @@ class ppc_amigaos_nat_target : public inf_child_target
+ 	{
+ 		struct Task *task = (struct Task *)(ptid == minus_one_ptid ? inferior_ptid.pid () : ptid.pid ());
+ 		
+-		IExec->DebugPrintF("[GDB] %s ( step: %d, gdb_signal: %d, Task: %p  )\n",__func__,step,signal,task);
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d ( step: %d, gdb_signal: %d, Task: %p )\n"),__func__,__LINE__,step,signal,task ).c_str());;
+ 
+ 		IExec->RestartTask (task,0);
+ 	}
+@@ -201,7 +201,7 @@ class ppc_amigaos_nat_target : public inf_child_target
+ 
+ 		struct Task *task = (struct Task *)inf->pid;
+ 
+-		IExec->DebugPrintF( "[GDB] %s ( task: %p )\n",__func__,task );
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d ( task: %p )\n"),__func__,__LINE__,task ).c_str());
+ 
+ 		if( task ) 
+ 		{
+@@ -218,7 +218,7 @@ class ppc_amigaos_nat_target : public inf_child_target
+ 	/*
+ 	std::string pid_to_str (ptid_t ptid) override
+ 	{
+-		IExec->DebugPrintF ("[GDB] %s Entering\n",__func__);
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Entering\n"),__func__,__LINE__ ).c_str());
+ 		
+ 		/ *
+ 		if( ptid != minus_one_ptid )
+@@ -243,7 +243,7 @@ class ppc_amigaos_nat_target : public inf_child_target
+ 	/*
+ 	bool info_proc (const char *args, enum info_proc_what what) override 
+ 	{
+-		IExec->DebugPrintF("[GDB] %s (false)\n",__func__);
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d (false)\n"),__func__,__LINE__ ).c_str());
+ 		return false;
+ 	}
+ 	*/
+@@ -440,41 +440,41 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 	while( 1 )
+ 	{
+-		IExec->DebugPrintF("[GDB] %s Entering wait loop\n",__func__);
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Entering wait loop\n"),__func__,__LINE__ ).c_str());
+ 
+ 		uint32 signal = IExec->Wait (SIGBREAKF_CTRL_D|SIGBREAKF_CTRL_C|1<<amigaos_debug_hook_data.debugger_port->mp_SigBit);
+ 
+ 		if( ( signal & SIGBREAKF_CTRL_D ) == SIGBREAKF_CTRL_D )
+ 		{
+-			IExec->DebugPrintF("[GDB] %s received SIGBREAKF_CTRL_D\n",__func__);
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d received SIGBREAKF_CTRL_D\n"),__func__,__LINE__ ).c_str());
+ 
+ 			ourstatus->set_exited (0);
+ 
+-			IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%08x\n"),__func__,__LINE__,ptid ).c_str());
+ 
+ 			return ptid;
+ 		}
+ 
+ 		if( ( signal & SIGBREAKF_CTRL_C ) == SIGBREAKF_CTRL_C )
+ 		{
+-			IExec->DebugPrintF("[GDB] %s received SIGBREAKF_CTRL_C\n",__func__);
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d received SIGBREAKF_CTRL_C\n"),__func__,__LINE__ ).c_str());
+ 
+ 			IExec->SuspendTask ((struct Task *)process,0);
+ 
+ 			ourstatus->set_stopped (GDB_SIGNAL_TRAP);
+ 
+-			IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%08x\n"),__func__,__LINE__,ptid ).c_str());
+ 
+ 			return ptid;
+ 		}
+ 
+ 		while (struct Message *message = IExec->GetMsg (amigaos_debug_hook_data.debugger_port) ) 		
+ 		{
+-			IExec->DebugPrintF("[GDB] %s received message: %p\n",__func__,message );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d received message: %p\n"),__func__,__LINE__,message ).c_str());
+ 
+ 			struct debugger_message *debuggerMessage = (struct debugger_message *)message;
+ 
+-			IExec->DebugPrintF("[GDB] %s received debug message for task: %p\n",__func__,debuggerMessage->process );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d received debug message for task: %p\n"),__func__,__LINE__,debuggerMessage->process ).c_str());
+ 
+ 			if( debuggerMessage->signal == -1 )
+ 			{
+@@ -482,19 +482,19 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 				{
+ 					case DM_FLAGS_TASK_OPENLIB:
+ 					{
+-						IExec->DebugPrintF("[GDB] %s received task open library\n",__func__);
++						IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d received task open library\n"),__func__,__LINE__ ).c_str());
+ 
+ 						break;
+ 					}
+ 					case DM_FLAGS_TASK_CLOSELIB:
+ 					{
+-						IExec->DebugPrintF("[GDB] %s received task close library\n",__func__);
++						IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d received task close library\n"),__func__,__LINE__ ).c_str());
+ 
+ 						break;
+ 					}
+ 					case DM_FLAGS_TASK_TERMINATED:
+ 					{
+-						IExec->DebugPrintF("[GDB] %s received task terminated\n",__func__);
++						IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d received task terminated\n"),__func__,__LINE__ ).c_str());
+ 
+ 						if( process == debuggerMessage->process) 
+ 						{
+@@ -507,7 +507,7 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 					}
+ 					case DM_FLAGS_TASK_FINAL:
+ 					{
+-						IExec->DebugPrintF("[GDB] %s received SIGB_CHILD of Process %p with dos return: %ld\n",__func__,debuggerMessage->process,debuggerMessage->ReturnCode);
++						IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d received SIGB_CHILD of Process %p with dos return: %ld\n"),__func__,__LINE__,debuggerMessage->process,debuggerMessage->ReturnCode ).c_str());
+ 
+ 						if( debuggerMessage->process == process ) {
+ 							ourstatus->set_exited (debuggerMessage->ReturnCode);
+@@ -518,20 +518,20 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 							free_message (debuggerMessage);
+ 
+-							IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
++							IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%08x\n"),__func__,__LINE__,ptid ).c_str());
+ 
+ 							return ptid;
+ 						}
+ 						else
+ 						{
+-							IExec->DebugPrintF("[GDB] Process %p already killed\n",__func__,__LINE__,debuggerMessage->process );
++							IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Process %p already killed\n"),__func__,__LINE__,debuggerMessage->process ).c_str());
+ 						}
+ 
+ 						break;
+ 					}
+ 					default:
+ 					{
+-						IExec->DebugPrintF("[GDB] %s received unknown flags for signal -1 from callback %ld\n",__func__,debuggerMessage->flags);
++						IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d received unknown flags for signal -1 from callback %ld\n"),__func__,__LINE__,debuggerMessage->flags ).c_str());
+ 	
+ 						break;
+ 					}
+@@ -541,7 +541,7 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 			}
+ 			else
+ 			{
+-				IExec->DebugPrintF("[GDB] %s Inferior (%p) signaled : '%s'\n",__func__,process,gdb_signal_to_name ((enum gdb_signal)debuggerMessage->signal));
++				IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Inferior (%p) signaled : '%s'\n"),__func__,__LINE__,process,gdb_signal_to_name ((enum gdb_signal)debuggerMessage->signal) ).c_str());
+ 
+ 				switch (debuggerMessage->signal)
+ 				{
+@@ -576,7 +576,7 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 					}
+ 					default:
+ 					{
+-						IExec->DebugPrintF("[GDB] %s received unknown signal from callback %ld\n",__func__,debuggerMessage->signal);
++						IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d received unknown signal from callback %ld\n"),__func__,__LINE__,debuggerMessage->signal ).c_str());
+ 
+ 						break;
+ 					}
+@@ -584,14 +584,14 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 				free_message (debuggerMessage);
+ 				
+-				IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid );
++				IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%08x\n"),__func__,__LINE__,ptid ).c_str());
+ 
+ 				return ptid;
+ 			}		
+ 		}
+ 	}
+ 
+-	IExec->DebugPrintF("[GDB] %s@%d Leaving with ptid: 0x%08x\n",__func__,__LINE__,ptid_t::make_minus_one () );
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%08x\n"),__func__,__LINE__,ptid_t::make_minus_one () ).c_str());
+ 
+ 	return ptid_t::make_minus_one ();
+ }
+@@ -604,7 +604,7 @@ ppc_amigaos_nat_target::fetch_registers (struct regcache *regcache, int regno)
+ 	ppc_gdbarch_tdep *tdep = gdbarch_tdep<ppc_gdbarch_tdep> (gdbarch);	
+ 	struct Task *task = (struct Task *)regcache->ptid().pid();
+ 
+-	IExec->DebugPrintF("[GDB] %s ( regcache: %p, regno: %d (%s), task: %p)\n",__func__,regcache,regno,gdbarch_register_name( gdbarch,regno ),task);
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d ( regcache: %p, regno: %d (%s), task: %p)\n"),__func__,__LINE__,regcache,regno,gdbarch_register_name( gdbarch,regno ),task ).c_str());
+ 
+ 	struct ExceptionContext context;
+ 	IDebug->ReadTaskContext( task,&context,RTCF_INFO | RTCF_SPECIAL | RTCF_STATE | RTCF_GENERAL | RTCF_FPU | RTCF_VECTOR );
+@@ -672,13 +672,16 @@ ppc_amigaos_nat_target::fetch_registers (struct regcache *regcache, int regno)
+ void
+ ppc_amigaos_nat_target::store_registers (struct regcache *regcache, int regno)
+ {
+-	printf( "[GDB] %s Todo ( regcache: %p, regno: %d)\n",__func__,regcache,regno );
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Todo ( regcache: %p, regno: %d)\n"),__func__,__LINE__,regcache,regno ).c_str());
+ }
+ 
+ enum target_xfer_status
+ ppc_amigaos_nat_target::xfer_partial (enum target_object object,const char *annex, gdb_byte *readbuf,const gdb_byte *writebuf,ULONGEST offset, ULONGEST len, ULONGEST *xfered_len)
+ {
+-	IExec->DebugPrintF ( string_printf (_("[GDB] %s called for memory tranfser at address: 0x%s for %s bytes (readbuf: %p, writebuf: %p, annex: '%s', object: %d )\n"),__func__,phex (offset, sizeof (offset)),pulongest (len), readbuf, writebuf, annex, object).c_str());
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d called for memory tranfser at address: 0x%s for %s bytes (readbuf: %p, writebuf: %p, annex: '%s', object: %d )\n"),__func__,__LINE__,phex (offset, sizeof (offset)),pulongest (len), readbuf, writebuf, annex, object).c_str());
++
++	enum target_xfer_status result = TARGET_XFER_E_IO;
++
+ 
+ 	switch (object)
+ 	{
+@@ -687,23 +690,40 @@ ppc_amigaos_nat_target::xfer_partial (enum target_object object,const char *anne
+ 			if (offset == 0) 
+ 			{
+ 				// ML: Helps to unwind farme correctly
+-				return TARGET_XFER_E_IO;
++				result = TARGET_XFER_E_IO;
+ 			}
+ 			else
+ 			{
+ 				APTR user_stack = IExec->SuperState();
+ 
+ 				ULONG currentAttrs = IMMU->GetMemoryAttrs( (APTR)offset,0 );
+-				IMMU->SetMemoryAttrs ( (APTR)offset,len,MEMATTRF_READ_WRITE );
++				IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Address 0x%s attributes 0x%s\n"),__func__,__LINE__,phex (offset, sizeof (offset)),phex (currentAttrs, sizeof (currentAttrs))).c_str());
++
++				IMMU->SetMemoryAttrs ( (APTR)offset,len,currentAttrs & MEMATTRF_READ_WRITE );
+ 
+ 				if (readbuf) 
+ 				{
+ 					IExec->CopyMem( (APTR)offset,(APTR)readbuf,len );
++
++					result = TARGET_XFER_OK;
+ 				}
+ 				else // if(writebuf)
+ 				{
+-					IExec->CopyMem( (APTR)writebuf,(APTR)offset,len );
+-					IExec->CacheClearE( (APTR)offset,len,CACRF_ClearI );
++					ULONG modifiedAttrs = IMMU->GetMemoryAttrs( (APTR)offset,0 );
++
++					if( ( modifiedAttrs & MEMATTRF_RW_MASK ) == MEMATTRF_READ_ONLY )
++					{
++						IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Could not modified Address 0x%s attributes 0x%s to allow writing\n"),__func__,__LINE__,phex (offset, sizeof (offset)),phex (modifiedAttrs, sizeof (modifiedAttrs))).c_str());
++
++						result = TARGET_XFER_UNAVAILABLE;
++					}
++					else
++					{
++						IExec->CopyMem( (APTR)writebuf,(APTR)offset,len );
++						IExec->CacheClearE( (APTR)offset,len,CACRF_ClearI );
++
++						result = TARGET_XFER_OK;
++					}
+ 				}
+ 
+ 				IMMU->SetMemoryAttrs( (APTR)offset,len,currentAttrs );
+@@ -716,24 +736,22 @@ ppc_amigaos_nat_target::xfer_partial (enum target_object object,const char *anne
+ 
+ 			*xfered_len = len;
+ 
+-			IExec->DebugPrintF ( string_printf (_("[GDB] %s tansferfed %s bytes\n"),__func__,pulongest (*xfered_len)).c_str());
+-
+-			return TARGET_XFER_OK;			
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d tansferfed %s bytes\n"),__func__,__LINE__,pulongest (*xfered_len)).c_str());
+ 		}
+ 		break;
+ 
+ 		case TARGET_OBJECT_LIBRARIES:
+ 		{
+-			IExec->DebugPrintF("[GDB] %s tansferfed object library '%s' failed, aka not supported yet\n",__func__,annex);
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d tansferfed object library '%s' failed, aka not supported yet\n"),__func__,__LINE__,annex ).c_str());
+ 
+-			return TARGET_XFER_E_IO;			
++			result = TARGET_XFER_E_IO;
+ 		}
+ 		break;
+ 
+ 		default:
+ 			if (beneath()) 
+ 			{
+-				IExec->DebugPrintF("[GDB] %s tansferfed delegated to beneath for target_object %d\n",__func__,object);
++				IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d tansferfed delegated to beneath for target_object %d\n"),__func__,__LINE__,object ).c_str());
+ 
+ 				return this->beneath ()->xfer_partial (object,annex,readbuf,writebuf,offset,len,xfered_len);
+ 			}
+@@ -742,13 +760,13 @@ ppc_amigaos_nat_target::xfer_partial (enum target_object object,const char *anne
+ 			 with the current_target having no target beneath).  */
+ 	}
+ 
+-	return TARGET_XFER_E_IO;
++	return result;
+ }
+ 
+ void
+ ppc_amigaos_nat_target::attach (const char *args, int from_tty)
+ {
+-	printf( "[GDB] %s ( args: '%s', from_tty: %d )\n",__func__,args,from_tty );
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d args: '%s', from_tty: %d\n"),__func__,__LINE__,args,from_tty ).c_str());	
+ }
+ 
+ void
+@@ -783,7 +801,7 @@ ppc_amigaos_relocate_sections (const char *exec_file,BPTR exec_seglist)
+ 						
+ 					if( address )
+ 					{
+-						IExec->DebugPrintF ( string_printf (_("[GDB] On symfile_object relocated %d section '%s' from 0x%08lx to %p, size %ld, old offset: 0x%s\n"),section->index,section->name,section->vma,address,section->size,phex ( osect->addr(), sizeof (osect->addr()))).c_str());
++						IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d On symfile_object relocated %d section '%s' from 0x%08lx to %p, size %ld, old offset: 0x%s\n"),__func__,__LINE__,section->index,section->name,section->vma,address,section->size,phex ( osect->addr(), sizeof (osect->addr()))).c_str());
+ 						
+ 						offsets[ osect_idx ] = (CORE_ADDR)address - osect->addr();
+ 					}
+@@ -802,7 +820,7 @@ ppc_amigaos_relocate_sections (const char *exec_file,BPTR exec_seglist)
+ 								
+ 					if( address )
+ 					{
+-						printf ( "[GDB] On exec_bfd relocated %d section '%s' from %08lx to %p, size %ld\n",section->index,section->name,section->vma,address,section->size);
++						IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d On exec_bfd relocated %d section '%s' from 0x%08lx to %p, size %ld\n"),__func__,__LINE__,section->index,section->name,section->vma,address,section->size).c_str());
+ 						
+ 						exec_set_section_address( exec_file,section->index,(CORE_ADDR)address );							
+ 					}
+@@ -882,7 +900,7 @@ void ppc_amigaos_nat_target::create_inferior (const char *exec_file,const std::s
+ 			TAG_DONE
+ 		);
+ 
+-	IExec->DebugPrintF ( "[GDB] Process %p has debug message %p\n",amigaos_debug_hook_data.current_process,dmsg );
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Process %p has debug message %p\n"),__func__,__LINE__,amigaos_debug_hook_data.current_process,dmsg ).c_str());
+ 
+ 	if (! amigaos_debug_hook_data.current_process)
+ 	{
+@@ -912,7 +930,7 @@ void ppc_amigaos_nat_target::create_inferior (const char *exec_file,const std::s
+ 
+ 	ppc_amigaos_relocate_sections (exec_file,(BPTR)dmsg->seglist);
+ 
+-	IExec->DebugPrintF("[GDB] %s inferior_ptid=0x%08x inf=%p thr=%p\n",__func__,inferior_ptid.pid(),inf,thr);
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d inferior_ptid=0x%08x inf=%p thr=%p\n"),__func__,__LINE__,inferior_ptid.pid(),inf,thr ).c_str());
+ }
+ 
+ static ppc_amigaos_nat_target the_ppc_amigaos_nat_target;
+@@ -928,11 +946,11 @@ VOID amigaos_debug_suspend( struct Hook *amigaos_debug_hook )
+ {
+ 	struct Task *current = IExec->FindTask (NULL);
+ 
+-	IExec->DebugPrintF("[GDB] %s inferiorer %p started by kernel, suspending myself and installing debug hook: %p\n",__func__,current,amigaos_debug_hook);
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d inferiorer %p started by kernel, suspending myself and installing debug hook: %p\n"),__func__,__LINE__,current,amigaos_debug_hook ).c_str());
+ 	
+ 	IExec->SuspendTask (current,0);
+ 
+-	IExec->DebugPrintF("[GDB] %s inferiorer %p started by gdb\n",__func__,current);
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d inferiorer %p started by gdb\n"),__func__,__LINE__,current ).c_str());
+ }
+ 
+ VOID amigaos_debug_kill( int32 return_code,struct debugger_message *dmsg ) 
+@@ -941,7 +959,7 @@ VOID amigaos_debug_kill( int32 return_code,struct debugger_message *dmsg )
+ 
+ 	dmsg->ReturnCode = return_code;
+ 
+-	IExec->DebugPrintF("[GDB] %s inferiorer %p killed by kernel, sending death message: %p\n",__func__,current,dmsg);
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d inferiorer %p killed by kernel, sending death message: %p\n"),__func__,__LINE__,current,dmsg ).c_str());
+ 
+ 	IExec->PutMsg( dmsg->msg.mn_ReplyPort,(struct Message *)dmsg );	
+ }
+@@ -953,24 +971,24 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 	
+ 	if( (struct Task *)data->current_process != currentTask )
+ 	{
+-		IExec->DebugPrintF ("[GDB] Task: %p ('%s'), task NOT under our observation\n",currentTask,currentTask->tc_Node.ln_Name);
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Task: %p ('%s'), task NOT under our observation\n"),__func__,__LINE__,currentTask,currentTask->tc_Node.ln_Name ).c_str());
+ 
+ 		return 0;
+ 	}
+-	IExec->DebugPrintF ("[GDB] Task: %p ('%s'), task IS under our observation\n",currentTask,currentTask->tc_Node.ln_Name);
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Task: %p ('%s'), task IS under our observation\n"),__func__,__LINE__,currentTask,currentTask->tc_Node.ln_Name ).c_str());
+ 
+ 
+ 	switch( dbgmsg->type ) 
+ 	{
+ 		case DBHMT_EXCEPTION:
+ 		{
+-			IExec->DebugPrintF ("[GDB] Task: %p ('%s'),Exception ooccured (DBHMT_EXCEPTION)\n",currentTask,currentTask->tc_Node.ln_Name);
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Task: %p ('%s'),Exception ooccured (DBHMT_EXCEPTION)\n"),__func__,__LINE__,currentTask,currentTask->tc_Node.ln_Name ).c_str());
+ 
+ 			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);
+ 			message->flags	= 0;
+ 			message->signal	= trap_to_signal( dbgmsg->message.context,message->flags );
+ 			
+-			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d debug hook sending message: %p\n"),__func__,__LINE__,message ).c_str());
+ 
+ 			IExec->PutMsg (data->debugger_port,(struct Message *)message);
+ 
+@@ -978,13 +996,13 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 		}
+ 		case DBHMT_ADDTASK:
+ 		{
+-			IExec->DebugPrintF("[GDB] Task: %p ('%s'), (DBHMT_ADDTASK), Task added\n",currentTask,currentTask->tc_Node.ln_Name);
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Task: %p ('%s'), (DBHMT_ADDTASK), Task added\n"),__func__,__LINE__,currentTask,currentTask->tc_Node.ln_Name ).c_str());
+ 
+ 			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);	
+ 			message->flags	= DM_FLAGS_TASK_ATTACHED;
+ 			message->signal	= -1;
+ 			
+-			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d debug hook sending message: %p\n"),__func__,__LINE__,message ).c_str());
+ 
+ 			IExec->PutMsg (data->debugger_port,(struct Message *)message);
+ 
+@@ -992,13 +1010,13 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 		}
+ 		case DBHMT_REMTASK:
+ 		{
+-			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_REMTASK), Task removed\n",currentTask,currentTask->tc_Node.ln_Name);
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Task: %p ('%s'), (DBHMT_REMTASK), Task removed\n"),__func__,__LINE__,currentTask,currentTask->tc_Node.ln_Name ).c_str());
+ 
+ 			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);
+ 			message->flags	= DM_FLAGS_TASK_TERMINATED;
+ 			message->signal	= -1;
+ 			
+-			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d debug hook sending message: %p\n"),__func__,__LINE__,message ).c_str());
+ 
+ 			IExec->PutMsg (data->debugger_port,(struct Message *)message);
+ 			
+@@ -1006,14 +1024,14 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 		}
+ 		case DBHMT_OPENLIB:
+ 		{
+-			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_OPENLIB), Task opened library '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Task: %p ('%s'), (DBHMT_OPENLIB), Task opened library '%s'\n"),__func__,__LINE__,currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString ).c_str());
+ 
+ 			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);
+ 			message->flags		= DM_FLAGS_TASK_OPENLIB;
+ 			message->signal		= -1;
+ 			message->library	= dbgmsg->message.library;
+ 			
+-			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d debug hook sending message: %p\n"),__func__,__LINE__,message ).c_str());
+ 
+ 			IExec->PutMsg (data->debugger_port,(struct Message *)message);
+ 
+@@ -1021,14 +1039,14 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 		}
+ 		case DBHMT_CLOSELIB:
+ 		{
+-			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_CLOSELIB), Task closed library '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Task: %p ('%s'), (DBHMT_CLOSELIB), Task closed library '%s'\n"),__func__,__LINE__,currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString ).c_str());
+ 
+ 			struct debugger_message *message = ppc_amigaos_nat_target->alloc_message ((struct Process *)currentTask);	
+ 			message->flags		= DM_FLAGS_TASK_CLOSELIB;
+ 			message->signal		= -1;
+ 			message->library	= dbgmsg->message.library;
+ 
+-			IExec->DebugPrintF ("[GDB] debug hook sending message: %p\n",message );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d debug hook sending message: %p\n"),__func__,__LINE__,message ).c_str());
+ 
+ 			IExec->PutMsg (data->debugger_port,(struct Message *)message);
+ 
+@@ -1036,17 +1054,17 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ 		}
+ 		case DBHMT_SHAREDOBJECTOPEN:
+ 		{
+-			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_SHAREDOBJECTOPEN), Task opened shared object '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Task: %p ('%s'), (DBHMT_SHAREDOBJECTOPEN), Task opened shared object '%s'\n"),__func__,__LINE__,currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString ).c_str());
+ 			break;
+ 		}
+ 		case DBHMT_SHAREDOBJECTCLOSE:
+ 		{
+-			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_SHAREDOBJECTCLOSE), Task closed shared object '%s'\n",currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString);
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Task: %p ('%s'), (DBHMT_SHAREDOBJECTCLOSE), Task closed shared object '%s'\n"),__func__,__LINE__,currentTask,currentTask->tc_Node.ln_Name,(char*)dbgmsg->message.library->lib_IdString ).c_str());
+ 			break;
+ 		}
+ 		default:
+ 		{
+-			IExec->DebugPrintF ("[GDB] Task: %p ('%s'), (DBHMT_UNKNOWN), Task unknown message type %lu\n",currentTask,currentTask->tc_Node.ln_Name,dbgmsg->type);
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Task: %p ('%s'), (DBHMT_UNKNOWN), Task unknown message type %lu\n"),__func__,__LINE__,currentTask,currentTask->tc_Node.ln_Name,dbgmsg->type ).c_str());
+ 		}
+ 	}
+ 
+@@ -1056,67 +1074,67 @@ ULONG amigaos_debug_callback (struct Hook *hook, struct Task *currentTask,struct
+ static int
+ trap_to_signal(struct ExceptionContext *context, uint32 flags)
+ {
+-	IExec->DebugPrintF( "[GDB] trap_to_signal ( flags: 0x%lx )\n",flags );
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d trap_to_signal ( flags: 0x%lx )\n"),__func__,__LINE__,flags ).c_str());
+ 
+ 	if (!context || (flags & DM_FLAGS_TASK_TERMINATED)) {
+-		IExec->DebugPrintF( "[GDB] Return GDB_SIGNAL_QUIT )\n" );
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return GDB_SIGNAL_QUIT )\n"),__func__,__LINE__ ).c_str());
+ 	
+ 		return GDB_SIGNAL_QUIT;
+ 	}
+ 
+-	IExec->DebugPrintF( "[GDB] traptype: 0x%lx\n",context->Traptype );
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d traptype: 0x%lx\n"),__func__,__LINE__,context->Traptype ).c_str());
+ 
+ 	switch (context->Traptype)
+ 	{
+ 	case TRAP_MCE:
+ 	case TRAP_DSI:
+-		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_SEGV )\n" );
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( GDB_SIGNAL_SEGV )\n"),__func__,__LINE__ ).c_str());
+ 		return GDB_SIGNAL_SEGV;
+ 	case TRAP_ISI:
+ 	case TRAP_ALIGN:
+-		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_BUS )\n" );
++		IExec->DebugPrintF ( string_printf (_("[GDB] R%s@%d eturn ( GDB_SIGNAL_BUS )\n"),__func__,__LINE__ ).c_str());
+ 		return GDB_SIGNAL_BUS;
+ 	case TRAP_EXTERN:
+-		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_INT )\n" );
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( GDB_SIGNAL_INT )\n"),__func__,__LINE__ ).c_str());
+ 		return GDB_SIGNAL_INT;
+ 	case TRAP_PROG: 
+ 		if (context->msr & EXC_FPE) {
+-			IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( GDB_SIGNAL_FPE )\n"),__func__,__LINE__ ).c_str());
+ 			return GDB_SIGNAL_FPE;
+ 		}
+ 		else if (context->msr & EXC_ILLEGAL) {
+-			IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( GDB_SIGNAL_ILL )\n"),__func__,__LINE__ ).c_str());
+ 			return GDB_SIGNAL_ILL;
+ 		}
+ 		else if (context->msr & EXC_PRIV) {
+-			IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( GDB_SIGNAL_ILL )\n"),__func__,__LINE__ ).c_str());
+ 			return GDB_SIGNAL_ILL;
+ 		}
+ 		else {
+-			IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_TRAP )\n" );
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( GDB_SIGNAL_TRAP )\n"),__func__,__LINE__ ).c_str());
+ 			return GDB_SIGNAL_TRAP;
+ 		}
+ 	case TRAP_FPU:
+-		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( GDB_SIGNAL_FPE )\n"),__func__,__LINE__ ).c_str());
+ 		return GDB_SIGNAL_FPE;
+ 	case TRAP_DEC:
+-		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_ALRM )\n" );
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( GDB_SIGNAL_ALRM )\n"),__func__,__LINE__ ).c_str());
+ 		return GDB_SIGNAL_ALRM;
+ 	case TRAP_RESERVEDA:
+ 	case TRAP_RESERVEDB:
+-		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_ILL )\n" );
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( GDB_SIGNAL_ILL )\n"),__func__,__LINE__ ).c_str());
+ 		return GDB_SIGNAL_ILL;
+ 	case TRAP_SYSCALL:
+-		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_CHLD )\n" );
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( GDB_SIGNAL_CHLD )\n"),__func__,__LINE__ ).c_str());
+ 		return GDB_SIGNAL_CHLD;
+ 	case TRAP_TRACEI:
+-		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_TRAP )\n" );
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( GDB_SIGNAL_TRAP )\n"),__func__,__LINE__ ).c_str());
+ 		return GDB_SIGNAL_TRAP;
+ 	case TRAP_FPA:
+-		IExec->DebugPrintF( "[GDB] Return ( GDB_SIGNAL_FPE )\n" );
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( GDB_SIGNAL_FPE )\n"),__func__,__LINE__ ).c_str());
+ 		return GDB_SIGNAL_FPE;
+ 	default:
+-		IExec->DebugPrintF( "[GDB] Return ( -1 )\n" );
++		IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Return ( -1 )\n"),__func__,__LINE__ ).c_str());
+ 		return -1;
+ 	}
+ }
+\ No newline at end of file
+-- 
+2.43.0
+
+
+From f7663a8a3b3b586bc45470d546221534ce39298e Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 13 Jun 2025 12:44:29 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 53/61] 
+ #18 Improved path handling for native build
+
+---
+ binutils/addr2line.c       |  4 ++++
+ binutils/ar.c              |  4 ++++
+ binutils/elfedit.c         |  4 ++++
+ binutils/nm.c              |  4 ++++
+ binutils/objcopy.c         |  4 ++++
+ binutils/objdump.c         |  4 ++++
+ binutils/readelf.c         |  4 ++++
+ binutils/size.c            |  4 ++++
+ binutils/strings.c         |  4 ++++
+ gas/as.c                   |  4 ++++
+ gdb/filesystem.c           | 20 ++++++++++++++++++++
+ gdb/filesystem.h           | 18 ++++++++++++++++++
+ gdb/gdb.c                  |  4 ++++
+ gdb/source.c               |  2 +-
+ gdbsupport/host-defs.h     |  2 ++
+ gprof/gprof.c              |  4 ++++
+ include/filenames.h        |  6 ++++--
+ ld/ldmain.c                |  4 ++++
+ libiberty/lbasename.c      |  2 ++
+ libiberty/make-temp-file.c |  2 +-
+ 20 files changed, 100 insertions(+), 4 deletions(-)
+
+diff --git a/binutils/addr2line.c b/binutils/addr2line.c
+index 1fe9ce2a780..328b1529bb5 100644
+--- a/binutils/addr2line.c
++++ b/binutils/addr2line.c
+@@ -480,6 +480,10 @@ process_file (const char *file_name, const char *section_name,
+ int
+ main (int argc, char **argv)
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++	
+   const char *file_name;
+   const char *section_name;
+   char *target;
+diff --git a/binutils/ar.c b/binutils/ar.c
+index f8b161aaf5a..726fed7f017 100644
+--- a/binutils/ar.c
++++ b/binutils/ar.c
+@@ -719,6 +719,10 @@ int main (int, char **);
+ int
+ main (int argc, char **argv)
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++	
+   int arg_index;
+   char **files;
+   int file_count;
+diff --git a/binutils/elfedit.c b/binutils/elfedit.c
+index 117e67639a0..473609479ed 100644
+--- a/binutils/elfedit.c
++++ b/binutils/elfedit.c
+@@ -981,6 +981,10 @@ usage (FILE *stream, int exit_status)
+ int
+ main (int argc, char ** argv)
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++	
+   int c, status;
+   char *end;
+ 
+diff --git a/binutils/nm.c b/binutils/nm.c
+index c3c407af266..dc3b3d2fc0c 100644
+--- a/binutils/nm.c
++++ b/binutils/nm.c
+@@ -1987,6 +1987,10 @@ just_print_symbol_name (struct extended_symbol_info *info, bfd *abfd)
+ int
+ main (int argc, char **argv)
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++	
+   int c;
+   int retval;
+ 
+diff --git a/binutils/objcopy.c b/binutils/objcopy.c
+index 4e85ed7966a..789c51f9b39 100644
+--- a/binutils/objcopy.c
++++ b/binutils/objcopy.c
+@@ -6094,6 +6094,10 @@ copy_main (int argc, char *argv[])
+ int
+ main (int argc, char *argv[])
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++	
+ #ifdef HAVE_LC_MESSAGES
+   setlocale (LC_MESSAGES, "");
+ #endif
+diff --git a/binutils/objdump.c b/binutils/objdump.c
+index ee2f577cc3e..cb7b356d90b 100644
+--- a/binutils/objdump.c
++++ b/binutils/objdump.c
+@@ -5862,6 +5862,10 @@ display_file (char *filename, char *target, bool last_file)
+ int
+ main (int argc, char **argv)
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++	
+   int c;
+   char *target = default_target;
+   bool seenflag = false;
+diff --git a/binutils/readelf.c b/binutils/readelf.c
+index 0439e7af16b..c87ff814f51 100644
+--- a/binutils/readelf.c
++++ b/binutils/readelf.c
+@@ -22969,6 +22969,10 @@ db_task_printsym (unsigned int addr)
+ int
+ main (int argc, char ** argv)
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++	
+   int err;
+ 
+ #ifdef HAVE_LC_MESSAGES
+diff --git a/binutils/size.c b/binutils/size.c
+index 94738977cb8..2eb213c81f1 100644
+--- a/binutils/size.c
++++ b/binutils/size.c
+@@ -132,6 +132,10 @@ int main (int, char **);
+ int
+ main (int argc, char **argv)
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++	
+   int temp;
+   int c;
+ 
+diff --git a/binutils/strings.c b/binutils/strings.c
+index e2c1ead6bfd..6b6213720e3 100644
+--- a/binutils/strings.c
++++ b/binutils/strings.c
+@@ -174,6 +174,10 @@ int main (int, char **);
+ int
+ main (int argc, char **argv)
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++	
+   int optc;
+   int exit_status = 0;
+   bool files_given = false;
+diff --git a/gas/as.c b/gas/as.c
+index 602ed3b5f79..e00b05855b7 100644
+--- a/gas/as.c
++++ b/gas/as.c
+@@ -1270,6 +1270,10 @@ free_notes (void)
+ int
+ main (int argc, char ** argv)
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++	
+   char ** argv_orig = argv;
+   struct stat sob;
+ 
+diff --git a/gdb/filesystem.c b/gdb/filesystem.c
+index f768d99413f..2cb938d29ba 100644
+--- a/gdb/filesystem.c
++++ b/gdb/filesystem.c
+@@ -25,13 +25,17 @@
+ const char file_system_kind_auto[] = "auto";
+ const char file_system_kind_unix[] = "unix";
+ const char file_system_kind_dos_based[] = "dos-based";
++#ifdef ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM
+ const char file_system_kind_amigaos_based[] = "amiga-based";
++#endif
+ const char *const target_file_system_kinds[] =
+ {
+   file_system_kind_auto,
+   file_system_kind_unix,
+   file_system_kind_dos_based,
++#ifdef ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM
+   file_system_kind_amigaos_based,
++#endif
+   NULL
+ };
+ const char *target_file_system_kind = file_system_kind_auto;
+@@ -43,8 +47,10 @@ effective_target_file_system_kind (void)
+     {
+       if (gdbarch_has_dos_based_file_system (target_gdbarch ()))
+ 	return file_system_kind_dos_based;
++#ifdef ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM	
+ 	  else if (gdbarch_has_amiga_based_file_system (target_gdbarch ()))
+ 	return file_system_kind_amigaos_based;
++#endif	
+       else
+ 	return file_system_kind_unix;
+     }
+@@ -57,8 +63,10 @@ target_lbasename (const char *kind, const char *name)
+ {
+   if (kind == file_system_kind_dos_based)
+     return dos_lbasename (name);
++#ifdef ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM	
+   else if (kind == file_system_kind_amigaos_based)
+     return amiga_lbasename (name);
++#endif
+   else
+     return unix_lbasename (name);
+ }
+@@ -92,6 +100,7 @@ _initialize_filesystem ()
+ 			&target_file_system_kind, _("\
+ Set assumed file system kind for target reported file names."), _("\
+ Show assumed file system kind for target reported file names."),
++#ifdef ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM
+ 			_("\
+ If `unix', target file names (e.g., loaded shared library file names)\n\
+ starting the forward slash (`/') character are considered absolute,\n\
+@@ -104,6 +113,17 @@ by a colon (e.g., `sys:'), are also considered absolute, and the\n\
+ directory separator character is the forward slash (`/'). Set to\n\
+ `auto' (which is the default), to let GDB decide, based on its\n\
+ knowledge of the target operating system."),
++#else
++			_("\
++If `unix', target file names (e.g., loaded shared library file names)\n\
++starting the forward slash (`/') character are considered absolute,\n\
++and the directory separator character is the forward slash (`/').  If\n\
++`dos-based', target file names starting with a drive letter followed\n\
++by a colon (e.g., `c:'), are also considered absolute, and the\n\
++backslash (`\\') is also considered a directory separator. Set to\n\
++`auto' (which is the default), to let GDB decide, based on its\n\
++knowledge of the target operating system."),
++#endif
+ 			NULL, /* setfunc */
+ 			show_target_file_system_kind_command,
+ 			&setlist, &showlist);
+diff --git a/gdb/filesystem.h b/gdb/filesystem.h
+index 7e2994b8183..176911aeef9 100644
+--- a/gdb/filesystem.h
++++ b/gdb/filesystem.h
+@@ -29,26 +29,44 @@ extern const char *target_file_system_kind;
+ /* Same as IS_DIR_SEPARATOR but with file system kind KIND's
+    semantics, instead of host semantics.  */
+ 
++#ifdef ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM
+ #define IS_TARGET_DIR_SEPARATOR(kind, c)				\
+   (((kind) == file_system_kind_dos_based) ? IS_DOS_DIR_SEPARATOR (c) \
+    : ((kind) == file_system_kind_amigaos_based) ? IS_AMIGOS_DIR_SEPARATOR(c) \
+    : IS_UNIX_DIR_SEPARATOR (c))
++#else
++#define IS_TARGET_DIR_SEPARATOR(kind, c)				\
++  (((kind) == file_system_kind_dos_based) ? IS_DOS_DIR_SEPARATOR (c) \
++   : IS_UNIX_DIR_SEPARATOR (c))
++#endif
+ 
+ /* Same as IS_ABSOLUTE_PATH but with file system kind KIND's
+    semantics, instead of host semantics.  */
+ 
++#ifdef ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM
+ #define IS_TARGET_ABSOLUTE_PATH(kind, p)				\
+   (((kind) == file_system_kind_dos_based) ? IS_DOS_ABSOLUTE_PATH (p) \
+    : ((kind) == file_system_kind_amigaos_based) ? IS_AMIGOS_ABSOLUTE_PATH(p) \
+    : IS_UNIX_ABSOLUTE_PATH (p))
++#else
++#define IS_TARGET_ABSOLUTE_PATH(kind, p)				\
++  (((kind) == file_system_kind_dos_based) ? IS_DOS_ABSOLUTE_PATH (p) \
++   : IS_UNIX_ABSOLUTE_PATH (p))
++#endif
+ 
+ /* Same as HAS_DRIVE_SPEC but with file system kind KIND's semantics,
+    instead of host semantics.  */
+ 
++#ifdef ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM
+ #define HAS_TARGET_DRIVE_SPEC(kind, p)					\
+   (((kind) == file_system_kind_dos_based) ? HAS_DOS_DRIVE_SPEC (p) \
+    : ((kind) == file_system_kind_amigaos_based) ? HAS_AMIGOS_DRIVE_SPEC(p) \
+    : 0)
++#else
++#define HAS_TARGET_DRIVE_SPEC(kind, p)					\
++  (((kind) == file_system_kind_dos_based) ? HAS_DOS_DRIVE_SPEC (p) \
++   : 0)
++#endif
+ 
+ /* Same as lbasename, but with file system kind KIND's semantics,
+    instead of host semantics.  */
+diff --git a/gdb/gdb.c b/gdb/gdb.c
+index c540f558af6..62e0495f25c 100644
+--- a/gdb/gdb.c
++++ b/gdb/gdb.c
+@@ -23,6 +23,10 @@
+ int
+ main (int argc, char **argv)
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++	
+   struct captured_main_args args;
+ 
+   memset (&args, 0, sizeof args);
+diff --git a/gdb/source.c b/gdb/source.c
+index fabe869802b..fe3c60d2489 100644
+--- a/gdb/source.c
++++ b/gdb/source.c
+@@ -831,7 +831,7 @@ openp (const char *path, openp_flags opts, const char *string,
+     }
+ 
+   if (!path)
+-  #if defined(__amigaos4__) 
++  #if defined(__amigaos4__) && defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
+     path = "\"\"";
+   #else
+     path = ".";
+diff --git a/gdbsupport/host-defs.h b/gdbsupport/host-defs.h
+index e7deafff6a7..b922a6a9f11 100644
+--- a/gdbsupport/host-defs.h
++++ b/gdbsupport/host-defs.h
+@@ -54,8 +54,10 @@
+ # define CANT_FORK
+ # undef HAVE_POLL
+ # undef HAVE_SOCKETPAIR
++#ifdef ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM
+ # define DIRNAME_SEPARATOR ';'
+ #endif
++#endif
+ 
+ #ifndef DIRNAME_SEPARATOR
+ #define DIRNAME_SEPARATOR ':'
+diff --git a/gprof/gprof.c b/gprof/gprof.c
+index 9392575f747..984738dcff6 100644
+--- a/gprof/gprof.c
++++ b/gprof/gprof.c
+@@ -183,6 +183,10 @@ Usage: %s [-[abcDhilLrsTvwxyz]] [-[ABCeEfFJnNOpPqQRStZ][name]] [-I dirs]\n\
+ int
+ main (int argc, char **argv)
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++	
+   char **sp, *str;
+   Sym **cg = 0;
+   int ch, user_specified = 0;
+diff --git a/include/filenames.h b/include/filenames.h
+index 3a12e2d025d..8b3c07ab590 100644
+--- a/include/filenames.h
++++ b/include/filenames.h
+@@ -43,7 +43,7 @@ extern "C" {
+ #  define HAS_DRIVE_SPEC(f) HAS_DOS_DRIVE_SPEC (f)
+ #  define IS_DIR_SEPARATOR(c) IS_DOS_DIR_SEPARATOR (c)
+ #  define IS_ABSOLUTE_PATH(f) IS_DOS_ABSOLUTE_PATH (f)
+-#elif defined(__amigaos4__)
++#elif defined(__amigaos4__) && defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
+ #  ifndef HAVE_AMIGA_BASED_FILE_SYSTEM
+ #    define HAVE_AMIGA_BASED_FILE_SYSTEM 1
+ #  endif
+@@ -73,7 +73,7 @@ extern "C" {
+ 
+ /* Remove the drive spec from F, assuming HAS_DRIVE_SPEC (f).
+    The result is a pointer to the remainder of F.  */
+-#if defined(__amigaos4__)
++#if defined(__amigaos4__) && defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
+ #define STRIP_DRIVE_SPEC(f)	(index( &(f)[0],':') + 1 )
+ #else
+ #define STRIP_DRIVE_SPEC(f)	((f) + 2)
+@@ -83,9 +83,11 @@ extern "C" {
+ #define IS_DOS_ABSOLUTE_PATH(f) IS_ABSOLUTE_PATH_1 (1, f)
+ #define HAS_DOS_DRIVE_SPEC(f) HAS_DRIVE_SPEC_1 (1, f)
+ 
++#ifdef ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM
+ #define IS_AMIGOS_DIR_SEPARATOR(c) ( ((c) == '/') || ((c) == ':') )
+ #define IS_AMIGOS_ABSOLUTE_PATH(f) HAS_AMIGOS_DRIVE_SPEC(f)
+ #define HAS_AMIGOS_DRIVE_SPEC(f) (index (&(f)[0], ':') != NULL ) 
++#endif
+ 
+ #define IS_UNIX_DIR_SEPARATOR(c) IS_DIR_SEPARATOR_1 (0, c)
+ #define IS_UNIX_ABSOLUTE_PATH(f) IS_ABSOLUTE_PATH_1 (0, f)
+diff --git a/ld/ldmain.c b/ld/ldmain.c
+index 308928445fe..80b215de004 100644
+--- a/ld/ldmain.c
++++ b/ld/ldmain.c
+@@ -243,6 +243,10 @@ ld_bfd_error_handler (const char *fmt, va_list ap)
+ int
+ main (int argc, char **argv)
+ {
++#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++  enableUnixPaths();
++#endif
++
+   char *emulation;
+   long start_time = get_run_time ();
+ 
+diff --git a/libiberty/lbasename.c b/libiberty/lbasename.c
+index d1f40818b22..b0f0cbdf273 100644
+--- a/libiberty/lbasename.c
++++ b/libiberty/lbasename.c
+@@ -73,6 +73,7 @@ dos_lbasename (const char *name)
+   return base;
+ }
+ 
++#ifdef ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM
+ const char *
+ amiga_lbasename (const char *name)
+ {
+@@ -90,6 +91,7 @@ amiga_lbasename (const char *name)
+ 
+   return base;
+ }
++#endif
+ 
+ const char *
+ lbasename (const char *name)
+diff --git a/libiberty/make-temp-file.c b/libiberty/make-temp-file.c
+index 5f66abacc55..582796648c7 100644
+--- a/libiberty/make-temp-file.c
++++ b/libiberty/make-temp-file.c
+@@ -156,7 +156,7 @@ choose_tmpdir (void)
+       tmpdir[len] = DIR_SEPARATOR;
+       tmpdir[len+1] = '\0';
+       memoized_tmpdir = tmpdir;
+-#elif __amigaos4__
++#elif __amigaos4__ && defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
+     memoized_tmpdir = xstrdup ("T:");
+ #else /* defined(_WIN32) && !defined(__CYGWIN__) */
+       DWORD len;
+-- 
+2.43.0
+
+
+From 020dca751b93e15884f931170da5952831a77d67 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 13 Jun 2025 18:45:12 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 54/61] 
+ #29 Encoded amiga specifc paths for gdb data, debug, jit-reade auto-load dir
+
+---
+ bfd/configure    |  9 ++++++-
+ bfd/configure.ac |  9 ++++++-
+ gdb/auto-load.c  |  5 ----
+ gdb/configure    | 66 +++++++++++++++++++++++++++++++++++++-----------
+ gdb/configure.ac | 21 +++++++++++++--
+ 5 files changed, 86 insertions(+), 24 deletions(-)
+
+diff --git a/bfd/configure b/bfd/configure
+index a5754abfb0d..1b3a79867a2 100755
+--- a/bfd/configure
++++ b/bfd/configure
+@@ -12024,7 +12024,14 @@ $as_echo "#define USE_MINGW64_LEADING_UNDERSCORES 1" >>confdefs.h
+ 
+ fi
+ 
+-DEBUGDIR=${libdir}/debug
++case "$host" in
++  powerpc-*-amigaos*)
++    DEBUGDIR="SKD:gcc/lib/debug"
++    ;;
++  *)
++	DEBUGDIR=${libdir}/debug
++	;;
++esac
+ 
+ # Check whether --with-separate-debug-dir was given.
+ if test "${with_separate_debug_dir+set}" = set; then :
+diff --git a/bfd/configure.ac b/bfd/configure.ac
+index 352be794f65..52cf139a9bc 100644
+--- a/bfd/configure.ac
++++ b/bfd/configure.ac
+@@ -161,7 +161,14 @@ AS_IF([ test x"$enable_leading_mingw64_underscores" = xyes ],
+   [AC_DEFINE(USE_MINGW64_LEADING_UNDERSCORES, 1,
+     [Define if we should use leading underscore on 64 bit mingw targets])])
+ 
+-DEBUGDIR=${libdir}/debug
++case "$host" in
++  powerpc-*-amigaos*)
++    DEBUGDIR="SKD:gcc/lib/debug"
++    ;;
++  *)
++	DEBUGDIR=${libdir}/debug
++	;;
++esac
+ AC_ARG_WITH(separate-debug-dir,
+   AS_HELP_STRING([--with-separate-debug-dir=DIR],
+                  [Look for global separate debug info in DIR [[default=LIBDIR/debug]]]),
+diff --git a/gdb/auto-load.c b/gdb/auto-load.c
+index 4a577f88219..198bb073a1b 100644
+--- a/gdb/auto-load.c
++++ b/gdb/auto-load.c
+@@ -43,11 +43,6 @@
+ #include "gdbsupport/pathstuff.h"
+ #include "cli/cli-style.h"
+ 
+-#ifdef __amigaos4__
+-#define AUTO_LOAD_DIR "$debugdir;$datadir/auto-load"
+-#define AUTO_LOAD_SAFE_PATH AUTO_LOAD_DIR
+-#endif
+-
+ /* The section to look in for auto-loaded scripts (in file formats that
+    support sections).
+    Each entry in this section is a record that begins with a leading byte
+diff --git a/gdb/configure b/gdb/configure
+index 40dbec7efa4..4d445516431 100755
+--- a/gdb/configure
++++ b/gdb/configure
+@@ -17724,7 +17724,14 @@ if test "${with_gdb_datadir+set}" = set; then :
+   withval=$with_gdb_datadir;
+     GDB_DATADIR=$withval
+ else
+-  GDB_DATADIR=${datadir}/gdb
++	case "$host" in
++		powerpc-*-amigaos*)
++			GDB_DATADIR="SDK:gcc/share/gdb"
++		;;
++    	*)
++			GDB_DATADIR=${datadir}/gdb
++		;;
++	esac
+ fi
+ 
+ 
+@@ -17750,12 +17757,19 @@ _ACEOF
+      test_prefix=$exec_prefix
+   fi
+   value=0
+-  case ${ac_define_dir} in
+-     "${test_prefix}"|"${test_prefix}/"*|\
+-	'${exec_prefix}'|'${exec_prefix}/'*)
+-     value=1
+-     ;;
+-  esac
++  case "$host" in
++    powerpc-*-amigaos*)
++	value=1
++    ;;
++    *)
++    case ${ac_define_dir} in
++		"${test_prefix}"|"${test_prefix}/"*|\
++		'${exec_prefix}'|'${exec_prefix}/'*)
++		value=1
++		;;
++	esac
++	;;
++  esac 
+ 
+ cat >>confdefs.h <<_ACEOF
+ #define GDB_DATADIR_RELOCATABLE $value
+@@ -17790,7 +17804,14 @@ $as_echo_n "checking for default auto-load directory... " >&6; }
+ if test "${with_auto_load_dir+set}" = set; then :
+   withval=$with_auto_load_dir;
+ else
+-  with_auto_load_dir='$debugdir:$datadir/auto-load'
++	case "$host" in
++		powerpc-*-amigaos*)
++			with_auto_load_dir="SKD:gcc/lib/debug;SDK:gcc/share/gdb/auto-load"
++		;;
++    	*)
++			with_auto_load_dir='$debugdir:$datadir/auto-load'
++		;;
++	esac
+ fi
+ 
+ escape_dir=`echo $with_auto_load_dir | sed -e 's/[$]datadir\>/\\\\\\\\\\\\&/g' -e 's/[$]debugdir\>/\\\\\\\\\\\\&/g'`
+@@ -20819,7 +20840,14 @@ if test "${with_jit_reader_dir+set}" = set; then :
+   withval=$with_jit_reader_dir;
+     JIT_READER_DIR=$withval
+ else
+-  JIT_READER_DIR=${libdir}/gdb
++	case "$host" in
++		powerpc-*-amigaos*)
++			JIT_READER_DIR="SDK:gcc/lib/gdb"
++		;;
++    	*)
++			JIT_READER_DIR=${libdir}/gdb
++		;;
++	esac
+ fi
+ 
+ 
+@@ -20845,12 +20873,20 @@ _ACEOF
+      test_prefix=$exec_prefix
+   fi
+   value=0
+-  case ${ac_define_dir} in
+-     "${test_prefix}"|"${test_prefix}/"*|\
+-	'${exec_prefix}'|'${exec_prefix}/'*)
+-     value=1
+-     ;;
+-  esac
++  case "$host" in
++    powerpc-*-amigaos*)
++	value=1
++    ;;
++    *)
++	case ${ac_define_dir} in
++		"${test_prefix}"|"${test_prefix}/"*|\
++		'${exec_prefix}'|'${exec_prefix}/'*)
++		value=1
++		;;
++	esac
++	;;
++  esac 
++ 
+ 
+ cat >>confdefs.h <<_ACEOF
+ #define JIT_READER_DIR_RELOCATABLE $value
+diff --git a/gdb/configure.ac b/gdb/configure.ac
+index 6d749defda5..8036e3b1e5d 100644
+--- a/gdb/configure.ac
++++ b/gdb/configure.ac
+@@ -126,7 +126,15 @@ AC_DEFINE_DIR(BINDIR, bindir, [Directory of programs.])
+ 
+ GDB_AC_WITH_DIR(GDB_DATADIR, gdb-datadir,
+     [look for global separate data files in this path @<:@DATADIR/gdb@:>@],
+-    [${datadir}/gdb])
++    [
++case "$host" in
++	powerpc-*-amigaos*)
++    	"SDK:gcc/share/gdb"
++    ;;
++	*)
++		${datadir}/gdb
++    ;;
++esac])
+ 
+ AC_ARG_WITH(relocated-sources,
+ AS_HELP_STRING([--with-relocated-sources=PATH], [automatically relocate this path for source files]),
+@@ -628,7 +636,16 @@ AC_SEARCH_LIBS(dlopen, dl)
+ 
+ GDB_AC_WITH_DIR([JIT_READER_DIR], [jit-reader-dir],
+                 [directory to load the JIT readers from],
+-                [${libdir}/gdb])
++                [
++case "$host" in
++	powerpc-*-amigaos*)
++		"SDK:gcc/lib/gdb"
++	;;
++	*)
++		${libdir}/gdb
++	;;
++esac])
++
+ 
+ AC_ARG_WITH(expat,
+   AS_HELP_STRING([--with-expat], [include expat support (auto/yes/no)]),
+-- 
+2.43.0
+
+
+From d7110a726b9eee92be7f54df9d25d9c4d688f2b9 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 15 Jun 2025 12:37:17 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 55/61] 
+ #29 Fixed type in SDK assigne
+
+---
+ bfd/configure    | 2 +-
+ bfd/configure.ac | 2 +-
+ gdb/configure    | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/bfd/configure b/bfd/configure
+index 1b3a79867a2..5368917beed 100755
+--- a/bfd/configure
++++ b/bfd/configure
+@@ -12026,7 +12026,7 @@ fi
+ 
+ case "$host" in
+   powerpc-*-amigaos*)
+-    DEBUGDIR="SKD:gcc/lib/debug"
++    DEBUGDIR="SDK:gcc/lib/debug"
+     ;;
+   *)
+ 	DEBUGDIR=${libdir}/debug
+diff --git a/bfd/configure.ac b/bfd/configure.ac
+index 52cf139a9bc..0b75fcb02e9 100644
+--- a/bfd/configure.ac
++++ b/bfd/configure.ac
+@@ -163,7 +163,7 @@ AS_IF([ test x"$enable_leading_mingw64_underscores" = xyes ],
+ 
+ case "$host" in
+   powerpc-*-amigaos*)
+-    DEBUGDIR="SKD:gcc/lib/debug"
++    DEBUGDIR="SDK:gcc/lib/debug"
+     ;;
+   *)
+ 	DEBUGDIR=${libdir}/debug
+diff --git a/gdb/configure b/gdb/configure
+index 4d445516431..3a386bff7fd 100755
+--- a/gdb/configure
++++ b/gdb/configure
+@@ -17806,7 +17806,7 @@ if test "${with_auto_load_dir+set}" = set; then :
+ else
+ 	case "$host" in
+ 		powerpc-*-amigaos*)
+-			with_auto_load_dir="SKD:gcc/lib/debug;SDK:gcc/share/gdb/auto-load"
++			with_auto_load_dir="SDK:gcc/lib/debug;SDK:gcc/share/gdb/auto-load"
+ 		;;
+     	*)
+ 			with_auto_load_dir='$debugdir:$datadir/auto-load'
+-- 
+2.43.0
+
+
+From 6ade2ccb06908eebb55c08726fbe0d11e2aaa7a3 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 15 Jun 2025 13:55:19 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 56/61] 
+ #29 Adjusted additional places where DEBUGDIR is defined for amigaos
+
+---
+ binutils/dwarf.c |  4 ++++
+ gdb/configure    |  9 ++++++++-
+ gdb/configure.ac | 10 +++++++++-
+ 3 files changed, 21 insertions(+), 2 deletions(-)
+
+diff --git a/binutils/dwarf.c b/binutils/dwarf.c
+index 281a055a6d5..481002b97c9 100644
+--- a/binutils/dwarf.c
++++ b/binutils/dwarf.c
+@@ -11514,8 +11514,12 @@ load_separate_debug_info (const char *            main_filename,
+   canon_dir[canon_dirlen] = '\0';
+ 
+ #ifndef DEBUGDIR
++#if __amigaos4__
++#define DEBUGDIR "SDK:gcc/lib/debug"
++#else
+ #define DEBUGDIR "/lib/debug"
+ #endif
++#endif
+ #ifndef EXTRA_DEBUG_ROOT1
+ #define EXTRA_DEBUG_ROOT1 "/usr/lib/debug"
+ #endif
+diff --git a/gdb/configure b/gdb/configure
+index 3a386bff7fd..25ab754d359 100755
+--- a/gdb/configure
++++ b/gdb/configure
+@@ -17657,7 +17657,14 @@ if test "${with_separate_debug_dir+set}" = set; then :
+   withval=$with_separate_debug_dir;
+     DEBUGDIR=$withval
+ else
+-  DEBUGDIR=${libdir}/debug
++	case "$host" in
++	powerpc-*-amigaos*)
++		DEBUGDIR="SDK:gcc/lib/debug"
++		;;
++	*)
++		DEBUGDIR=${libdir}/debug
++		;;
++	esac
+ fi
+ 
+ 
+diff --git a/gdb/configure.ac b/gdb/configure.ac
+index 8036e3b1e5d..1177011f738 100644
+--- a/gdb/configure.ac
++++ b/gdb/configure.ac
+@@ -112,7 +112,15 @@ AC_SUBST(MAKEINFO_EXTRA_FLAGS)
+ 
+ GDB_AC_WITH_DIR(DEBUGDIR, separate-debug-dir,
+     [look for global separate debug info in this path @<:@LIBDIR/debug@:>@],
+-    [${libdir}/debug])
++    [
++case "$host" in
++powerpc-*-amigaos*)
++	DEBUGDIR="SDK:gcc/lib/debug"
++	;;
++*)
++	DEBUGDIR=${libdir}/debug
++	;;
++esac])
+ 
+ # We can't pass paths as command line arguments.
+ # Mingw32 tries to be clever and will convert the paths for us.
+-- 
+2.43.0
+
+
+From 811241da55248e705f0ce6a65ff647b08c408d89 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Sun, 15 Jun 2025 14:44:33 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 57/61] 
+ #18 Additional some improvments in path handling targeting ppc-amigaos
+
+---
+ gdb/gdb.c                     |  4 ----
+ gdbsupport/common-inferior.cc |  8 ++++----
+ gdbsupport/pathstuff.cc       | 17 +++++++++++++++++
+ 3 files changed, 21 insertions(+), 8 deletions(-)
+
+diff --git a/gdb/gdb.c b/gdb/gdb.c
+index 62e0495f25c..c540f558af6 100644
+--- a/gdb/gdb.c
++++ b/gdb/gdb.c
+@@ -23,10 +23,6 @@
+ int
+ main (int argc, char **argv)
+ {
+-#if defined(__amigaos4__) && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
+-  enableUnixPaths();
+-#endif
+-	
+   struct captured_main_args args;
+ 
+   memset (&args, 0, sizeof args);
+diff --git a/gdbsupport/common-inferior.cc b/gdbsupport/common-inferior.cc
+index b48dc4f0639..7b32b67f701 100644
+--- a/gdbsupport/common-inferior.cc
++++ b/gdbsupport/common-inferior.cc
+@@ -39,10 +39,10 @@ construct_inferior_arguments (gdb::array_view<char * const> argv)
+ 	 Windows shells.  */
+       static const char special[] = "\"!&*|[]{}<>?`~^=;, \t\n";
+       static const char quote = '"';
+-#elif __amigaos4__
+-      /* This holds all the characters considered special to the
+-	 Amiga shells. Currently copy of unix */
+-      static const char special[] = "\"!#$&*()\\|[]{}<>?'`~^; \t\n";
++#elif __amigaos4__ && !defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++      /* ML: TODO: This holds all the characters considered special to the
++	 Amiga shells. Currently copy of unix plus : mins ~??? */
++      static const char special[] = "\"!#$&*()\\|[]{}<>'`~^;: \t\n";
+       static const char quote = '"';
+ #else
+       /* This holds all the characters considered special to the
+diff --git a/gdbsupport/pathstuff.cc b/gdbsupport/pathstuff.cc
+index 4a8f4719324..3439d6f38f7 100644
+--- a/gdbsupport/pathstuff.cc
++++ b/gdbsupport/pathstuff.cc
+@@ -129,8 +129,11 @@ gdb_abspath (const char *path)
+ {
+   gdb_assert (path != NULL && path[0] != '\0');
+ 
++// TODO: ML: AmigaOS doesn have sometghing like ~, or let it expand to HOME: ??
++#ifndef __amigaos4__
+   if (path[0] == '~')
+     return gdb_tilde_expand (path);
++#endif
+ 
+   if (IS_ABSOLUTE_PATH (path) || current_directory == NULL)
+     return path;
+@@ -202,6 +205,20 @@ path_join (gdb::array_view<const char *> paths)
+       if (i > 0)
+ 	gdb_assert (strlen (path) == 0 || !IS_ABSOLUTE_PATH (path));
+ 
++#if defined(__amigaos4__)
++	  // ML: Check if the first path is root and must be converted to an Assign
++	  if( i == 0 && path[i] == '/')
++	 {
++	    char *str = (char *)paths[i];
++		int shift = 1;
++		for( ;str[shift] != '\0';shift++ )
++		{
++			str[ shift - 1 ] = str[shift];
++		}
++		str[ shift - 1] = ':';
++	 }	   
++#endif
++
+       if (!ret.empty () && !IS_DIR_SEPARATOR (ret.back ()))
+ 	  ret += '/';
+ 
+-- 
+2.43.0
+
+
+From cea68e87be0b7653aa7793e4bc60c4b6c1e889ae Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Mon, 16 Jun 2025 12:54:52 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 58/61] 
+ Fixed compiler warnings
+
+---
+ gdb/ppc-amigaos-nat.c | 10 +++++-----
+ include/filenames.h   |  6 +++++-
+ 2 files changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/gdb/ppc-amigaos-nat.c b/gdb/ppc-amigaos-nat.c
+index 9c405b93910..67701a6f34f 100644
+--- a/gdb/ppc-amigaos-nat.c
++++ b/gdb/ppc-amigaos-nat.c
+@@ -450,7 +450,7 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 			ourstatus->set_exited (0);
+ 
+-			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%08x\n"),__func__,__LINE__,ptid ).c_str());
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%s\n"),__func__,__LINE__,phex_nz (ptid.tid (),sizeof (ULONGEST)) ).c_str());
+ 
+ 			return ptid;
+ 		}
+@@ -463,7 +463,7 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 			ourstatus->set_stopped (GDB_SIGNAL_TRAP);
+ 
+-			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%08x\n"),__func__,__LINE__,ptid ).c_str());
++			IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%s\n"),__func__,__LINE__,phex_nz (ptid.tid (),sizeof (ULONGEST)) ).c_str());
+ 
+ 			return ptid;
+ 		}
+@@ -518,7 +518,7 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 							free_message (debuggerMessage);
+ 
+-							IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%08x\n"),__func__,__LINE__,ptid ).c_str());
++							IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%s\n"),__func__,__LINE__,phex_nz (ptid.tid (),sizeof (ULONGEST)) ).c_str());
+ 
+ 							return ptid;
+ 						}
+@@ -584,14 +584,14 @@ ppc_amigaos_nat_target::wait (ptid_t ptid, struct target_waitstatus *ourstatus,t
+ 
+ 				free_message (debuggerMessage);
+ 				
+-				IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%08x\n"),__func__,__LINE__,ptid ).c_str());
++				IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%s\n"),__func__,__LINE__,phex_nz (ptid.tid (),sizeof (ULONGEST)) ).c_str());
+ 
+ 				return ptid;
+ 			}		
+ 		}
+ 	}
+ 
+-	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%08x\n"),__func__,__LINE__,ptid_t::make_minus_one () ).c_str());
++	IExec->DebugPrintF ( string_printf (_("[GDB] %s@%d Leaving with ptid: 0x%s\n"),__func__,__LINE__,phex_nz (ptid_t::make_minus_one ().tid (),sizeof (ULONGEST)) ).c_str());
+ 
+ 	return ptid_t::make_minus_one ();
+ }
+diff --git a/include/filenames.h b/include/filenames.h
+index 8b3c07ab590..da94b3328cb 100644
+--- a/include/filenames.h
++++ b/include/filenames.h
+@@ -28,6 +28,10 @@ Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.
+ 
+ #include "hashtab.h" /* for hashval_t */
+ 
++#if defined(__amigaos4__) && defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
++#include <string.h>
++#endif
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+@@ -74,7 +78,7 @@ extern "C" {
+ /* Remove the drive spec from F, assuming HAS_DRIVE_SPEC (f).
+    The result is a pointer to the remainder of F.  */
+ #if defined(__amigaos4__) && defined(ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM)
+-#define STRIP_DRIVE_SPEC(f)	(index( &(f)[0],':') + 1 )
++#define STRIP_DRIVE_SPEC(f)	(strchr( &(f)[0],':') + 1 )
+ #else
+ #define STRIP_DRIVE_SPEC(f)	((f) + 2)
+ #endif
+-- 
+2.43.0
+
+
+From 8340bd4026a53b3957526a2579a3ad74ccdb6536 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 4 Jul 2025 15:40:40 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 59/61] 
+ #29 Added addtional logic for amiga paths in gnulib
+
+---
+ gnulib/import/filename.h | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/gnulib/import/filename.h b/gnulib/import/filename.h
+index ab77ca2df91..74b2dba2594 100644
+--- a/gnulib/import/filename.h
++++ b/gnulib/import/filename.h
+@@ -88,6 +88,14 @@ extern "C" {
+ # define IS_FILE_NAME_WITH_DIR(Filename) \
+     (strchr ((Filename), '/') != NULL || strchr ((Filename), '\\') != NULL \
+      || HAS_DEVICE (Filename))
++#elif defined __amigaos4__ && ENABLE_HAVE_AMIGA_BASED_FILE_SYSTEM
++# define ISSLASH(C) ((C) == '/')
++# define HAS_DEVICE(Filename) (strchr ((Filename), ':') != NULL)
++# define FILE_SYSTEM_PREFIX_LEN(Filename) ((strchr ((Filename), ':') - (Filename)) + 1)
++# define FILE_SYSTEM_DRIVE_PREFIX_CAN_BE_RELATIVE 0
++# define IS_ABSOLUTE_FILE_NAME(Filename) (HAS_DEVICE (Filename))
++# define IS_RELATIVE_FILE_NAME(Filename) (! IS_ABSOLUTE_FILE_NAME (Filename))
++# define IS_FILE_NAME_WITH_DIR(Filename) (strchr ((Filename), '/') != NULL)
+ #else
+   /* Unix */
+ # define ISSLASH(C) ((C) == '/')
+-- 
+2.43.0
+
+
+From 00b01d75402fba503fa353de930e9b53270e7c0a Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 4 Jul 2025 15:41:39 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 60/61] 
+ #29 Tweaked build system to use canoniclize_file_name from clib4 targeting
+ amigaos (req. > v1.6 of clib4)
+
+---
+ gnulib/configure                 | 63 +++++++++++++++-----------------
+ gnulib/import/m4/canonicalize.m4 | 20 ++++++++--
+ gnulib/import/m4/gnulib-comp.m4  |  1 -
+ 3 files changed, 46 insertions(+), 38 deletions(-)
+
+diff --git a/gnulib/configure b/gnulib/configure
+index aaa4b6c0801..ae64507a1e9 100644
+--- a/gnulib/configure
++++ b/gnulib/configure
+@@ -13815,8 +13815,8 @@ rm -f core conftest.err conftest.$ac_objext \
+         LIBS=$save_LIBS
+         test $gl_pthread_api = yes && break
+       done
+-      echo "$as_me:13816: gl_pthread_api=$gl_pthread_api" >&5
+-      echo "$as_me:13817: LIBPTHREAD=$LIBPTHREAD" >&5
++      echo "$as_me:${as_lineno-$LINENO}: gl_pthread_api=$gl_pthread_api" >&5
++      echo "$as_me:${as_lineno-$LINENO}: LIBPTHREAD=$LIBPTHREAD" >&5
+ 
+       gl_pthread_in_glibc=no
+       # On Linux with glibc >= 2.34, libc contains the fully functional
+@@ -13841,7 +13841,7 @@ rm -f conftest*
+ 
+           ;;
+       esac
+-      echo "$as_me:13842: gl_pthread_in_glibc=$gl_pthread_in_glibc" >&5
++      echo "$as_me:${as_lineno-$LINENO}: gl_pthread_in_glibc=$gl_pthread_in_glibc" >&5
+ 
+       # Test for libpthread by looking for pthread_kill. (Not pthread_self,
+       # since it is defined as a macro on OSF/1.)
+@@ -13995,7 +13995,7 @@ fi
+ 
+         fi
+       fi
+-      echo "$as_me:13996: LIBPMULTITHREAD=$LIBPMULTITHREAD" >&5
++      echo "$as_me:${as_lineno-$LINENO}: LIBPMULTITHREAD=$LIBPMULTITHREAD" >&5
+     fi
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether POSIX threads API is available" >&5
+ $as_echo_n "checking whether POSIX threads API is available... " >&6; }
+@@ -17072,8 +17072,8 @@ rm -f core conftest.err conftest.$ac_objext \
+         LIBS=$save_LIBS
+         test $gl_pthread_api = yes && break
+       done
+-      echo "$as_me:17073: gl_pthread_api=$gl_pthread_api" >&5
+-      echo "$as_me:17074: LIBPTHREAD=$LIBPTHREAD" >&5
++      echo "$as_me:${as_lineno-$LINENO}: gl_pthread_api=$gl_pthread_api" >&5
++      echo "$as_me:${as_lineno-$LINENO}: LIBPTHREAD=$LIBPTHREAD" >&5
+ 
+       gl_pthread_in_glibc=no
+       # On Linux with glibc >= 2.34, libc contains the fully functional
+@@ -17098,7 +17098,7 @@ rm -f conftest*
+ 
+           ;;
+       esac
+-      echo "$as_me:17099: gl_pthread_in_glibc=$gl_pthread_in_glibc" >&5
++      echo "$as_me:${as_lineno-$LINENO}: gl_pthread_in_glibc=$gl_pthread_in_glibc" >&5
+ 
+       # Test for libpthread by looking for pthread_kill. (Not pthread_self,
+       # since it is defined as a macro on OSF/1.)
+@@ -17252,7 +17252,7 @@ fi
+ 
+         fi
+       fi
+-      echo "$as_me:17253: LIBPMULTITHREAD=$LIBPMULTITHREAD" >&5
++      echo "$as_me:${as_lineno-$LINENO}: LIBPMULTITHREAD=$LIBPMULTITHREAD" >&5
+     fi
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether POSIX threads API is available" >&5
+ $as_echo_n "checking whether POSIX threads API is available... " >&6; }
+@@ -17478,8 +17478,8 @@ rm -f core conftest.err conftest.$ac_objext \
+         LIBS=$save_LIBS
+         test $gl_pthread_api = yes && break
+       done
+-      echo "$as_me:17479: gl_pthread_api=$gl_pthread_api" >&5
+-      echo "$as_me:17480: LIBPTHREAD=$LIBPTHREAD" >&5
++      echo "$as_me:${as_lineno-$LINENO}: gl_pthread_api=$gl_pthread_api" >&5
++      echo "$as_me:${as_lineno-$LINENO}: LIBPTHREAD=$LIBPTHREAD" >&5
+ 
+       gl_pthread_in_glibc=no
+       # On Linux with glibc >= 2.34, libc contains the fully functional
+@@ -17504,7 +17504,7 @@ rm -f conftest*
+ 
+           ;;
+       esac
+-      echo "$as_me:17505: gl_pthread_in_glibc=$gl_pthread_in_glibc" >&5
++      echo "$as_me:${as_lineno-$LINENO}: gl_pthread_in_glibc=$gl_pthread_in_glibc" >&5
+ 
+       # Test for libpthread by looking for pthread_kill. (Not pthread_self,
+       # since it is defined as a macro on OSF/1.)
+@@ -17658,7 +17658,7 @@ fi
+ 
+         fi
+       fi
+-      echo "$as_me:17659: LIBPMULTITHREAD=$LIBPMULTITHREAD" >&5
++      echo "$as_me:${as_lineno-$LINENO}: LIBPMULTITHREAD=$LIBPMULTITHREAD" >&5
+     fi
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether POSIX threads API is available" >&5
+ $as_echo_n "checking whether POSIX threads API is available... " >&6; }
+@@ -22785,7 +22785,14 @@ $as_echo "$gl_cv___builtin_expect" >&6; }
+ 
+ 
+   if test $ac_cv_func_canonicalize_file_name = no; then
+-    HAVE_CANONICALIZE_FILE_NAME=0
++    case "$host_os" in
++      amigaos*)
++        HAVE_CANONICALIZE_FILE_NAME=1
++        ;;
++      *)
++        HAVE_CANONICALIZE_FILE_NAME=0
++        ;;
++    esac
+     if test $ac_cv_func_realpath = no; then
+       HAVE_REALPATH=0
+     else
+@@ -22799,8 +22806,15 @@ $as_echo "$gl_cv___builtin_expect" >&6; }
+       *yes)
+         ;;
+       *)
+-        REPLACE_CANONICALIZE_FILE_NAME=1
+-        REPLACE_REALPATH=1
++        case "$host_os" in
++          amigaos*)
++            # Do not replace on AmigaOS
++            ;;
++          *)
++            REPLACE_CANONICALIZE_FILE_NAME=1
++            REPLACE_REALPATH=1
++            ;;
++       esac
+         ;;
+     esac
+   fi
+@@ -22835,25 +22849,6 @@ _ACEOF
+ 
+ 
+ 
+-          GL_GNULIB_CANONICALIZE_FILE_NAME=1
+-
+-
+-
+-
+-
+-$as_echo "#define GNULIB_TEST_CANONICALIZE_FILE_NAME 1" >>confdefs.h
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+           GL_GNULIB_REALPATH=1
+ 
+ 
+diff --git a/gnulib/import/m4/canonicalize.m4 b/gnulib/import/m4/canonicalize.m4
+index b55d5c06e26..5a4940bdd99 100644
+--- a/gnulib/import/m4/canonicalize.m4
++++ b/gnulib/import/m4/canonicalize.m4
+@@ -31,7 +31,14 @@ AC_DEFUN([gl_CANONICALIZE_LGPL],
+   AC_REQUIRE([gl_STDLIB_H_DEFAULTS])
+   AC_REQUIRE([gl_CANONICALIZE_LGPL_SEPARATE])
+   if test $ac_cv_func_canonicalize_file_name = no; then
+-    HAVE_CANONICALIZE_FILE_NAME=0
++    case "$host_os" in
++      amigaos*)
++        HAVE_CANONICALIZE_FILE_NAME=1
++        ;;
++      *)
++        HAVE_CANONICALIZE_FILE_NAME=0
++        ;;
++    esac
+     if test $ac_cv_func_realpath = no; then
+       HAVE_REALPATH=0
+     else
+@@ -45,8 +52,15 @@ AC_DEFUN([gl_CANONICALIZE_LGPL],
+       *yes)
+         ;;
+       *)
+-        REPLACE_CANONICALIZE_FILE_NAME=1
+-        REPLACE_REALPATH=1
++        case "$host_os" in
++          amigaos*)
++           # Do not replace on AmigaOS
++            ;;
++          *)
++            REPLACE_CANONICALIZE_FILE_NAME=1
++            REPLACE_REALPATH=1
++            ;;
++       esac
+         ;;
+     esac
+   fi
+diff --git a/gnulib/import/m4/gnulib-comp.m4 b/gnulib/import/m4/gnulib-comp.m4
+index 94e2cfe1a52..5e95e440feb 100644
+--- a/gnulib/import/m4/gnulib-comp.m4
++++ b/gnulib/import/m4/gnulib-comp.m4
+@@ -288,7 +288,6 @@ AC_DEFUN([gl_INIT],
+   gl_CONDITIONAL([GL_COND_OBJ_CANONICALIZE_LGPL],
+                  [test $HAVE_CANONICALIZE_FILE_NAME = 0 || test $REPLACE_CANONICALIZE_FILE_NAME = 1])
+   gl_MODULE_INDICATOR([canonicalize-lgpl])
+-  gl_STDLIB_MODULE_INDICATOR([canonicalize_file_name])
+   gl_STDLIB_MODULE_INDICATOR([realpath])
+   gl_UNISTD_MODULE_INDICATOR([chdir])
+   gl_FUNC_CHDIR_LONG
+-- 
+2.43.0
+
+
+From 6a88508e12c5b5c674caad2ee4bd2441f11a5b00 Mon Sep 17 00:00:00 2001
+From: MigthyMax <migthymax1977@gmail.com>
+Date: Fri, 4 Jul 2025 15:42:03 +0200
+Subject: [[PATCH] Changes for compiling binutils 2.40 for AmigaOS 4 using clib4 61/61] 
+ Fixed methods signature to avoid compile warnings
+
+---
+ libiberty/pex-amigaos.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/libiberty/pex-amigaos.c b/libiberty/pex-amigaos.c
+index 0c61a108764..c0cda087397 100644
+--- a/libiberty/pex-amigaos.c
++++ b/libiberty/pex-amigaos.c
+@@ -47,13 +47,13 @@ extern int errno;
+ #endif
+ 
+ static int pex_amiga_open_read (struct pex_obj *, const char *, int);
+-static int pex_amiga_open_write (struct pex_obj *, const char *, int);
++static int pex_amiga_open_write (struct pex_obj *, const char *, int, int);
+ static pid_t pex_amiga_exec_child (struct pex_obj *, int, const char *,
+ 				 char * const *, char * const *,
+ 				 int, int, int, int,
+ 				 const char **, int *);
+ static int pex_amiga_close (struct pex_obj *, int);
+-static int pex_amiga_wait (struct pex_obj *, long, int *, struct pex_time *,
++static pid_t pex_amiga_wait (struct pex_obj *, pid_t, int *, struct pex_time *,
+ 			   int, const char **, int *);
+ static FILE *pex_amiga_fdopenr (struct pex_obj *, int, int);
+ static FILE *pex_amiga_fdopenw (struct pex_obj *, int, int);
+@@ -96,7 +96,7 @@ pex_amiga_open_read (struct pex_obj *obj ATTRIBUTE_UNUSED, const char *name,
+ 
+ static int
+ pex_amiga_open_write (struct pex_obj *obj ATTRIBUTE_UNUSED, const char *name,
+-		     int binary ATTRIBUTE_UNUSED)
++		     int binary ATTRIBUTE_UNUSED, int append ATTRIBUTE_UNUSED)
+ {
+   /* Note that we can't use O_EXCL here because gcc may have already
+      created the temporary file via make_temp_file.  */
+@@ -307,8 +307,8 @@ pex_amiga_fdopenw (struct pex_obj *obj ATTRIBUTE_UNUSED, int fd,
+    has already completed, and we just need to return the exit
+    status.  */
+ 
+-static int
+-pex_amiga_wait (struct pex_obj *obj, long pid, int *status,
++static pid_t
++pex_amiga_wait (struct pex_obj *obj, pid_t pid, int *status,
+ 		struct pex_time *time, int done ATTRIBUTE_UNUSED,
+ 		const char **errmsg ATTRIBUTE_UNUSED,
+ 		int *err ATTRIBUTE_UNUSED)
 -- 
 2.43.0
 


### PR DESCRIPTION
I have no idea if I correctly created the patch file. What makes me somehow suspicious is that in the patch file for every commit at the end the line `2.43.0` appears, no idea where it comes from!

To build a native binutils (without working gdb), it is recommended to use the docker image ` walkero/amigagccondocker:os4-gcc11` and within that running container performing the following steps as user `amidev`:

```
mkdir native-build
cd mkdir native-build
CFLAGS="-mcrt=clib4 -Wno-sign-compare -gstabs -fno-omit-frame-pointer -lpthread -athread=native" CXXFLAGS="-mcrt=clib4 -Wno-sign-compare -gstabs -fno-omit-frame-pointer -lpthread -athread=native" ../configure --disable-gdb --disable-plugins --disable-sim --disable-nls --host=ppc-amigaos --target=ppc-amigaos --prefix=/opt/code/dist
```

Make sure that the `/opt/code/dist`exits, or adjust it to your needs!

Oh an by the way it needs `clib4` at least version `2.0` 