### PR TITLE
Using unsetenv, fixing the issues with env variables

### DIFF
--- a/gcc/11/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/11/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,7 +1,7 @@
 From ca2bf5421bf1590462978def816d55bdfcaf5ad3 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Feb 2015 20:25:55 +0100
-Subject: [PATCH 01/43] Changes for AmigaOS version of gcc.
+Subject: [PATCH 01/44] Changes for AmigaOS version of gcc.
 
 ---
  fixincludes/configure                 |   1 +
@@ -3506,5 +3506,5 @@ index 6568adfca2089c116ae2cbdfa8c933aa76fdddf8..16fa6bf68690127c7a735979108b1add
  
  #endif // _GLIBCXX_CSTDDEF
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/11/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,7 +1,7 @@
 From d2e9fe9fc44195b75f20b694c649e2a8d26fab80 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 14 Nov 2014 20:03:56 +0100
-Subject: [PATCH 02/43] Added new function attribute "lineartags" and pragma
+Subject: [PATCH 02/44] Added new function attribute "lineartags" and pragma
  "amigaos tagtype".
 
 Functions that have the lineartags attribute are assumed to be functions
@@ -397,5 +397,5 @@ index 5da34e80ef1d7424d53529f11189a8bc53722664..fca3aa8212900da47d323dd01f91e59c
  amigaos_legitimize_baserel_address (rtx addr)
  {
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/11/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,7 +1,7 @@
 From b8836f452e842f755938a27c4e9678310c34333a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 9 Jul 2015 06:54:37 +0200
-Subject: [PATCH 03/43] Disable .machine directive generation.
+Subject: [PATCH 03/44] Disable .machine directive generation.
 
 It breaks manual args to the assembler with different flavor,
 e.g., -Wa,-m440. This is probably not the right fix.
@@ -33,5 +33,5 @@ index 17a24382496bad3794746e783ad9026ae620833a..94e65d8fd7a8471ea9d107e63e2ab99c
  }
  
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/11/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From 36ca277f3a855bad380107cf6a8487e22ddbad08 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 20:56:33 +0100
-Subject: [PATCH 04/43] The default link mode is static for AmigaOS.
+Subject: [PATCH 04/44] The default link mode is static for AmigaOS.
 
 Changed the g++ driver to reflect this.
 ---
@@ -47,5 +47,5 @@ index 984106f10dd108c0bb23ac30df5f5a10abbddf6a..72fac8c105b60ca4a97e913c9437a60f
  	case OPT_static_libstdc__:
  	  library = library >= 0 ? 2 : library;
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/11/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,7 +1,7 @@
 From c434d41595b884251e3897b4838e00c13eef691e Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 21:39:42 +0100
-Subject: [PATCH 05/43] Disable the usage of /dev/urandom when compiling for
+Subject: [PATCH 05/44] Disable the usage of /dev/urandom when compiling for
  AmigaOS.
 
 ---
@@ -67,5 +67,5 @@ index d8cc254adef2677798354697af5d7eb957c03c9a..9856a8009e42f37defb131ea38284dcf
  }
  
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/11/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,7 +1,7 @@
 From 91b3fbe2a997600c2c53450bf57f792c8990cb84 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 5 Dec 2015 13:17:26 +0100
-Subject: [PATCH 06/43] Expand arg zero on AmigaOS using the PROGDIR: assign.
+Subject: [PATCH 06/44] Expand arg zero on AmigaOS using the PROGDIR: assign.
 
 This should make sure that the proper relative paths are computed during
 process_command().
@@ -37,5 +37,5 @@ index edc3164f07213c5507b1802a7df426912af01643..101e209663894896d3ecfb129c0120ca
    set_up_specs ();
    putenv_COLLECT_AS_OPTIONS (assembler_options);
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/11/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,7 +1,7 @@
 From 874697ee4b49ab3671ef95ad8dc6505edde54efb Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 21 Jan 2016 20:46:59 +0100
-Subject: [PATCH 07/43] Some AmigaOS 4.x compability changes for posix thread
+Subject: [PATCH 07/44] Some AmigaOS 4.x compability changes for posix thread
  support.
 
 ---
@@ -81,5 +81,5 @@ index eb8af567cd525b163017d2aea9923744b4b53e86..8c979f07b0a84af4e0f4ea7214554ff4
  {
    if (__gthread_active_p ())
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/11/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From 378f23604f6e797e1bc951ec029f1857cc5d624b Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 22 Jan 2016 20:04:50 +0100
-Subject: [PATCH 08/43] Added libstc++ support for AmigaOS.
+Subject: [PATCH 08/44] Added libstc++ support for AmigaOS.
 
 ---
  .../os/{generic => amigaos}/ctype_base.h      |  0
@@ -246,5 +246,5 @@ index ec32980aa0db898623804980af65dad588e4d9f5..e9789a4981c6fc36c6b660ab768427bb
    cygwin*)
      os_include_dir="os/newlib"
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/11/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,7 +1,7 @@
 From 1c4610e9a877b15560ec4b613411ae5c87ecd579 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 3 Mar 2017 08:52:48 +0100
-Subject: [PATCH 09/43] Enable libatomic for ppc-amigaos.
+Subject: [PATCH 09/44] Enable libatomic for ppc-amigaos.
 
 It is not really finished yet.
 ---
@@ -179,5 +179,5 @@ index 670b0d72cfec2027a02347eb5b62521054f264c4..f78d93afba8849adac23d24b152cf400
  	# If the target supports disabling interrupts, we can work in
  	# kernel-mode, given the system is not multi-processor.
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
+++ b/gcc/11/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
@@ -1,7 +1,7 @@
 From ad2c77934d14882a2452b7d40e495d9c30cb1243 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 23 May 2018 10:54:19 +0200
-Subject: [PATCH 10/43] Implement libat_lock_n() and libat_unlock_n().
+Subject: [PATCH 10/44] Implement libat_lock_n() and libat_unlock_n().
 
 ---
  libatomic/config/amigaos/lock.c | 58 ++++++++++++++++++++++++++-------
@@ -100,5 +100,5 @@ index ffd09f50095429f844bfe6bf7bec8741f56f1a28..82dd696f78cc4afa5592c5fb83f33e91
 -
 -#endif
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/11/patches/0011-Pretend-C99-compatibility.patch
@@ -1,7 +1,7 @@
 From 2c20a0bea404d101bdad3217aca88aba97ef320b Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 4 Mar 2017 07:39:21 +0100
-Subject: [PATCH 11/43] Pretend C99 compatibility.
+Subject: [PATCH 11/44] Pretend C99 compatibility.
 
 At least newlib is not fully C99 compatible because it doesn't expose
 various C99 function if __STRICT_ANSI__ is declared. Also it misses
@@ -108,5 +108,5 @@ index 47b954cf2faca25ffbac6d5b5e81857ad22cad90..99325ad0682f2f88bc04ca38a50cc97a
  } // extern "C++"
  
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/11/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,7 +1,7 @@
 From 475e949574cf50e56642161c9602196c89508f93 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 3 Apr 2018 19:52:01 +0200
-Subject: [PATCH 12/43] Add amigaos-stdint.h for libatomic.
+Subject: [PATCH 12/44] Add amigaos-stdint.h for libatomic.
 
 ---
  gcc/config.gcc                                      | 2 +-
@@ -50,5 +50,5 @@ index cf771b4f614a98d09190c19fad90624c04e5c69d..854009ca098f9dff59be936425a565dd
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/11/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,7 +1,7 @@
 From d56d6316b070dcda6d6129076ee509a36cc385b0 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 22:48:33 +0200
-Subject: [PATCH 13/43] Rerun make maint-deps in libiberty.
+Subject: [PATCH 13/44] Rerun make maint-deps in libiberty.
 
 ---
  libiberty/Makefile.in | 36 ++++++++++++++++++++++--------------
@@ -161,5 +161,5 @@ index f2cdf05edb1b2f92461dbf8c22dc5fb79b8e17c3..8bed1cc0a32ad557dc141ed0efca410e
  	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/xmalloc.c -o noasan/$@; \
  	else true; fi
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/11/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,7 +1,7 @@
 From fdd78fa5061cbba19dfe499f05ef9dbd41c01edc Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 23:50:48 +0200
-Subject: [PATCH 14/43] Add custom implementation of various env-related
+Subject: [PATCH 14/44] Add custom implementation of various env-related
  functions.
 
 No official clib does support unsetenv() but this is required by newer gcc.
@@ -204,5 +204,5 @@ index 0000000000000000000000000000000000000000..6ec12b89c740874d0b7a83f322f80d5c
 +   return lvar->lv_Value;
 +}
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/11/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,7 +1,7 @@
 From 4ee2384d42515dccc28da5a3ab960c82ed31a41f Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 5 Apr 2018 19:56:45 +0200
-Subject: [PATCH 15/43] Define va_startlinear and va_getlinearva.
+Subject: [PATCH 15/44] Define va_startlinear and va_getlinearva.
 
 These were usually defined in the clibs' stdarg.h. As we have now
 changed the include path order, clibs' stdarg.h is never included.
@@ -41,5 +41,5 @@ index 7b6c63237dd81117f5e0e92860a7b266b903f7d9..7127b05e44ac34d31b17125bce4e6e43
     have no conflict with that.  */
  #ifndef _VA_LIST_
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/11/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,7 +1,7 @@
 From da25a17a97d0ba7e41e5ad1e5c537c42fc88a956 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Apr 2018 22:02:09 +0200
-Subject: [PATCH 16/43] Fix r2 restoring in the epilog of baserel-restoring
+Subject: [PATCH 16/44] Fix r2 restoring in the epilog of baserel-restoring
  functions.
 
 ---
@@ -28,5 +28,5 @@ index 1b4fa45f958d26f4b31d612511a93e144b955447..8ab9384442849682a52da127b822d09c
        emit_move_insn (reg, mem);
  
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/11/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,7 +1,7 @@
 From a17366f2505e15901978284d489a4d0c6f119e7c Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 19 Apr 2018 21:00:30 +0200
-Subject: [PATCH 17/43] Avoid section anchors in the baserel mode.
+Subject: [PATCH 17/44] Avoid section anchors in the baserel mode.
 
 ---
  gcc/config/rs6000/amigaos-protos.h |  1 +
@@ -80,5 +80,5 @@ index 3d91ae6dc7c40c75487e26b2e3bd23878b098982..3192daff4ab83071c82f14e99319b92f
  
  #undef INIT_CUMULATIVE_INCOMING_ARGS
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/11/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,7 +1,7 @@
 From 9ed880080d9fc28243939667e169adb4e62adb9f Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 20 Apr 2018 20:04:30 +0200
-Subject: [PATCH 18/43] Respect -nostdinc also for SDK includes.
+Subject: [PATCH 18/44] Respect -nostdinc also for SDK includes.
 
 ---
  gcc/config/rs6000/amigaos.h | 4 +---
@@ -29,5 +29,5 @@ index 3192daff4ab83071c82f14e99319b92fca72ac3a..8536aa48426b68811287e404abf7ffb6
  #define LINK_SPEC "\
  --defsym __amigaos4__=1 \
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0019-Add-_Static_warning.patch
+++ b/gcc/11/patches/0019-Add-_Static_warning.patch
@@ -1,7 +1,7 @@
 From 2aa525318b251d5abaab1f3fbe303fc56d76e306 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 24 Apr 2018 22:46:21 +0200
-Subject: [PATCH 19/43] Add _Static_warning().
+Subject: [PATCH 19/44] Add _Static_warning().
 
 This acts very similar to _Static_assert() but produces a warning
 rather than an compiler error.
@@ -137,5 +137,5 @@ index 4f75f19ac50d5d7647947247459c118a269ae309..cabac1b72d43f630d80d7a4c19e912b6
  				  /*maybe_range_for_decl*/NULL);
  }
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0020-Rename-lineartags-to-checktags.patch
+++ b/gcc/11/patches/0020-Rename-lineartags-to-checktags.patch
@@ -1,7 +1,7 @@
 From 3a5b6349a3186734edcaeb530a6f9dfc4c3b07fa Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 27 Apr 2018 22:48:18 +0200
-Subject: [PATCH 20/43] Rename lineartags to checktags.
+Subject: [PATCH 20/44] Rename lineartags to checktags.
 
 The name lineartags would imply linearvarargs but this is not implemented
 or necessary.
@@ -110,5 +110,5 @@ index 8536aa48426b68811287e404abf7ffb6e071a5bf..1dd078c97addc6768b326f231329c662
  /* Overrides */
  
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
+++ b/gcc/11/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
@@ -1,7 +1,7 @@
 From 4179bb5d123c2a1abb412afab70897e5c5d33b88 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 28 Apr 2018 08:09:58 +0200
-Subject: [PATCH 21/43] Fix order of AmigaOS PPC sections in the documentation.
+Subject: [PATCH 21/44] Fix order of AmigaOS PPC sections in the documentation.
 
 ---
  gcc/doc/extend.texi |  4 ++--
@@ -84,5 +84,5 @@ index dcf676808bf0a6b8bf45bc35e553593b850f76f6..fc5db027e8e823a2626eda0aa42e60d0
  @opindex mcrt
  
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
+++ b/gcc/11/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
@@ -1,7 +1,7 @@
 From bbe6252c1570841d49fe4e91d81b6cfe2fc12b36 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sun, 29 Apr 2018 00:08:22 +0200
-Subject: [PATCH 22/43] Provide a documentation for checktags and tagtype
+Subject: [PATCH 22/44] Provide a documentation for checktags and tagtype
  attributes.
 
 ---
@@ -67,5 +67,5 @@ index 3172fed42dbd8da70eb3ae23b9b12f8dd3d3c51d..9434baee12b6553dee7aa2d3339d7f66
  @cindex Statement Attributes
  
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0023-Adapt-libssp-for-AmigaOS.patch
+++ b/gcc/11/patches/0023-Adapt-libssp-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From 0b073f62e619eae5e3843b3f46353cf358125fe7 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 22 May 2018 23:14:01 +0200
-Subject: [PATCH 23/43] Adapt libssp for AmigaOS.
+Subject: [PATCH 23/44] Adapt libssp for AmigaOS.
 
 ---
  libssp/ssp.c | 8 +++++---
@@ -64,5 +64,5 @@ index 6e911f087f1e6dc32fd5a6a54a54d49fed481e99..e036b6fbb32963387a07a6ff791e6afe
       is dead.  */
    {
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0024-Add-amigaos-thread-model.patch
+++ b/gcc/11/patches/0024-Add-amigaos-thread-model.patch
@@ -1,7 +1,7 @@
 From 4bff5b055ad5872d344c0cbf5f35e2866f1113f0 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 4 May 2018 18:22:24 +0200
-Subject: [PATCH 24/43] Add amigaos thread model.
+Subject: [PATCH 24/44] Add amigaos thread model.
 
 It is work in progress.
 ---
@@ -2003,5 +2003,5 @@ index d182cade8351418e7327e472166aabd130a44465..3a8f2594620ea58f0044505fc2372a29
      posix)	thread_header=gthr-posix.h ;;
      rtems)	thread_header=config/gthr-rtems.h ;;
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
+++ b/gcc/11/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
@@ -1,7 +1,7 @@
 From 60b5e89488df721be18c46c054f30a0a6dc3783c Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 27 Oct 2018 08:06:21 +0200
-Subject: [PATCH 25/43] Add aregparam attribute for functions for the m68k
+Subject: [PATCH 25/44] Add aregparam attribute for functions for the m68k
  backend.
 
 These can be used to pass arguments to directly named registers.
@@ -260,5 +260,5 @@ index 8dfa3a9bb4c8f9ba8eca411bdc46580f0f511ea1..863cc7e967f13256fd3fdeffbd1a9ebd
  #define EXIT_IGNORE_STACK 1
  
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0026-gcc10-Don-t-use-poisoned-define.patch
+++ b/gcc/11/patches/0026-gcc10-Don-t-use-poisoned-define.patch
@@ -1,7 +1,7 @@
 From 14fcabf8e705ee8e976268639e06bb6b7843c2e8 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 17:22:55 +0100
-Subject: [PATCH 26/43] gcc10: Don't use poisoned define.
+Subject: [PATCH 26/44] gcc10: Don't use poisoned define.
 
 ---
  gcc/config/rs6000/amigaos.h | 3 ---
@@ -28,5 +28,5 @@ index eb64a964b83759cd31fd38f3a56a738f33a87f2f..fb0fb13c8f4e789dea40538f4c5b7b2f
  #undef PROCESSOR_DEFAULT
  #define PROCESSOR_DEFAULT PROCESSOR_PPC604e
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0027-gcc10-Remove-unused-variable.patch
+++ b/gcc/11/patches/0027-gcc10-Remove-unused-variable.patch
@@ -1,7 +1,7 @@
 From a75b78f8f64bb2dcece0eaf512e673464945188e Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 17:25:51 +0100
-Subject: [PATCH 27/43] gcc10: Remove unused variable.
+Subject: [PATCH 27/44] gcc10: Remove unused variable.
 
 ---
  gcc/c/c-parser.c | 3 ---
@@ -41,5 +41,5 @@ index 7df9b9f0f5c3e143b8bf375ec0af052e1641c319..a335171dd3eabdcaf933d3d9921fc882
      bool old_flag_plugin_added = flag_plugin_added;
      register_callback ("amigaos-tagtype", PLUGIN_FINISH_DECL,
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0028-gcc10-Remove-tagtype-attribute.patch
+++ b/gcc/11/patches/0028-gcc10-Remove-tagtype-attribute.patch
@@ -1,7 +1,7 @@
 From d4758e059cdf8414ff7af8253aca771bc659929b Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 22:05:59 +0100
-Subject: [PATCH 28/43] gcc10: Remove tagtype attribute.
+Subject: [PATCH 28/44] gcc10: Remove tagtype attribute.
 
 The 'Add tagtype attribute that can be passed to enum' patch needs
 to be adapted. Temporarily disable the patch since adaptation requires
@@ -29,5 +29,5 @@ index fb0fb13c8f4e789dea40538f4c5b7b2f891efa7a..81c1f13d2b29ece2a3581a832d602a51
  /* Overrides */
  
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0029-gcc10-Define-CC1_SPEC.patch
+++ b/gcc/11/patches/0029-gcc10-Define-CC1_SPEC.patch
@@ -1,7 +1,7 @@
 From 9007fb56df168370620653b37f0025c9172106a3 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 22:07:45 +0100
-Subject: [PATCH 29/43] gcc10: Define CC1_SPEC.
+Subject: [PATCH 29/44] gcc10: Define CC1_SPEC.
 
 ---
  gcc/config/rs6000/amigaos.h | 13 +++++++++++++
@@ -38,5 +38,5 @@ index 81c1f13d2b29ece2a3581a832d602a517f5d7ce9..38ba54769051e96740284ebf8fdf7bbd
  #undef TARGET_OS_CPP_BUILTINS
  #define TARGET_OS_CPP_BUILTINS()                \
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
+++ b/gcc/11/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
@@ -1,7 +1,7 @@
 From 83d35ac81939d40647c9b4b665ef8e0e0fbcbe74 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 8 Jan 2021 01:02:33 +0100
-Subject: [PATCH 30/43] gcc10: Link lto-dump with -athread=native.
+Subject: [PATCH 30/44] gcc10: Link lto-dump with -athread=native.
 
 ---
  gcc/config/rs6000/x-amigaos | 3 ++-
@@ -30,5 +30,5 @@ index a3dd2195809c2ce1fbab8be854f3c987dccc039b..6d9efb985ff5619c741e44edaf5431b9
 \ No newline at end of file
 +$(ALL_EXECUTABLES) : override LDFLAGS += -athread=native -Wl,--gc-sections
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
+++ b/gcc/11/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
@@ -1,7 +1,7 @@
 From 4eb610725c924cceff83841dc625fc2d7b089c5d Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 8 Jan 2021 14:03:50 +0100
-Subject: [PATCH 31/43] gcc10: Expose max_align_t when using clib2.
+Subject: [PATCH 31/44] gcc10: Expose max_align_t when using clib2.
 
 ---
  libstdc++-v3/include/c_global/cstddef | 3 ---
@@ -51,5 +51,5 @@ index 16fa6bf68690127c7a735979108b1addbd562d2b..6568adfca2089c116ae2cbdfa8c933aa
  
  #endif // _GLIBCXX_CSTDDEF
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
+++ b/gcc/11/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
@@ -1,7 +1,7 @@
 From ea3657b18b4b513bbe8133cdf9ad39cdd6b24227 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sun, 7 Feb 2021 19:38:47 +0100
-Subject: [PATCH 32/43] gcc10: Don't define __STRICT_ANSI__.
+Subject: [PATCH 32/44] gcc10: Don't define __STRICT_ANSI__.
 
 Doing so hides C99 features when configuring libstdc++.
 ---
@@ -34,5 +34,5 @@ index 649c69160accc004109d5e42496d9ec704f648e7..e5141f3dd90aae8137b084ef499b0d37
  
  #endif
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
+++ b/gcc/11/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
@@ -1,7 +1,7 @@
 From f577ea25c118b0df0a0246c0b7e69c60d8bfffc1 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Mon, 15 Mar 2021 15:55:11 +0100
-Subject: [PATCH 33/43] gcc10: Fix libstdc++v3 paths.
+Subject: [PATCH 33/44] gcc10: Fix libstdc++v3 paths.
 
 ---
  libstdc++-v3/src/c++17/fs_ops.cc  |  13 +++-
@@ -302,5 +302,5 @@ index 5d3f40a9ddfc6cfaff8d3444022967558fabacbc..38838429702a7e09c96f7b82e2d044af
      }
    }
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0034-gcc11-Include-stdint.h-when-sys-mman.h-is-missing.patch
+++ b/gcc/11/patches/0034-gcc11-Include-stdint.h-when-sys-mman.h-is-missing.patch
@@ -1,7 +1,7 @@
 From cc18633f23ed85f928bbb42eff1804c9b8dcf57c Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 28 May 2021 16:21:55 +0200
-Subject: [PATCH 34/43] gcc11: Include stdint.h when sys/mman.h is missing.
+Subject: [PATCH 34/44] gcc11: Include stdint.h when sys/mman.h is missing.
 
 Since sys/mman.h indirectly includes stdint.h, we need to explicitly
 include stdint.h when sys/mman.h is missing.
@@ -29,5 +29,5 @@ index 7b0d367ec52693dec4ea2a798635b3e32fa8f300..fc2a00eb4efb3539f2a4252ad39547ac
  typedef unsigned gcov_position_t __attribute__ ((mode (SI)));
  #if LONG_LONG_TYPE_SIZE > 32
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0035-gcc11-Use-include_next-to-circumvent-fenv.h-include-.patch
+++ b/gcc/11/patches/0035-gcc11-Use-include_next-to-circumvent-fenv.h-include-.patch
@@ -1,7 +1,7 @@
 From 21038518de5259bf01fba80c8b3c166cdc27852f Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 28 May 2021 16:27:59 +0200
-Subject: [PATCH 35/43] gcc11: Use include_next to circumvent fenv.h include
+Subject: [PATCH 35/44] gcc11: Use include_next to circumvent fenv.h include
  guard.
 
 Include guards will prevent the correct fenv.h to be included
@@ -30,5 +30,5 @@ index 0b0ec35a8377d8af928e97dbffd7e52a6ef9e3b3..3a6381577e0b3e34842759dba06e3ee8
  #undef feclearexcept
  #undef fegetexceptflag
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0036-gcc11-Fix-to-exception-raised-by-Callable-in-call_on.patch
+++ b/gcc/11/patches/0036-gcc11-Fix-to-exception-raised-by-Callable-in-call_on.patch
@@ -1,7 +1,7 @@
 From 77f7f0c5599769277466bad07f9258ee7a30dfac Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Wed, 5 Oct 2022 11:36:32 +0100
-Subject: [PATCH 36/43] gcc11: Fix to exception raised by Callable in call_once
+Subject: [PATCH 36/44] gcc11: Fix to exception raised by Callable in call_once
  implementation.
 
 In the case the Callable raises an exception, the shared resources between
@@ -127,5 +127,5 @@ index d4c5d13f65407aca5ce8aa938ea7131dc6b28662..17242119de191b34af5bf35b4a7842b5
    /// Flag type used by std::call_once
    struct once_flag
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0037-gcc11-Add-builtin-_AMIGA-define.patch
+++ b/gcc/11/patches/0037-gcc11-Add-builtin-_AMIGA-define.patch
@@ -1,7 +1,7 @@
 From b0c88f9efd21aa7247984eecaa65bea87111af90 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ola=20S=C3=B6der?= <rolfkopman@gmail.com>
 Date: Sun, 9 Apr 2023 22:34:16 +0200
-Subject: [PATCH 37/43] gcc11: Add builtin _AMIGA define.
+Subject: [PATCH 37/44] gcc11: Add builtin _AMIGA define.
 
 Define _AMIGA like on AROS, MorphOS and OS3 (SAS/C).
 ---
@@ -27,5 +27,5 @@ index 38ba54769051e96740284ebf8fdf7bbddb1ba83a..6700c742353d2fc0f36496b54f403edd
        builtin_define_std ("amigaos4");		\
        builtin_assert ("system=amigaos");	\
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0038-Provide-clib4-as-an-additional-C-runtime-library.patch
+++ b/gcc/11/patches/0038-Provide-clib4-as-an-additional-C-runtime-library.patch
@@ -1,7 +1,7 @@
 From bcc0093faf359ddea31e8983d54072214386ab77 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Thu, 23 Nov 2023 22:12:35 +0000
-Subject: [PATCH 38/43] Provide clib4 as an additional C runtime library.
+Subject: [PATCH 38/44] Provide clib4 as an additional C runtime library.
 
 As well as the existing newlib and clib2 as C runtime library choices,
 clib4 is now introduced. Support for clib4 is currently restricted to
@@ -264,5 +264,5 @@ index 99325ad0682f2f88bc04ca38a50cc97a2bcea4d5..deae1df7fd4657b48ee9ccd4f0d1781f
  {
  _GLIBCXX_BEGIN_NAMESPACE_VERSION
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0039-Allow-option-pthread-to-link-to-libpthread.patch
+++ b/gcc/11/patches/0039-Allow-option-pthread-to-link-to-libpthread.patch
@@ -1,7 +1,7 @@
 From ec1fb5ea73803fd972ae85ea52d67503b66dca84 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Tue, 14 May 2024 17:54:10 +0100
-Subject: [PATCH 39/43] Allow option -pthread to link to libpthread
+Subject: [PATCH 39/44] Allow option -pthread to link to libpthread
 
 ---
  gcc/config/rs6000/amigaos.h   | 2 +-
@@ -48,5 +48,5 @@ index 9eca30e7da072fb0a25d25ffff6ef9f38ab7f985..e90c41d9ca849ec0f178e25d31013f13
  Enum
  Name(athread) Type(int) UnknownError(argument %qs to %<-athread%> not recognized)
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0040-gcc11-Updated-the-amigaos.h-ASM_CPU_SPEC.patch
+++ b/gcc/11/patches/0040-gcc11-Updated-the-amigaos.h-ASM_CPU_SPEC.patch
@@ -1,7 +1,7 @@
 From 250496993eefc677b8111204a2103669e7333538 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Sat, 10 Aug 2024 12:10:46 +0100
-Subject: [PATCH 40/43] gcc11: Updated the amigaos.h ASM_CPU_SPEC
+Subject: [PATCH 40/44] gcc11: Updated the amigaos.h ASM_CPU_SPEC
 
 ---
  gcc/config/rs6000/amigaos.h | 114 ++++++++++++++++++++----------------
@@ -139,5 +139,5 @@ index af4e25428afd26502fae782be8b69e9b0225d732..1256bd92425e397a0dd7a13bb8df6741
  %{g1: %{!fno-eliminate-unused-debug-symbols: -feliminate-unused-debug-symbols}} \
  %{msdata: -msdata=default} \
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0041-Add-strtold-to-the-std-namespace.patch
+++ b/gcc/11/patches/0041-Add-strtold-to-the-std-namespace.patch
@@ -1,7 +1,7 @@
 From d71ae27a856b5c6492254e557a3ad7b38501bfd3 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Wed, 20 Nov 2024 19:23:46 +0000
-Subject: [PATCH 41/43] Add strtold to the std namespace.
+Subject: [PATCH 41/44] Add strtold to the std namespace.
 
 strtold is provided by both NEWLIB and CLIB4. Previously,
 std::strtold was not available for C++.
@@ -63,5 +63,5 @@ index deae1df7fd4657b48ee9ccd4f0d1781f2d09237e..591c22937e34c527765da0145854299f
  #endif // _GLIBCXX_USE_C99_STDLIB
  
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0042-Fixing-pthread_cond_clockwait-call-in-std_mutex-when.patch
+++ b/gcc/11/patches/0042-Fixing-pthread_cond_clockwait-call-in-std_mutex-when.patch
@@ -1,7 +1,7 @@
 From 35efe8168e29ffcb8e19c3f38238a577bf48dbfc Mon Sep 17 00:00:00 2001
 From: Georgios Sokianos <walkero@gmail.com>
 Date: Tue, 13 Jan 2026 20:48:52 +0000
-Subject: [PATCH 42/43] Fixing pthread_cond_clockwait call in std_mutex, when
+Subject: [PATCH 42/44] Fixing pthread_cond_clockwait call in std_mutex, when
  this is available
 
 ---
@@ -55,5 +55,5 @@ index 357c689143892e6a083ff6741c016854d9a999b1..5f29d602e51f4254969b56cffd6e138b
      notify_one() noexcept
      {
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0043-Added-eh-frame-hdr-in-LINK_SPEC.patch
+++ b/gcc/11/patches/0043-Added-eh-frame-hdr-in-LINK_SPEC.patch
@@ -1,7 +1,7 @@
 From a7b91940c8b7fe1a46b50e5cd7148a32ad74bd81 Mon Sep 17 00:00:00 2001
 From: Georgios Sokianos <walkero@gmail.com>
 Date: Thu, 12 Mar 2026 19:31:33 +0000
-Subject: [PATCH 43/43] Added --eh-frame-hdr in LINK_SPEC
+Subject: [PATCH 43/44] Added --eh-frame-hdr in LINK_SPEC
 
 ---
  gcc/config/rs6000/amigaos.h | 1 +
@@ -26,5 +26,5 @@ index 1256bd92425e397a0dd7a13bb8df674192c9cd9b..298902b8caafdd07059bfc645b8be89a
  %(link_thread) %(link_shlib) %(link_text) \
  %{mbaserel: %{msdata|msdata=default|msdata=sysv: %e-mbaserel and -msdata options are incompatible}} \
 -- 
-2.43.0
+2.34.1
 

--- a/gcc/11/patches/0044-conditionally-use-setenv-amigaos-only-when-host-clib.patch
+++ b/gcc/11/patches/0044-conditionally-use-setenv-amigaos-only-when-host-clib.patch
@@ -1,0 +1,335 @@
+From 779020cb77eda945dfce8c29fa4fc0c6a51f79ef Mon Sep 17 00:00:00 2001
+From: Georgios Sokianos <walkero@gmail.com>
+Date: Mon, 15 Jun 2026 22:31:05 +0000
+Subject: [PATCH 44/44] conditionally use setenv-amigaos only when host clib
+ lacks unsetenv, and add atexit cleanup to restore env vars on exit
+
+---
+ libiberty/configure        |  68 ++++++++++++--
+ libiberty/configure.ac     |   7 +-
+ libiberty/setenv-amigaos.c | 175 +++++++++++++++++++++++++++----------
+ 3 files changed, 196 insertions(+), 54 deletions(-)
+
+diff --git a/libiberty/configure b/libiberty/configure
+index 4d89df5e81d8d29e9747581527c8c6e2537b6373..f224afe0b0702194d162e139d3d299f54357bf6f 100755
+--- a/libiberty/configure
++++ b/libiberty/configure
+@@ -6564,20 +6564,74 @@ if test -z "${setobjs}"; then
+     # On android, getpagesize is defined in unistd.h as a static inline
+     # function, which AC_CHECK_FUNCS does not handle properly.
+     ac_cv_func_getpagesize=yes
+     ;;
+ 
+    *-*-amigaos*)
+-     # current newlib lacks unsetenv(), so we custom versions
+-     # of setenv() and unsetenv().
+-     case " $LIBOBJS " in
+-   *" setenv-amigaos.$ac_objext "* ) ;;
+-   *) LIBOBJS="$LIBOBJS setenv-amigaos.$ac_objext"
+-  ;;
+- esac
++     # Use our setenv-amigaos fallback only when the host clib lacks unsetenv().
++     # Modern clib2, clib4, and newlib all provide it and handle shell environment
++     # cleanup correctly on exit, so prefer those over our implementation.
++     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for unsetenv" >&5
++$as_echo_n "checking for unsetenv... " >&6; }
++if ${ac_cv_func_unsetenv+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++/* Define unsetenv to an innocuous variant, in case <limits.h> declares unsetenv.
++   For example, HP-UX 11i <limits.h> declares gettimeofday.  */
++#define unsetenv innocuous_unsetenv
++
++/* System header to define __stub macros and hopefully few prototypes,
++    which can conflict with char unsetenv (); below.
++    Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
++    <limits.h> exists even on freestanding compilers.  */
++
++#ifdef __STDC__
++# include <limits.h>
++#else
++# include <assert.h>
++#endif
++
++#undef unsetenv
+ 
++/* Override any GCC internal prototype to avoid an error.
++   Use char because int might match the return type of a GCC
++   builtin and then its argument prototype would still apply.  */
++#ifdef __cplusplus
++extern "C"
++#endif
++char unsetenv ();
++int
++main ()
++{
++return unsetenv ();
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"; then :
++  ac_cv_func_unsetenv=yes
++else
++  ac_cv_func_unsetenv=no
++fi
++rm -f core conftest.err conftest.$ac_objext \
++    conftest$ac_exeext conftest.$ac_ext
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_unsetenv" >&5
++$as_echo "$ac_cv_func_unsetenv" >&6; }
++if test "x$ac_cv_func_unsetenv" = xyes; then :
++
++else
++  case " $LIBOBJS " in
++  *" setenv-amigaos.$ac_objext "* ) ;;
++  *) LIBOBJS="$LIBOBJS setenv-amigaos.$ac_objext"
++ ;;
++esac
++
++fi
+      ;;
+ 
+   hppa*-*-hpux*)
+     # Replace system snprintf and vsnprintf with libiberty implementations.
+     case " $LIBOBJS " in
+   *" snprintf.$ac_objext "* ) ;;
+diff --git a/libiberty/configure.ac b/libiberty/configure.ac
+index d57c6fb4682e21b0bc2094173eab0991bd180bcb..2f11d267b378189b8152106362f7940fec03bae0 100644
+--- a/libiberty/configure.ac
++++ b/libiberty/configure.ac
+@@ -616,15 +616,16 @@ if test -z "${setobjs}"; then
+     # On android, getpagesize is defined in unistd.h as a static inline
+     # function, which AC_CHECK_FUNCS does not handle properly.
+     ac_cv_func_getpagesize=yes
+     ;;
+ 
+   *-*-amigaos*)
+-    # current newlib lacks unsetenv(), so we custom versions
+-    # of setenv() and unsetenv().
+-    AC_LIBOBJ([setenv-amigaos])
++    # Use our setenv-amigaos fallback only when the host clib lacks unsetenv().
++    # Modern clib2, clib4, and newlib all provide it and handle shell environment
++    # cleanup correctly on exit, so prefer those over our implementation.
++    AC_CHECK_FUNC([unsetenv], [], [AC_LIBOBJ([setenv-amigaos])])
+     ;;
+ 
+   hppa*-*-hpux*)
+     # Replace system snprintf and vsnprintf with libiberty implementations.
+     AC_LIBOBJ([snprintf])
+     AC_LIBOBJ([vsnprintf])
+diff --git a/libiberty/setenv-amigaos.c b/libiberty/setenv-amigaos.c
+index 6ec12b89c740874d0b7a83f322f80d5cd6f7a05e..e1954c3d4bde5feffbabc0179c187ef405551474 100644
+--- a/libiberty/setenv-amigaos.c
++++ b/libiberty/setenv-amigaos.c
+@@ -1,74 +1,161 @@
+ /* A custom implementation of various env functions
+  *
+- * This is necessary as no official clib supports unsetenv()
+- * but setenv().
++ * Used as a fallback when the host clib lacks unsetenv().  Modern clib2,
++ * clib4, and newlib all provide setenv()/unsetenv() with proper cleanup, so
++ * this file is only compiled when configure detects unsetenv() is absent.
++ *
++ * On the native AmigaOS shell, programs run within the same process as the
++ * shell, so SetVar(GVF_LOCAL_ONLY) changes persist after the program exits.
++ * An atexit handler therefore saves each variable's original state before
++ * the first modification and restores everything on process exit.
+  */
+ #define __USE_INLINE__
+ 
+ #include <proto/dos.h>
+ #include <proto/exec.h>
+ 
++#include <stdlib.h>
+ #include <string.h>
+ 
+-
+ #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+ 
++struct saved_var {
++    char *name;
++    char *value;   /* original value, or NULL if the variable did not exist */
++    LONG  len;     /* lv_Len of the original value (0 when value == NULL) */
++    struct saved_var *next;
++};
++
++static struct saved_var *saved_list = NULL;
++static int atexit_registered = 0;
++
++static void
++restore_vars_on_exit (void)
++{
++    struct saved_var *v = saved_list;
++    while (v)
++    {
++        struct saved_var *next = v->next;
++        if (v->value)
++        {
++            SetVar(v->name, v->value, v->len, GVF_LOCAL_ONLY);
++            FreeVec(v->value);
++        }
++        else
++        {
++            DeleteVar(v->name, GVF_LOCAL_ONLY);
++        }
++        FreeVec(v->name);
++        FreeVec(v);
++        v = next;
++    }
++    saved_list = NULL;
++}
++
++/* Record the current value of 'name' the first time we are about to change it. */
++static void
++save_original (const char *name)
++{
++    struct LocalVar *lvar;
++    struct saved_var *entry;
++    struct saved_var *v = saved_list;
++
++    while (v)
++    {
++        if (strcmp(v->name, name) == 0)
++            return;   /* already saved — keep only the oldest value */
++        v = v->next;
++    }
++
++    entry = (struct saved_var *)AllocVec(sizeof(struct saved_var), MEMF_CLEAR);
++    if (!entry)
++        return;
++
++    entry->name = (char *)AllocVec(strlen(name) + 1, MEMF_ANY);
++    if (!entry->name)
++    {
++        FreeVec(entry);
++        return;
++    }
++    strcpy(entry->name, name);
++
++    lvar = FindVar(name, GVF_LOCAL_ONLY);
++    if (lvar)
++    {
++        entry->len   = lvar->lv_Len;
++        entry->value = (char *)AllocVec(lvar->lv_Len + 1, MEMF_ANY);
++        if (entry->value)
++        {
++            memcpy(entry->value, lvar->lv_Value, lvar->lv_Len);
++            entry->value[lvar->lv_Len] = '\0';
++        }
++    }
++    /* else: entry->value stays NULL — variable did not exist before */
++
++    entry->next = saved_list;
++    saved_list  = entry;
++
++    if (!atexit_registered)
++    {
++        atexit(restore_vars_on_exit);
++        atexit_registered = 1;
++    }
++}
++
+ int
+ setenv (const char *name, const char *value, int replace)
+ {
+-   if (!replace)
+-   {
+-       if (FindVar(name, GVF_LOCAL_ONLY))
+-       {
+-           return 0;
+-       }
+-   }
+-
+-   return !SetVar(name, value, -1, GVF_LOCAL_ONLY);
++    if (!replace)
++    {
++        if (FindVar(name, GVF_LOCAL_ONLY))
++            return 0;
++    }
++
++    save_original(name);
++    return !SetVar(name, value, -1, GVF_LOCAL_ONLY);
+ }
+ 
+-void
++int
+ unsetenv (const char *name)
+ {
+-   DeleteVar(name, GVF_LOCAL_ONLY);
++    save_original(name);
++    DeleteVar(name, GVF_LOCAL_ONLY);
++    return 0;
+ }
+ 
+-void
++int
+ putenv (char *str)
+ {
+-   int i;
+-
+-   if (str[0] == '=')
+-   {
+-       return;
+-   }
+-
+-   for (i=0; str[i]; i++)
+-   {
+-       if (str[i] == '=')
+-       {
+-           char *name = (char*)AllocVec(i + 1, MEMF_ANY);
+-           if (name)
+-           {
+-               strncpy(name, str, i);
+-               name[i] = 0;
+-
+-               setenv(name, &str[i] + 1, 1);
+-               FreeVec(name);
+-               return;
+-           }
+-       }
+-   }
++    int i;
++
++    if (str[0] == '=')
++        return -1;
++
++    for (i = 0; str[i]; i++)
++    {
++        if (str[i] == '=')
++        {
++            char *name = (char *)AllocVec(i + 1, MEMF_ANY);
++            if (name)
++            {
++                strncpy(name, str, i);
++                name[i] = 0;
++                setenv(name, &str[i] + 1, 1);
++                FreeVec(name);
++                return 0;
++            }
++            return -1;
++        }
++    }
++    return -1;
+ }
+ 
+ char *
+ getenv (const char *name)
+ {
+-   struct LocalVar *lvar;
++    struct LocalVar *lvar;
+ 
+-   if (!(lvar = FindVar(name, GVF_LOCAL_ONLY)))
+-   {
+-       return NULL;
+-   }
+-   return lvar->lv_Value;
++    if (!(lvar = FindVar(name, GVF_LOCAL_ONLY)))
++        return NULL;
++    return lvar->lv_Value;
+ }
+-- 
+2.34.1
+

--- a/gcc/13/patches/0001-amigaos-4-native-and-cross-compiler-changes.patch
+++ b/gcc/13/patches/0001-amigaos-4-native-and-cross-compiler-changes.patch
@@ -1,7 +1,7 @@
 From cf0edcb46b952956e7249b39fd62728cc2d1d591 Mon Sep 17 00:00:00 2001
 From: Georgios Sokianos <walkero@gmail.com>
 Date: Tue, 9 Jun 2026 21:08:44 +0000
-Subject: [PATCH] amigaos 4 native and cross compiler changes
+Subject: [PATCH 1/2] amigaos 4 native and cross compiler changes
 
 ---
  config-ml.in                                  |    4 +-
@@ -6940,5 +6940,5 @@ index d65b5482e8b969b3609b278bf7fd82b5e25ce4ac..a66f92027fd572cc5100dc8e4e2e25ed
      }
    }
 -- 
-2.53.0
+2.34.1
 

--- a/gcc/13/patches/0002-conditionally-use-setenv-amigaos-only-when-host-clib.patch
+++ b/gcc/13/patches/0002-conditionally-use-setenv-amigaos-only-when-host-clib.patch
@@ -1,0 +1,335 @@
+From 8afc5af644ec62109e992dac17454cdda5ad8e45 Mon Sep 17 00:00:00 2001
+From: Georgios Sokianos <walkero@gmail.com>
+Date: Tue, 16 Jun 2026 15:06:23 +0000
+Subject: [PATCH 2/2] conditionally use setenv-amigaos only when host clib
+ lacks unsetenv, and add atexit cleanup to restore env vars on exit
+
+---
+ libiberty/configure        |  68 ++++++++++++--
+ libiberty/configure.ac     |   7 +-
+ libiberty/setenv-amigaos.c | 175 +++++++++++++++++++++++++++----------
+ 3 files changed, 196 insertions(+), 54 deletions(-)
+
+diff --git a/libiberty/configure b/libiberty/configure
+index 438669041e1757623c304900231060e65d39e90e..b6d40e6a1dbd063ed47c51006d47cd1a3cc129ea 100755
+--- a/libiberty/configure
++++ b/libiberty/configure
+@@ -6603,20 +6603,74 @@ if test -z "${setobjs}"; then
+     # On android, getpagesize is defined in unistd.h as a static inline
+     # function, which AC_CHECK_FUNCS does not handle properly.
+     ac_cv_func_getpagesize=yes
+     ;;
+ 
+    *-*-amigaos*)
+-     # current newlib lacks unsetenv(), so we custom versions
+-     # of setenv() and unsetenv().
+-     case " $LIBOBJS " in
+-   *" setenv-amigaos.$ac_objext "* ) ;;
+-   *) LIBOBJS="$LIBOBJS setenv-amigaos.$ac_objext"
+-  ;;
+- esac
++     # Use our setenv-amigaos fallback only when the host clib lacks unsetenv().
++     # Modern clib2, clib4, and newlib all provide it and handle shell environment
++     # cleanup correctly on exit, so prefer those over our implementation.
++     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for unsetenv" >&5
++$as_echo_n "checking for unsetenv... " >&6; }
++if ${ac_cv_func_unsetenv+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++/* Define unsetenv to an innocuous variant, in case <limits.h> declares unsetenv.
++   For example, HP-UX 11i <limits.h> declares gettimeofday.  */
++#define unsetenv innocuous_unsetenv
++
++/* System header to define __stub macros and hopefully few prototypes,
++    which can conflict with char unsetenv (); below.
++    Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
++    <limits.h> exists even on freestanding compilers.  */
++
++#ifdef __STDC__
++# include <limits.h>
++#else
++# include <assert.h>
++#endif
++
++#undef unsetenv
+ 
++/* Override any GCC internal prototype to avoid an error.
++   Use char because int might match the return type of a GCC
++   builtin and then its argument prototype would still apply.  */
++#ifdef __cplusplus
++extern "C"
++#endif
++char unsetenv ();
++int
++main ()
++{
++return unsetenv ();
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"; then :
++  ac_cv_func_unsetenv=yes
++else
++  ac_cv_func_unsetenv=no
++fi
++rm -f core conftest.err conftest.$ac_objext \
++    conftest$ac_exeext conftest.$ac_ext
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_unsetenv" >&5
++$as_echo "$ac_cv_func_unsetenv" >&6; }
++if test "x$ac_cv_func_unsetenv" = xyes; then :
++
++else
++  case " $LIBOBJS " in
++  *" setenv-amigaos.$ac_objext "* ) ;;
++  *) LIBOBJS="$LIBOBJS setenv-amigaos.$ac_objext"
++ ;;
++esac
++
++fi
+      ;;
+ 
+   hppa*-*-hpux*)
+     # Replace system snprintf and vsnprintf with libiberty implementations.
+     case " $LIBOBJS " in
+   *" snprintf.$ac_objext "* ) ;;
+diff --git a/libiberty/configure.ac b/libiberty/configure.ac
+index 4b2ab042c8ecbfe4d9cb9add8ca250383bb73a27..8b62d812781f8cb483faf03566f80d443de9011e 100644
+--- a/libiberty/configure.ac
++++ b/libiberty/configure.ac
+@@ -622,15 +622,16 @@ if test -z "${setobjs}"; then
+     # On android, getpagesize is defined in unistd.h as a static inline
+     # function, which AC_CHECK_FUNCS does not handle properly.
+     ac_cv_func_getpagesize=yes
+     ;;
+ 
+   *-*-amigaos*)
+-    # current newlib lacks unsetenv(), so we custom versions
+-    # of setenv() and unsetenv().
+-    AC_LIBOBJ([setenv-amigaos])
++    # Use our setenv-amigaos fallback only when the host clib lacks unsetenv().
++    # Modern clib2, clib4, and newlib all provide it and handle shell environment
++    # cleanup correctly on exit, so prefer those over our implementation.
++    AC_CHECK_FUNC([unsetenv], [], [AC_LIBOBJ([setenv-amigaos])])
+     ;;
+ 
+   hppa*-*-hpux*)
+     # Replace system snprintf and vsnprintf with libiberty implementations.
+     AC_LIBOBJ([snprintf])
+     AC_LIBOBJ([vsnprintf])
+diff --git a/libiberty/setenv-amigaos.c b/libiberty/setenv-amigaos.c
+index 6ec12b89c740874d0b7a83f322f80d5cd6f7a05e..e1954c3d4bde5feffbabc0179c187ef405551474 100644
+--- a/libiberty/setenv-amigaos.c
++++ b/libiberty/setenv-amigaos.c
+@@ -1,74 +1,161 @@
+ /* A custom implementation of various env functions
+  *
+- * This is necessary as no official clib supports unsetenv()
+- * but setenv().
++ * Used as a fallback when the host clib lacks unsetenv().  Modern clib2,
++ * clib4, and newlib all provide setenv()/unsetenv() with proper cleanup, so
++ * this file is only compiled when configure detects unsetenv() is absent.
++ *
++ * On the native AmigaOS shell, programs run within the same process as the
++ * shell, so SetVar(GVF_LOCAL_ONLY) changes persist after the program exits.
++ * An atexit handler therefore saves each variable's original state before
++ * the first modification and restores everything on process exit.
+  */
+ #define __USE_INLINE__
+ 
+ #include <proto/dos.h>
+ #include <proto/exec.h>
+ 
++#include <stdlib.h>
+ #include <string.h>
+ 
+-
+ #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+ 
++struct saved_var {
++    char *name;
++    char *value;   /* original value, or NULL if the variable did not exist */
++    LONG  len;     /* lv_Len of the original value (0 when value == NULL) */
++    struct saved_var *next;
++};
++
++static struct saved_var *saved_list = NULL;
++static int atexit_registered = 0;
++
++static void
++restore_vars_on_exit (void)
++{
++    struct saved_var *v = saved_list;
++    while (v)
++    {
++        struct saved_var *next = v->next;
++        if (v->value)
++        {
++            SetVar(v->name, v->value, v->len, GVF_LOCAL_ONLY);
++            FreeVec(v->value);
++        }
++        else
++        {
++            DeleteVar(v->name, GVF_LOCAL_ONLY);
++        }
++        FreeVec(v->name);
++        FreeVec(v);
++        v = next;
++    }
++    saved_list = NULL;
++}
++
++/* Record the current value of 'name' the first time we are about to change it. */
++static void
++save_original (const char *name)
++{
++    struct LocalVar *lvar;
++    struct saved_var *entry;
++    struct saved_var *v = saved_list;
++
++    while (v)
++    {
++        if (strcmp(v->name, name) == 0)
++            return;   /* already saved — keep only the oldest value */
++        v = v->next;
++    }
++
++    entry = (struct saved_var *)AllocVec(sizeof(struct saved_var), MEMF_CLEAR);
++    if (!entry)
++        return;
++
++    entry->name = (char *)AllocVec(strlen(name) + 1, MEMF_ANY);
++    if (!entry->name)
++    {
++        FreeVec(entry);
++        return;
++    }
++    strcpy(entry->name, name);
++
++    lvar = FindVar(name, GVF_LOCAL_ONLY);
++    if (lvar)
++    {
++        entry->len   = lvar->lv_Len;
++        entry->value = (char *)AllocVec(lvar->lv_Len + 1, MEMF_ANY);
++        if (entry->value)
++        {
++            memcpy(entry->value, lvar->lv_Value, lvar->lv_Len);
++            entry->value[lvar->lv_Len] = '\0';
++        }
++    }
++    /* else: entry->value stays NULL — variable did not exist before */
++
++    entry->next = saved_list;
++    saved_list  = entry;
++
++    if (!atexit_registered)
++    {
++        atexit(restore_vars_on_exit);
++        atexit_registered = 1;
++    }
++}
++
+ int
+ setenv (const char *name, const char *value, int replace)
+ {
+-   if (!replace)
+-   {
+-       if (FindVar(name, GVF_LOCAL_ONLY))
+-       {
+-           return 0;
+-       }
+-   }
+-
+-   return !SetVar(name, value, -1, GVF_LOCAL_ONLY);
++    if (!replace)
++    {
++        if (FindVar(name, GVF_LOCAL_ONLY))
++            return 0;
++    }
++
++    save_original(name);
++    return !SetVar(name, value, -1, GVF_LOCAL_ONLY);
+ }
+ 
+-void
++int
+ unsetenv (const char *name)
+ {
+-   DeleteVar(name, GVF_LOCAL_ONLY);
++    save_original(name);
++    DeleteVar(name, GVF_LOCAL_ONLY);
++    return 0;
+ }
+ 
+-void
++int
+ putenv (char *str)
+ {
+-   int i;
+-
+-   if (str[0] == '=')
+-   {
+-       return;
+-   }
+-
+-   for (i=0; str[i]; i++)
+-   {
+-       if (str[i] == '=')
+-       {
+-           char *name = (char*)AllocVec(i + 1, MEMF_ANY);
+-           if (name)
+-           {
+-               strncpy(name, str, i);
+-               name[i] = 0;
+-
+-               setenv(name, &str[i] + 1, 1);
+-               FreeVec(name);
+-               return;
+-           }
+-       }
+-   }
++    int i;
++
++    if (str[0] == '=')
++        return -1;
++
++    for (i = 0; str[i]; i++)
++    {
++        if (str[i] == '=')
++        {
++            char *name = (char *)AllocVec(i + 1, MEMF_ANY);
++            if (name)
++            {
++                strncpy(name, str, i);
++                name[i] = 0;
++                setenv(name, &str[i] + 1, 1);
++                FreeVec(name);
++                return 0;
++            }
++            return -1;
++        }
++    }
++    return -1;
+ }
+ 
+ char *
+ getenv (const char *name)
+ {
+-   struct LocalVar *lvar;
++    struct LocalVar *lvar;
+ 
+-   if (!(lvar = FindVar(name, GVF_LOCAL_ONLY)))
+-   {
+-       return NULL;
+-   }
+-   return lvar->lv_Value;
++    if (!(lvar = FindVar(name, GVF_LOCAL_ONLY)))
++        return NULL;
++    return lvar->lv_Value;
+ }
+-- 
+2.34.1
+

--- a/gcc/6/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/6/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,7 +1,7 @@
-From fb1fbc56ecf4c107fb138577d8aa135ed2ed80f6 Mon Sep 17 00:00:00 2001
+From 6d86a08ffa91a557bfad2e43d8de56462b07a074 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Feb 2015 20:25:55 +0100
-Subject: [PATCH 01/21] Changes for AmigaOS version of gcc.
+Subject: [PATCH 01/22] Changes for AmigaOS version of gcc.
 
 ---
  fixincludes/configure                 |    1 +

--- a/gcc/6/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/6/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,7 +1,7 @@
-From 091ebe485044d027b393b067505e9dfc35c12267 Mon Sep 17 00:00:00 2001
+From 41e619818e71fcb3f924c4d1b93d1ce6d60292f1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 14 Nov 2014 20:03:56 +0100
-Subject: [PATCH 02/21] Added new function attribute "lineartags" and pragma
+Subject: [PATCH 02/22] Added new function attribute "lineartags" and pragma
  "amigaos tagtype".
 
 Functions that have the lineartags attribute are assumed to be functions

--- a/gcc/6/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/6/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,7 +1,7 @@
-From 3bfa44553e3aa11ca27cc5a6fa2f1f5270c01a89 Mon Sep 17 00:00:00 2001
+From 46a6a6b3f59bf6f2c65b59a78f3f80cc8d01422c Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 9 Jul 2015 06:54:37 +0200
-Subject: [PATCH 03/21] Disable .machine directive generation.
+Subject: [PATCH 03/22] Disable .machine directive generation.
 
 It breaks manual args to the assembler with different flavor,
 e.g., -Wa,-m440. This is probably not the right fix.

--- a/gcc/6/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/6/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,7 +1,7 @@
-From 8032a07ba466421f9376f7e0bca8c692464063ae Mon Sep 17 00:00:00 2001
+From 56e93d1711a42cee3f510cff272ed5efc97c6249 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 20:56:33 +0100
-Subject: [PATCH 04/21] The default link mode is static for AmigaOS.
+Subject: [PATCH 04/22] The default link mode is static for AmigaOS.
 
 Changed the g++ driver to reflect this.
 ---

--- a/gcc/6/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/6/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,7 +1,7 @@
-From 170b394977e6ae18a504573e299ac290a0c58441 Mon Sep 17 00:00:00 2001
+From 688ff32098842614052fcdca8f62a516a2ea30e2 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 21:39:42 +0100
-Subject: [PATCH 05/21] Disable the usage of /dev/urandom when compiling for
+Subject: [PATCH 05/22] Disable the usage of /dev/urandom when compiling for
  AmigaOS.
 
 ---

--- a/gcc/6/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/6/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,7 +1,7 @@
-From a008069e551d9658ebd5d166a1569f102dadea4a Mon Sep 17 00:00:00 2001
+From 42ba85795f95dc9a7349fffdbf3008e42fa9f90a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 5 Dec 2015 13:17:26 +0100
-Subject: [PATCH 06/21] Expand arg zero on AmigaOS using the PROGDIR: assign.
+Subject: [PATCH 06/22] Expand arg zero on AmigaOS using the PROGDIR: assign.
 
 This should make sure that the proper relative paths are computed during
 process_command().

--- a/gcc/6/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/6/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,7 +1,7 @@
-From 35669b2c7f84f356af24dfbab6040214e22497c0 Mon Sep 17 00:00:00 2001
+From 6fae829eb643075d3ceabdcf54ce7f58f3ae9922 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 21 Jan 2016 20:46:59 +0100
-Subject: [PATCH 07/21] Some AmigaOS 4.x compability changes for posix thread
+Subject: [PATCH 07/22] Some AmigaOS 4.x compability changes for posix thread
  support.
 
 ---

--- a/gcc/6/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/6/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,7 +1,7 @@
-From 8e344c7495f38559c4ab23692f86fc7a78ee551a Mon Sep 17 00:00:00 2001
+From 1c260bf3ed66bb601f16675349632b85ccbee1c8 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 22 Jan 2016 20:04:50 +0100
-Subject: [PATCH 08/21] Added libstc++ support for AmigaOS.
+Subject: [PATCH 08/22] Added libstc++ support for AmigaOS.
 
 ---
  .../config/os/{generic => amigaos}/ctype_base.h     |  2 +-

--- a/gcc/6/patches/0009-Added-e500-support-for-AmigaOS.patch
+++ b/gcc/6/patches/0009-Added-e500-support-for-AmigaOS.patch
@@ -1,7 +1,7 @@
-From 3fbaae9e66b5a962272be8f453b2e128e67a1a28 Mon Sep 17 00:00:00 2001
+From 22b123a440e70f0d30fad529a8c4772e3ac049c8 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Mon, 30 Jan 2017 20:49:17 +0100
-Subject: [PATCH 09/21] Added e500 support for AmigaOS.
+Subject: [PATCH 09/22] Added e500 support for AmigaOS.
 
 ---
  gcc/config.gcc | 2 +-

--- a/gcc/6/patches/0010-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/6/patches/0010-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,7 +1,7 @@
-From 9b444e7541cbc72562cee7a8e1795a250d10d613 Mon Sep 17 00:00:00 2001
+From d7b25a19b23beb36e30b5b9e470ea302f9c06b52 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 3 Mar 2017 08:52:48 +0100
-Subject: [PATCH 10/21] Enable libatomic for ppc-amigaos.
+Subject: [PATCH 10/22] Enable libatomic for ppc-amigaos.
 
 It is not really finished yet.
 ---

--- a/gcc/6/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/6/patches/0011-Pretend-C99-compatibility.patch
@@ -1,7 +1,7 @@
-From 03161dccf14e031ceb5c62241bb62ce232c6e94c Mon Sep 17 00:00:00 2001
+From eba85da2e14a99d34994b84c9c3339bc646322e4 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 4 Mar 2017 07:39:21 +0100
-Subject: [PATCH 11/21] Pretend C99 compatibility.
+Subject: [PATCH 11/22] Pretend C99 compatibility.
 
 At least newlib is not fully C99 compatible because it doesn't expose
 various C99 function if __STRICT_ANSI__ is declared. Also it misses

--- a/gcc/6/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/6/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,7 +1,7 @@
-From 0cce69f2c07f7cb47daeeaddc02ca2de2afddc25 Mon Sep 17 00:00:00 2001
+From b658305523eb50ec75fcd44c99a03fe7ce96172a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 3 Apr 2018 19:52:01 +0200
-Subject: [PATCH 12/21] Add amigaos-stdint.h for libatomic.
+Subject: [PATCH 12/22] Add amigaos-stdint.h for libatomic.
 
 ---
  gcc/config.gcc                                      | 2 +-

--- a/gcc/6/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/6/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,7 +1,7 @@
-From a9933b944a4d65e33075614bb35a00ad5328a435 Mon Sep 17 00:00:00 2001
+From 2b0143578e9c819b8638fbf483ed46c8534e1928 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 22:48:33 +0200
-Subject: [PATCH 13/21] Rerun make maint-deps in libiberty.
+Subject: [PATCH 13/22] Rerun make maint-deps in libiberty.
 
 ---
  libiberty/Makefile.in | 36 ++++++++++++++++++++++--------------

--- a/gcc/6/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/6/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,7 +1,7 @@
-From 50341f21238fed7b02599edbcecc0b2b62a20a1a Mon Sep 17 00:00:00 2001
+From dc688d8580ca13380b3191458382b668c42f72fd Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 23:50:48 +0200
-Subject: [PATCH 14/21] Add custom implementation of various env-related
+Subject: [PATCH 14/22] Add custom implementation of various env-related
  functions.
 
 No official clib does support unsetenv() but this is required by newer gcc.

--- a/gcc/6/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/6/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,7 +1,7 @@
-From 60f42e29046983ae4ffbc9a759e2a871d013dc92 Mon Sep 17 00:00:00 2001
+From aeb233283ed94b08e7398c478c3e0c383d041b8b Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 5 Apr 2018 19:56:45 +0200
-Subject: [PATCH 15/21] Define va_startlinear and va_getlinearva.
+Subject: [PATCH 15/22] Define va_startlinear and va_getlinearva.
 
 These were usually defined in the clibs' stdarg.h. As we have now
 changed the include path order, clibs' stdarg.h is never included.

--- a/gcc/6/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/6/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,7 +1,7 @@
-From db84bd50e70189be71612ff6baf32371703ce129 Mon Sep 17 00:00:00 2001
+From a2e1513c78dfef5346af3ec86a7b3b80b504e633 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Apr 2018 22:02:09 +0200
-Subject: [PATCH 16/21] Fix r2 restoring in the epilog of baserel-restoring
+Subject: [PATCH 16/22] Fix r2 restoring in the epilog of baserel-restoring
  functions.
 
 ---

--- a/gcc/6/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/6/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,7 +1,7 @@
-From 3208b1057c63dfebd82fdbe25784742c92888491 Mon Sep 17 00:00:00 2001
+From 519f0455c933b3d5b9415f081a15c5c0d5284061 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 19 Apr 2018 21:00:30 +0200
-Subject: [PATCH 17/21] Avoid section anchors in the baserel mode.
+Subject: [PATCH 17/22] Avoid section anchors in the baserel mode.
 
 ---
  gcc/config/rs6000/amigaos-protos.h |  1 +

--- a/gcc/6/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/6/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,7 +1,7 @@
-From a8c9e108ae1743f3451691f0506db40a1e5a1360 Mon Sep 17 00:00:00 2001
+From 59a91de915dedf3247e75403da3004c35eda5f36 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 20 Apr 2018 20:04:30 +0200
-Subject: [PATCH 18/21] Respect -nostdinc also for SDK includes.
+Subject: [PATCH 18/22] Respect -nostdinc also for SDK includes.
 
 ---
  gcc/config/rs6000/amigaos.h | 4 +---

--- a/gcc/6/patches/0019-Provide-clib4-as-an-additional-C-runtime-library.patch
+++ b/gcc/6/patches/0019-Provide-clib4-as-an-additional-C-runtime-library.patch
@@ -1,7 +1,7 @@
-From 74d90b4683ab3248fe2f3ee1154fe552a6d4f4a8 Mon Sep 17 00:00:00 2001
+From a5358593905fd985ebe23a760643a2f2e118b1ed Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Fri, 12 Jan 2024 00:15:23 +0000
-Subject: [PATCH 19/21] Provide clib4 as an additional C runtime library.
+Subject: [PATCH 19/22] Provide clib4 as an additional C runtime library.
 
 As well as the existing newlib and clib2 as C runtime library choices,
 clib4 is now introduced.

--- a/gcc/6/patches/0020-Allow-option-pthread-to-link-to-libpthread.patch
+++ b/gcc/6/patches/0020-Allow-option-pthread-to-link-to-libpthread.patch
@@ -1,7 +1,7 @@
-From f69786f7865fa309edb8a6f8d82c967e4e305c09 Mon Sep 17 00:00:00 2001
+From ef506525bf3973357b57f98cc3e0c652a1a159d6 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Wed, 15 May 2024 23:56:46 +0100
-Subject: [PATCH 20/21] Allow option -pthread to link to libpthread
+Subject: [PATCH 20/22] Allow option -pthread to link to libpthread
 
 ---
  gcc/config/rs6000/amigaos.h   | 2 +-

--- a/gcc/6/patches/0021-Add-strtold-to-the-std-namespace.patch
+++ b/gcc/6/patches/0021-Add-strtold-to-the-std-namespace.patch
@@ -1,7 +1,7 @@
-From 705d741627ecdb228eb36aa880c76067915e9f28 Mon Sep 17 00:00:00 2001
+From 390a72d9d7d7abee1fa5bcde7aa23c86a0a5bd59 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Wed, 20 Nov 2024 20:11:23 +0000
-Subject: [PATCH 21/21] Add strtold to the std namespace.
+Subject: [PATCH 21/22] Add strtold to the std namespace.
 
 strtold is provided by both NEWLIB and CLIB4. Previously,
 std::strtold was not available for C++.
@@ -10,7 +10,7 @@ std::strtold was not available for C++.
  1 file changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/libstdc++-v3/include/c_global/cstdlib b/libstdc++-v3/include/c_global/cstdlib
-index 09d99212541ff9d456e5c7f0d11632fe5e1b67c4..8f87a546ad0756fed29bf8249bc00c020e7e21c6 100644
+index 09d99212541ff9d456e5c7f0d11632fe5e1b67c4..79a528e1b15421aa54790780a6abb0c0af87a443 100644
 --- a/libstdc++-v3/include/c_global/cstdlib
 +++ b/libstdc++-v3/include/c_global/cstdlib
 @@ -208,14 +208,14 @@ _GLIBCXX_END_NAMESPACE_VERSION
@@ -19,14 +19,14 @@ index 09d99212541ff9d456e5c7f0d11632fe5e1b67c4..8f87a546ad0756fed29bf8249bc00c02
  #undef strtoll
  #undef strtoull
  #undef strtof
-
+ 
 -/* clib2 and newlib do not provide an implementation of strtold */
 -#if !defined (__amigaos4__) || defined(__CLIB4__)
 +/* AmigaOS4: clib2 does not provide an implementation of strtold */
 +#ifndef __CLIB2__
  #undef strtold
  #endif
-
+ 
  namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
  {
  _GLIBCXX_BEGIN_NAMESPACE_VERSION
@@ -42,10 +42,10 @@ index 09d99212541ff9d456e5c7f0d11632fe5e1b67c4..8f87a546ad0756fed29bf8249bc00c02
 +#ifndef __CLIB2__
    using ::strtold;
  #endif
-
+ 
  _GLIBCXX_END_NAMESPACE_VERSION
  } // namespace __gnu_cxx
-
+ 
 @@ -272,13 +273,14 @@ namespace std
    using ::__gnu_cxx::lldiv;
  #endif
@@ -59,8 +59,9 @@ index 09d99212541ff9d456e5c7f0d11632fe5e1b67c4..8f87a546ad0756fed29bf8249bc00c02
    using ::__gnu_cxx::strtold;
  #endif
  } // namespace std
-
+ 
  #endif // _GLIBCXX_USE_C99_STDLIB
-
---
+ 
+-- 
 2.34.1
+

--- a/gcc/6/patches/0022-conditionally-use-setenv-amigaos-only-when-host-clib.patch
+++ b/gcc/6/patches/0022-conditionally-use-setenv-amigaos-only-when-host-clib.patch
@@ -1,0 +1,303 @@
+From 28e642baf0732c0f22bd16df96da90087e8b7253 Mon Sep 17 00:00:00 2001
+From: Georgios Sokianos <walkero@gmail.com>
+Date: Thu, 18 Jun 2026 21:30:45 +0000
+Subject: [PATCH 22/22] conditionally use setenv-amigaos only when host clib
+ lacks unsetenv, and add atexit cleanup to restore env vars on exit
+
+---
+ libiberty/configure        |  60 ++++++++++++++++++-
+ libiberty/configure.ac     |   7 ++-
+ libiberty/setenv-amigaos.c | 119 ++++++++++++++++++++++++++++++++-----
+ 3 files changed, 164 insertions(+), 22 deletions(-)
+
+diff --git a/libiberty/configure b/libiberty/configure
+index f72e5005b4ab83cf6d6b2e136ed7515d6c2eaa29..cc7e4ca42115612bee3049ceaf58a46a5ec685e8 100755
+--- a/libiberty/configure
++++ b/libiberty/configure
+@@ -6286,20 +6286,74 @@ if test -z "${setobjs}"; then
+     # On android, getpagesize is defined in unistd.h as a static inline
+     # function, which AC_CHECK_FUNCS does not handle properly.
+     ac_cv_func_getpagesize=yes
+     ;;
+ 
+   *-*-amigaos*)
+-    # current newlib lacks unsetenv(), so we custom versions
+-    # of setenv() and unsetenv().
+-    case " $LIBOBJS " in
++    # Use our setenv-amigaos fallback only when the host clib lacks unsetenv().
++    # Modern clib2, clib4, and newlib all provide it and handle shell environment
++    # cleanup correctly on exit, so prefer those over our implementation.
++    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for unsetenv" >&5
++$as_echo_n "checking for unsetenv... " >&6; }
++if ${ac_cv_func_unsetenv+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++/* Define unsetenv to an innocuous variant, in case <limits.h> declares unsetenv.
++   For example, HP-UX 11i <limits.h> declares gettimeofday.  */
++#define unsetenv innocuous_unsetenv
++
++/* System header to define __stub macros and hopefully few prototypes,
++    which can conflict with char unsetenv (); below.
++    Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
++    <limits.h> exists even on freestanding compilers.  */
++
++#ifdef __STDC__
++# include <limits.h>
++#else
++# include <assert.h>
++#endif
++
++#undef unsetenv
++
++/* Override any GCC internal prototype to avoid an error.
++   Use char because int might match the return type of a GCC
++   builtin and then its argument prototype would still apply.  */
++#ifdef __cplusplus
++extern "C"
++#endif
++char unsetenv ();
++int
++main ()
++{
++return unsetenv ();
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"; then :
++  ac_cv_func_unsetenv=yes
++else
++  ac_cv_func_unsetenv=no
++fi
++rm -f core conftest.err conftest.$ac_objext \
++    conftest$ac_exeext conftest.$ac_ext
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_unsetenv" >&5
++$as_echo "$ac_cv_func_unsetenv" >&6; }
++if test "x$ac_cv_func_unsetenv" = xyes; then :
++
++else
++  case " $LIBOBJS " in
+   *" setenv-amigaos.$ac_objext "* ) ;;
+   *) LIBOBJS="$LIBOBJS setenv-amigaos.$ac_objext"
+  ;;
+ esac
+ 
++fi
+     ;;
+ 
+   *-*-mingw32*)
+     # Under mingw32, sys_nerr and sys_errlist exist, but they are
+     # macros, so the test below won't find them.
+     libiberty_cv_var_sys_nerr=yes
+diff --git a/libiberty/configure.ac b/libiberty/configure.ac
+index 4ae698331038d287abe132b63c0cbeca9dd55666..ef0b7ab91e6c9846a275aac0d9251feb5e6a7ce1 100644
+--- a/libiberty/configure.ac
++++ b/libiberty/configure.ac
+@@ -605,15 +605,16 @@ if test -z "${setobjs}"; then
+     # On android, getpagesize is defined in unistd.h as a static inline
+     # function, which AC_CHECK_FUNCS does not handle properly.
+     ac_cv_func_getpagesize=yes
+     ;;
+ 
+   *-*-amigaos*)
+-    # current newlib lacks unsetenv(), so we custom versions
+-    # of setenv() and unsetenv().
+-    AC_LIBOBJ([setenv-amigaos])
++    # Use our setenv-amigaos fallback only when the host clib lacks unsetenv().
++    # Modern clib2, clib4, and newlib all provide it and handle shell environment
++    # cleanup correctly on exit, so prefer those over our implementation.
++    AC_CHECK_FUNC([unsetenv], [], [AC_LIBOBJ([setenv-amigaos])])
+     ;;
+ 
+   *-*-mingw32*)
+     # Under mingw32, sys_nerr and sys_errlist exist, but they are
+     # macros, so the test below won't find them.
+     libiberty_cv_var_sys_nerr=yes
+diff --git a/libiberty/setenv-amigaos.c b/libiberty/setenv-amigaos.c
+index 089d3cbcc6eb7d42d96e8dfb16d1b399cfe856b3..b9b464e7b8c1e1c1dbbbfcbdc22a7e1d070830d5 100644
+--- a/libiberty/setenv-amigaos.c
++++ b/libiberty/setenv-amigaos.c
+@@ -1,74 +1,161 @@
+ /* A custom implementation of various env functions
+  *
+- * This is necessary as no official clib supports unsetenv()
+- * but setenv().
++ * Used as a fallback when the host clib lacks unsetenv().  Modern clib2,
++ * clib4, and newlib all provide setenv()/unsetenv() with proper cleanup, so
++ * this file is only compiled when configure detects unsetenv() is absent.
++ *
++ * On the native AmigaOS shell, programs run within the same process as the
++ * shell, so SetVar(GVF_LOCAL_ONLY) changes persist after the program exits.
++ * An atexit handler therefore saves each variable's original state before
++ * the first modification and restores everything on process exit.
+  */
+ #define __USE_INLINE__
+ 
+ #include <proto/dos.h>
+ #include <proto/exec.h>
+ 
++#include <stdlib.h>
+ #include <string.h>
+ 
+-
+ #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+ 
++struct saved_var {
++	char *name;
++	char *value;   /* original value, or NULL if the variable did not exist */
++	LONG  len;     /* lv_Len of the original value (0 when value == NULL) */
++	struct saved_var *next;
++};
++
++static struct saved_var *saved_list = NULL;
++static int atexit_registered = 0;
++
++static void
++restore_vars_on_exit (void)
++{
++	struct saved_var *v = saved_list;
++	while (v)
++	{
++		struct saved_var *next = v->next;
++		if (v->value)
++		{
++			SetVar(v->name, v->value, v->len, GVF_LOCAL_ONLY);
++			FreeVec(v->value);
++		}
++		else
++		{
++			DeleteVar(v->name, GVF_LOCAL_ONLY);
++		}
++		FreeVec(v->name);
++		FreeVec(v);
++		v = next;
++	}
++	saved_list = NULL;
++}
++
++/* Record the current value of 'name' the first time we are about to change it. */
++static void
++save_original (const char *name)
++{
++	struct LocalVar *lvar;
++	struct saved_var *entry;
++	struct saved_var *v = saved_list;
++
++	while (v)
++	{
++		if (strcmp(v->name, name) == 0)
++			return;   /* already saved — keep only the oldest value */
++		v = v->next;
++	}
++
++	entry = (struct saved_var *)AllocVec(sizeof(struct saved_var), MEMF_CLEAR);
++	if (!entry)
++		return;
++
++	entry->name = (char *)AllocVec(strlen(name) + 1, MEMF_ANY);
++	if (!entry->name)
++	{
++		FreeVec(entry);
++		return;
++	}
++	strcpy(entry->name, name);
++
++	lvar = FindVar(name, GVF_LOCAL_ONLY);
++	if (lvar)
++	{
++		entry->len   = lvar->lv_Len;
++		entry->value = (char *)AllocVec(lvar->lv_Len + 1, MEMF_ANY);
++		if (entry->value)
++		{
++			memcpy(entry->value, lvar->lv_Value, lvar->lv_Len);
++			entry->value[lvar->lv_Len] = '\0';
++		}
++	}
++	/* else: entry->value stays NULL — variable did not exist before */
++
++	entry->next = saved_list;
++	saved_list  = entry;
++
++	if (!atexit_registered)
++	{
++		atexit(restore_vars_on_exit);
++		atexit_registered = 1;
++	}
++}
++
+ int
+ setenv (const char *name, const char *value, int replace)
+ {
+ 	if (!replace)
+ 	{
+ 		if (FindVar(name, GVF_LOCAL_ONLY))
+-		{
+ 			return 0;
+-		}
+ 	}
+ 
++	save_original(name);
+ 	return !SetVar(name, value, -1, GVF_LOCAL_ONLY);
+ }
+ 
+-void
++int
+ unsetenv (const char *name)
+ {
++	save_original(name);
+ 	DeleteVar(name, GVF_LOCAL_ONLY);
++	return 0;
+ }
+ 
+-void
++int
+ putenv (char *str)
+ {
+ 	int i;
+ 
+ 	if (str[0] == '=')
+-	{
+-		return;
+-	}
++		return -1;
+ 
+-	for (i=0; str[i]; i++)
++	for (i = 0; str[i]; i++)
+ 	{
+ 		if (str[i] == '=')
+ 		{
+-			char *name = (char*)AllocVec(i + 1, MEMF_ANY);
++			char *name = (char *)AllocVec(i + 1, MEMF_ANY);
+ 			if (name)
+ 			{
+ 				strncpy(name, str, i);
+ 				name[i] = 0;
+-
+ 				setenv(name, &str[i] + 1, 1);
+ 				FreeVec(name);
+-				return;
++				return 0;
+ 			}
++			return -1;
+ 		}
+ 	}
++	return -1;
+ }
+ 
+ char *
+ getenv (const char *name)
+ {
+ 	struct LocalVar *lvar;
+ 
+ 	if (!(lvar = FindVar(name, GVF_LOCAL_ONLY)))
+-	{
+ 		return NULL;
+-	}
+ 	return lvar->lv_Value;
+ }
+-- 
+2.34.1
+

--- a/gcc/8/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/8/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,7 +1,7 @@
-From 6f3b0c228b2122d1f601ed71a53185476b0cc3bb Mon Sep 17 00:00:00 2001
+From db2850fd7d779601a5dd1d02b1c92ca7157c09ca Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Feb 2015 20:25:55 +0100
-Subject: [PATCH 01/30] Changes for AmigaOS version of gcc.
+Subject: [PATCH 01/31] Changes for AmigaOS version of gcc.
 
 ---
  fixincludes/configure                 |    1 +

--- a/gcc/8/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/8/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,7 +1,7 @@
-From c5f2a43b7ae028a95f5744d76583035fd0171cf1 Mon Sep 17 00:00:00 2001
+From de5f989872452102060cbbe249048ba9d86b74cc Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 14 Nov 2014 20:03:56 +0100
-Subject: [PATCH 02/30] Added new function attribute "lineartags" and pragma
+Subject: [PATCH 02/31] Added new function attribute "lineartags" and pragma
  "amigaos tagtype".
 
 Functions that have the lineartags attribute are assumed to be functions

--- a/gcc/8/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/8/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,7 +1,7 @@
-From d801914b78606622e63d6ed0aedff816f9d67622 Mon Sep 17 00:00:00 2001
+From 9b5ed9a829b995e67629a22bbf721c991a225495 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 9 Jul 2015 06:54:37 +0200
-Subject: [PATCH 03/30] Disable .machine directive generation.
+Subject: [PATCH 03/31] Disable .machine directive generation.
 
 It breaks manual args to the assembler with different flavor,
 e.g., -Wa,-m440. This is probably not the right fix.

--- a/gcc/8/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/8/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,7 +1,7 @@
-From 19c459b4d1347b83a56893212fbb6886102df2a5 Mon Sep 17 00:00:00 2001
+From 363c51fe33b6d32153da129136b74edafc3f58b4 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 20:56:33 +0100
-Subject: [PATCH 04/30] The default link mode is static for AmigaOS.
+Subject: [PATCH 04/31] The default link mode is static for AmigaOS.
 
 Changed the g++ driver to reflect this.
 ---

--- a/gcc/8/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/8/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,7 +1,7 @@
-From c28e3674877c0aede0c36e9288a0287d157df936 Mon Sep 17 00:00:00 2001
+From 1485e5491b7fa2eb1ff8e379fc33bb25b5b54143 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 21:39:42 +0100
-Subject: [PATCH 05/30] Disable the usage of /dev/urandom when compiling for
+Subject: [PATCH 05/31] Disable the usage of /dev/urandom when compiling for
  AmigaOS.
 
 ---

--- a/gcc/8/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/8/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,7 +1,7 @@
-From 38789b3a6ff9d8a04aa7a27e88bbe6e244c81d2f Mon Sep 17 00:00:00 2001
+From 773677dd4c6fe747401db66ce7a359944dddff6e Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 5 Dec 2015 13:17:26 +0100
-Subject: [PATCH 06/30] Expand arg zero on AmigaOS using the PROGDIR: assign.
+Subject: [PATCH 06/31] Expand arg zero on AmigaOS using the PROGDIR: assign.
 
 This should make sure that the proper relative paths are computed during
 process_command().

--- a/gcc/8/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/8/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,7 +1,7 @@
-From 6c50d0f39edd65987c4bfb486e54e0f9498e3a3f Mon Sep 17 00:00:00 2001
+From 4b76433223e43a6efc95d41bf7689179233e3d7a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 21 Jan 2016 20:46:59 +0100
-Subject: [PATCH 07/30] Some AmigaOS 4.x compability changes for posix thread
+Subject: [PATCH 07/31] Some AmigaOS 4.x compability changes for posix thread
  support.
 
 ---

--- a/gcc/8/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/8/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,7 +1,7 @@
-From 04b87b3ca37f1a9de987637f5b223c27c5aaa579 Mon Sep 17 00:00:00 2001
+From d3e46ded965e2a20784c4a5acbbb53fe6bae9bb9 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 22 Jan 2016 20:04:50 +0100
-Subject: [PATCH 08/30] Added libstc++ support for AmigaOS.
+Subject: [PATCH 08/31] Added libstc++ support for AmigaOS.
 
 ---
  .../os/{generic => amigaos}/ctype_base.h      |  2 +-

--- a/gcc/8/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/8/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,7 +1,7 @@
-From 6b2502ad3148594cbc85b03cbf3d85ce82c70af7 Mon Sep 17 00:00:00 2001
+From d69cb98b04e1526b278625a5a58a60d18f0a914e Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 3 Mar 2017 08:52:48 +0100
-Subject: [PATCH 09/30] Enable libatomic for ppc-amigaos.
+Subject: [PATCH 09/31] Enable libatomic for ppc-amigaos.
 
 It is not really finished yet.
 ---

--- a/gcc/8/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
+++ b/gcc/8/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
@@ -1,7 +1,7 @@
-From f362a8d33be22d7c5900e1f1638f9ab94af27f00 Mon Sep 17 00:00:00 2001
+From 25c32ea25461f894e1b5035328162c803b97144a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 23 May 2018 10:54:19 +0200
-Subject: [PATCH 10/30] Implement libat_lock_n() and libat_unlock_n().
+Subject: [PATCH 10/31] Implement libat_lock_n() and libat_unlock_n().
 
 ---
  libatomic/config/amigaos/lock.c | 58 ++++++++++++++++++++++++++-------

--- a/gcc/8/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/8/patches/0011-Pretend-C99-compatibility.patch
@@ -1,7 +1,7 @@
-From 1642447c593cb4cedf838c2ec9beb9ccc23ca4b1 Mon Sep 17 00:00:00 2001
+From e030f7ffdb8e0bfaff7a625eafcd4775ba8c1d66 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 4 Mar 2017 07:39:21 +0100
-Subject: [PATCH 11/30] Pretend C99 compatibility.
+Subject: [PATCH 11/31] Pretend C99 compatibility.
 
 At least newlib is not fully C99 compatible because it doesn't expose
 various C99 function if __STRICT_ANSI__ is declared. Also it misses

--- a/gcc/8/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/8/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,7 +1,7 @@
-From 19e51805acfc5d157291e6c06505f941468b71ab Mon Sep 17 00:00:00 2001
+From 8f433a28d273bd82db4c81c2cf9211d1caf2df14 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 3 Apr 2018 19:52:01 +0200
-Subject: [PATCH 12/30] Add amigaos-stdint.h for libatomic.
+Subject: [PATCH 12/31] Add amigaos-stdint.h for libatomic.
 
 ---
  gcc/config.gcc                                      | 2 +-

--- a/gcc/8/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/8/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,7 +1,7 @@
-From 769a4d2d12464d18e5ba73edf60192b93f9109fe Mon Sep 17 00:00:00 2001
+From e3c90c7755ff2f4e209bb06ad42b742e850dfb7d Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 22:48:33 +0200
-Subject: [PATCH 13/30] Rerun make maint-deps in libiberty.
+Subject: [PATCH 13/31] Rerun make maint-deps in libiberty.
 
 ---
  libiberty/Makefile.in | 36 ++++++++++++++++++++++--------------

--- a/gcc/8/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/8/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,7 +1,7 @@
-From e0055474bff8049f1174df7fc973ad76595020c1 Mon Sep 17 00:00:00 2001
+From 48ba0d1d44f925d88a75875dd364c2ba8499397e Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 23:50:48 +0200
-Subject: [PATCH 14/30] Add custom implementation of various env-related
+Subject: [PATCH 14/31] Add custom implementation of various env-related
  functions.
 
 No official clib does support unsetenv() but this is required by newer gcc.

--- a/gcc/8/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/8/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,7 +1,7 @@
-From db892f6d9841605af36b1dddbbe613249c877e84 Mon Sep 17 00:00:00 2001
+From 06e7fd4df8dbbca7bea63120c8807783a0552480 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 5 Apr 2018 19:56:45 +0200
-Subject: [PATCH 15/30] Define va_startlinear and va_getlinearva.
+Subject: [PATCH 15/31] Define va_startlinear and va_getlinearva.
 
 These were usually defined in the clibs' stdarg.h. As we have now
 changed the include path order, clibs' stdarg.h is never included.

--- a/gcc/8/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/8/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,7 +1,7 @@
-From e6011ca854253df1900ce2753f2545d5f1618be3 Mon Sep 17 00:00:00 2001
+From 579cc23289fecaefe3e330c44e908c5fc171bdca Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Apr 2018 22:02:09 +0200
-Subject: [PATCH 16/30] Fix r2 restoring in the epilog of baserel-restoring
+Subject: [PATCH 16/31] Fix r2 restoring in the epilog of baserel-restoring
  functions.
 
 ---

--- a/gcc/8/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/8/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,7 +1,7 @@
-From 37ef8f1a54b2e94e21b61a3aa0e8a5eb58d7d7e5 Mon Sep 17 00:00:00 2001
+From 1a8c186dc0517e10ec4a98d924a1109361c9a05a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 19 Apr 2018 21:00:30 +0200
-Subject: [PATCH 17/30] Avoid section anchors in the baserel mode.
+Subject: [PATCH 17/31] Avoid section anchors in the baserel mode.
 
 ---
  gcc/config/rs6000/amigaos-protos.h |  1 +

--- a/gcc/8/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/8/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,7 +1,7 @@
-From d5b814e021f21663e8c1cd8426e7e2cb3beb5758 Mon Sep 17 00:00:00 2001
+From 135c65af2875c06221b913f3764fe6d632bcfe2e Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 20 Apr 2018 20:04:30 +0200
-Subject: [PATCH 18/30] Respect -nostdinc also for SDK includes.
+Subject: [PATCH 18/31] Respect -nostdinc also for SDK includes.
 
 ---
  gcc/config/rs6000/amigaos.h | 4 +---

--- a/gcc/8/patches/0019-Add-_Static_warning.patch
+++ b/gcc/8/patches/0019-Add-_Static_warning.patch
@@ -1,7 +1,7 @@
-From 910c7fb66f34cdecda82a751bfd4dba22bd3a880 Mon Sep 17 00:00:00 2001
+From 2bc1fa6cebdae630c284cb1a213b9973df4a9be5 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 24 Apr 2018 22:46:21 +0200
-Subject: [PATCH 19/30] Add _Static_warning().
+Subject: [PATCH 19/31] Add _Static_warning().
 
 This acts very similar to _Static_assert() but produces a warning
 rather than an compiler error.

--- a/gcc/8/patches/0020-Add-tagtype-attribute-that-can-be-passed-to-enum-con.patch
+++ b/gcc/8/patches/0020-Add-tagtype-attribute-that-can-be-passed-to-enum-con.patch
@@ -1,7 +1,7 @@
-From ba0ed10ad3f956059ca727e838bc1644856a8fe1 Mon Sep 17 00:00:00 2001
+From c59e68321f7a82f223d4008910b3f00fd5f03ef5 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 24 Apr 2018 06:29:13 +0200
-Subject: [PATCH 20/30] Add tagtype attribute that can be passed to enum
+Subject: [PATCH 20/31] Add tagtype attribute that can be passed to enum
  constants.
 
 The tagtype attribute can be applied to enum constants in order to annotate

--- a/gcc/8/patches/0021-Rename-lineartags-to-checktags.patch
+++ b/gcc/8/patches/0021-Rename-lineartags-to-checktags.patch
@@ -1,7 +1,7 @@
-From a4c043211aec7a771350a521604b950a9a7deef7 Mon Sep 17 00:00:00 2001
+From fb8715fabd5e0139e722f39b42895385a397940c Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 27 Apr 2018 22:48:18 +0200
-Subject: [PATCH 21/30] Rename lineartags to checktags.
+Subject: [PATCH 21/31] Rename lineartags to checktags.
 
 The name lineartags would imply linearvarargs but this is not implemented
 or necessary.

--- a/gcc/8/patches/0022-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
+++ b/gcc/8/patches/0022-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
@@ -1,7 +1,7 @@
-From 11acd3eca6b03f6f64ab0386ec5d176f656a7bbc Mon Sep 17 00:00:00 2001
+From 5da07cfe2080a6072575d31ddb50db7ec75be0d7 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 28 Apr 2018 08:09:58 +0200
-Subject: [PATCH 22/30] Fix order of AmigaOS PPC sections in the documentation.
+Subject: [PATCH 22/31] Fix order of AmigaOS PPC sections in the documentation.
 
 ---
  gcc/doc/invoke.texi | 264 ++++++++++++++++++++++----------------------

--- a/gcc/8/patches/0023-Provide-a-documentation-for-checktags-and-tagtype-at.patch
+++ b/gcc/8/patches/0023-Provide-a-documentation-for-checktags-and-tagtype-at.patch
@@ -1,7 +1,7 @@
-From 75b58899e792be1e0be50f87ee79726017b9f53a Mon Sep 17 00:00:00 2001
+From 59ebad33e6523ced4652f2a436a9c2c1869b8e5e Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sun, 29 Apr 2018 00:08:22 +0200
-Subject: [PATCH 23/30] Provide a documentation for checktags and tagtype
+Subject: [PATCH 23/31] Provide a documentation for checktags and tagtype
  attributes.
 
 ---

--- a/gcc/8/patches/0024-Adapt-libssp-for-AmigaOS.patch
+++ b/gcc/8/patches/0024-Adapt-libssp-for-AmigaOS.patch
@@ -1,7 +1,7 @@
-From 71f5c7753432b362aaa76aacc64dddd9273929cc Mon Sep 17 00:00:00 2001
+From 339ee6d4ec4f8f24e61db0c9a3178703d668e008 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 22 May 2018 23:14:01 +0200
-Subject: [PATCH 24/30] Adapt libssp for AmigaOS.
+Subject: [PATCH 24/31] Adapt libssp for AmigaOS.
 
 ---
  libssp/ssp.c | 8 +++++---

--- a/gcc/8/patches/0025-Add-amigaos-thread-model.patch
+++ b/gcc/8/patches/0025-Add-amigaos-thread-model.patch
@@ -1,7 +1,7 @@
-From 3843dff1665663e20881f12dbab9f402a55591b9 Mon Sep 17 00:00:00 2001
+From a19d8ce3cb48e467e318ab9ba4efc6e32c57e1f3 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 4 May 2018 18:22:24 +0200
-Subject: [PATCH 25/30] Add amigaos thread model.
+Subject: [PATCH 25/31] Add amigaos thread model.
 
 It is work in progress.
 ---

--- a/gcc/8/patches/0026-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
+++ b/gcc/8/patches/0026-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
@@ -1,7 +1,7 @@
-From d76787f616ce352bcdda427ad5c2b7a27b7d3da0 Mon Sep 17 00:00:00 2001
+From 0ed5965ac9a68631271eddb5f6c08ecfeee7b55f Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 27 Oct 2018 08:06:21 +0200
-Subject: [PATCH 26/30] Add aregparam attribute for functions for the m68k
+Subject: [PATCH 26/31] Add aregparam attribute for functions for the m68k
  backend.
 
 These can be used to pass arguments to directly named registers.

--- a/gcc/8/patches/0027-Default-to-DWARF-v2.patch
+++ b/gcc/8/patches/0027-Default-to-DWARF-v2.patch
@@ -1,7 +1,7 @@
-From 986ab690792bea0447ddc69c70b5362c67921cf2 Mon Sep 17 00:00:00 2001
+From 2dd943273743a316666045ea9158e51ae54cb6db Mon Sep 17 00:00:00 2001
 From: Marcus Comstedt <marcus@mc.pp.se>
 Date: Wed, 31 Jul 2019 22:10:48 +0200
-Subject: [PATCH 27/30] Default to DWARF v2
+Subject: [PATCH 27/31] Default to DWARF v2
 
 ---
  gcc/config/rs6000/amigaos.h | 4 ++++

--- a/gcc/8/patches/0028-Provide-clib4-as-an-additional-C-runtime-library.patch
+++ b/gcc/8/patches/0028-Provide-clib4-as-an-additional-C-runtime-library.patch
@@ -1,7 +1,7 @@
-From db6c0a5d97a77c30a28a30a12e58c3b1bd340fbc Mon Sep 17 00:00:00 2001
+From 9f395e8dcede6fc6eab6ca376e46b5aefa08bbea Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Thu, 25 Jan 2024 20:40:13 +0000
-Subject: [PATCH 28/30] Provide clib4 as an additional C runtime library.
+Subject: [PATCH 28/31] Provide clib4 as an additional C runtime library.
 
 As well as the existing newlib and clib2 as C runtime library choices,
 clib4 is now introduced.

--- a/gcc/8/patches/0029-Allow-option-pthread-to-link-to-libpthread.patch
+++ b/gcc/8/patches/0029-Allow-option-pthread-to-link-to-libpthread.patch
@@ -1,7 +1,7 @@
-From 1aa95d994f4de69667e276c8557365eaeb957d04 Mon Sep 17 00:00:00 2001
+From ba39ae0e74d865df5db0b101fd776f33a123420c Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Wed, 15 May 2024 19:20:02 +0100
-Subject: [PATCH 29/30] Allow option -pthread to link to libpthread
+Subject: [PATCH 29/31] Allow option -pthread to link to libpthread
 
 ---
  gcc/config/rs6000/amigaos.h   | 2 +-

--- a/gcc/8/patches/0030-Add-strtold-to-the-std-namespace.patch
+++ b/gcc/8/patches/0030-Add-strtold-to-the-std-namespace.patch
@@ -1,7 +1,7 @@
-From bff689218183c28e2e3aed872b9ad4f67c35496e Mon Sep 17 00:00:00 2001
+From a3f05e7f7aff561df0761b95b694a67e996d034c Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Wed, 20 Nov 2024 19:52:39 +0000
-Subject: [PATCH 30/30] Add strtold to the std namespace.
+Subject: [PATCH 30/31] Add strtold to the std namespace.
 
 strtold is provided by both NEWLIB and CLIB4. Previously,
 std::strtold was not available for C++.
@@ -10,7 +10,7 @@ std::strtold was not available for C++.
  1 file changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/libstdc++-v3/include/c_global/cstdlib b/libstdc++-v3/include/c_global/cstdlib
-index 4975c6070fbf120a0061dab496918566ef7b1d70..bea07912ad29240d64b47a9060b3238ec14db2fe 100644
+index 4975c6070fbf120a0061dab496918566ef7b1d70..1c4262e1cc5c0a7941adb59cff622bdec213fcbf 100644
 --- a/libstdc++-v3/include/c_global/cstdlib
 +++ b/libstdc++-v3/include/c_global/cstdlib
 @@ -188,14 +188,14 @@ _GLIBCXX_END_NAMESPACE_VERSION
@@ -19,14 +19,14 @@ index 4975c6070fbf120a0061dab496918566ef7b1d70..bea07912ad29240d64b47a9060b3238e
  #undef strtoll
  #undef strtoull
  #undef strtof
-
+ 
 -/* clib2 and newlib do not provide an implementation of strtold */
 -#if !defined (__amigaos4__) || defined(__CLIB4__)
 +/* AmigaOS4: clib2 does not provide an implementation of strtold */
 +#ifndef __CLIB2__
  #undef strtold
  #endif
-
+ 
  namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
  {
  _GLIBCXX_BEGIN_NAMESPACE_VERSION
@@ -42,10 +42,10 @@ index 4975c6070fbf120a0061dab496918566ef7b1d70..bea07912ad29240d64b47a9060b3238e
 +#ifndef __CLIB2__
    using ::strtold;
  #endif
-
+ 
  _GLIBCXX_END_NAMESPACE_VERSION
  } // namespace __gnu_cxx
-
+ 
 @@ -252,13 +253,14 @@ namespace std
    using ::__gnu_cxx::lldiv;
  #endif
@@ -59,8 +59,9 @@ index 4975c6070fbf120a0061dab496918566ef7b1d70..bea07912ad29240d64b47a9060b3238e
    using ::__gnu_cxx::strtold;
  #endif
  } // namespace std
-
+ 
  #endif // _GLIBCXX_USE_C99_STDLIB
-
---
+ 
+-- 
 2.34.1
+

--- a/gcc/8/patches/0031-conditionally-use-setenv-amigaos-only-when-host-clib.patch
+++ b/gcc/8/patches/0031-conditionally-use-setenv-amigaos-only-when-host-clib.patch
@@ -1,0 +1,303 @@
+From 68dd015a3cc6ab3d8a9fdaa670df090564a973e3 Mon Sep 17 00:00:00 2001
+From: Georgios Sokianos <walkero@gmail.com>
+Date: Thu, 18 Jun 2026 21:54:00 +0000
+Subject: [PATCH 31/31] conditionally use setenv-amigaos only when host clib
+ lacks unsetenv, and add atexit cleanup to restore env vars on exit
+
+---
+ libiberty/configure        |  60 ++++++++++++++++++-
+ libiberty/configure.ac     |   7 ++-
+ libiberty/setenv-amigaos.c | 119 ++++++++++++++++++++++++++++++++-----
+ 3 files changed, 164 insertions(+), 22 deletions(-)
+
+diff --git a/libiberty/configure b/libiberty/configure
+index 8d7e7670ffd68fddb11c8e57aae2edf2a1c30f00..35d62cced7bef33941b3cbdc279d24ff187f1a39 100755
+--- a/libiberty/configure
++++ b/libiberty/configure
+@@ -6297,20 +6297,74 @@ if test -z "${setobjs}"; then
+     # On android, getpagesize is defined in unistd.h as a static inline
+     # function, which AC_CHECK_FUNCS does not handle properly.
+     ac_cv_func_getpagesize=yes
+     ;;
+ 
+   *-*-amigaos*)
+-    # current newlib lacks unsetenv(), so we custom versions
+-    # of setenv() and unsetenv().
+-    case " $LIBOBJS " in
++    # Use our setenv-amigaos fallback only when the host clib lacks unsetenv().
++    # Modern clib2, clib4, and newlib all provide it and handle shell environment
++    # cleanup correctly on exit, so prefer those over our implementation.
++    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for unsetenv" >&5
++$as_echo_n "checking for unsetenv... " >&6; }
++if ${ac_cv_func_unsetenv+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++/* Define unsetenv to an innocuous variant, in case <limits.h> declares unsetenv.
++   For example, HP-UX 11i <limits.h> declares gettimeofday.  */
++#define unsetenv innocuous_unsetenv
++
++/* System header to define __stub macros and hopefully few prototypes,
++    which can conflict with char unsetenv (); below.
++    Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
++    <limits.h> exists even on freestanding compilers.  */
++
++#ifdef __STDC__
++# include <limits.h>
++#else
++# include <assert.h>
++#endif
++
++#undef unsetenv
++
++/* Override any GCC internal prototype to avoid an error.
++   Use char because int might match the return type of a GCC
++   builtin and then its argument prototype would still apply.  */
++#ifdef __cplusplus
++extern "C"
++#endif
++char unsetenv ();
++int
++main ()
++{
++return unsetenv ();
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"; then :
++  ac_cv_func_unsetenv=yes
++else
++  ac_cv_func_unsetenv=no
++fi
++rm -f core conftest.err conftest.$ac_objext \
++    conftest$ac_exeext conftest.$ac_ext
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_unsetenv" >&5
++$as_echo "$ac_cv_func_unsetenv" >&6; }
++if test "x$ac_cv_func_unsetenv" = xyes; then :
++
++else
++  case " $LIBOBJS " in
+   *" setenv-amigaos.$ac_objext "* ) ;;
+   *) LIBOBJS="$LIBOBJS setenv-amigaos.$ac_objext"
+  ;;
+ esac
+ 
++fi
+     ;;
+ 
+   *-*-mingw32*)
+     # Under mingw32, sys_nerr and sys_errlist exist, but they are
+     # macros, so the test below won't find them.
+     libiberty_cv_var_sys_nerr=yes
+diff --git a/libiberty/configure.ac b/libiberty/configure.ac
+index bf659d099e9cdfa030ec2d90e7992d6840dc2809..e05543381fd56069f05e2a0e8c7a614c71c18770 100644
+--- a/libiberty/configure.ac
++++ b/libiberty/configure.ac
+@@ -606,15 +606,16 @@ if test -z "${setobjs}"; then
+     # On android, getpagesize is defined in unistd.h as a static inline
+     # function, which AC_CHECK_FUNCS does not handle properly.
+     ac_cv_func_getpagesize=yes
+     ;;
+ 
+   *-*-amigaos*)
+-    # current newlib lacks unsetenv(), so we custom versions
+-    # of setenv() and unsetenv().
+-    AC_LIBOBJ([setenv-amigaos])
++    # Use our setenv-amigaos fallback only when the host clib lacks unsetenv().
++    # Modern clib2, clib4, and newlib all provide it and handle shell environment
++    # cleanup correctly on exit, so prefer those over our implementation.
++    AC_CHECK_FUNC([unsetenv], [], [AC_LIBOBJ([setenv-amigaos])])
+     ;;
+ 
+   *-*-mingw32*)
+     # Under mingw32, sys_nerr and sys_errlist exist, but they are
+     # macros, so the test below won't find them.
+     libiberty_cv_var_sys_nerr=yes
+diff --git a/libiberty/setenv-amigaos.c b/libiberty/setenv-amigaos.c
+index 089d3cbcc6eb7d42d96e8dfb16d1b399cfe856b3..b9b464e7b8c1e1c1dbbbfcbdc22a7e1d070830d5 100644
+--- a/libiberty/setenv-amigaos.c
++++ b/libiberty/setenv-amigaos.c
+@@ -1,74 +1,161 @@
+ /* A custom implementation of various env functions
+  *
+- * This is necessary as no official clib supports unsetenv()
+- * but setenv().
++ * Used as a fallback when the host clib lacks unsetenv().  Modern clib2,
++ * clib4, and newlib all provide setenv()/unsetenv() with proper cleanup, so
++ * this file is only compiled when configure detects unsetenv() is absent.
++ *
++ * On the native AmigaOS shell, programs run within the same process as the
++ * shell, so SetVar(GVF_LOCAL_ONLY) changes persist after the program exits.
++ * An atexit handler therefore saves each variable's original state before
++ * the first modification and restores everything on process exit.
+  */
+ #define __USE_INLINE__
+ 
+ #include <proto/dos.h>
+ #include <proto/exec.h>
+ 
++#include <stdlib.h>
+ #include <string.h>
+ 
+-
+ #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+ 
++struct saved_var {
++	char *name;
++	char *value;   /* original value, or NULL if the variable did not exist */
++	LONG  len;     /* lv_Len of the original value (0 when value == NULL) */
++	struct saved_var *next;
++};
++
++static struct saved_var *saved_list = NULL;
++static int atexit_registered = 0;
++
++static void
++restore_vars_on_exit (void)
++{
++	struct saved_var *v = saved_list;
++	while (v)
++	{
++		struct saved_var *next = v->next;
++		if (v->value)
++		{
++			SetVar(v->name, v->value, v->len, GVF_LOCAL_ONLY);
++			FreeVec(v->value);
++		}
++		else
++		{
++			DeleteVar(v->name, GVF_LOCAL_ONLY);
++		}
++		FreeVec(v->name);
++		FreeVec(v);
++		v = next;
++	}
++	saved_list = NULL;
++}
++
++/* Record the current value of 'name' the first time we are about to change it. */
++static void
++save_original (const char *name)
++{
++	struct LocalVar *lvar;
++	struct saved_var *entry;
++	struct saved_var *v = saved_list;
++
++	while (v)
++	{
++		if (strcmp(v->name, name) == 0)
++			return;   /* already saved — keep only the oldest value */
++		v = v->next;
++	}
++
++	entry = (struct saved_var *)AllocVec(sizeof(struct saved_var), MEMF_CLEAR);
++	if (!entry)
++		return;
++
++	entry->name = (char *)AllocVec(strlen(name) + 1, MEMF_ANY);
++	if (!entry->name)
++	{
++		FreeVec(entry);
++		return;
++	}
++	strcpy(entry->name, name);
++
++	lvar = FindVar(name, GVF_LOCAL_ONLY);
++	if (lvar)
++	{
++		entry->len   = lvar->lv_Len;
++		entry->value = (char *)AllocVec(lvar->lv_Len + 1, MEMF_ANY);
++		if (entry->value)
++		{
++			memcpy(entry->value, lvar->lv_Value, lvar->lv_Len);
++			entry->value[lvar->lv_Len] = '\0';
++		}
++	}
++	/* else: entry->value stays NULL — variable did not exist before */
++
++	entry->next = saved_list;
++	saved_list  = entry;
++
++	if (!atexit_registered)
++	{
++		atexit(restore_vars_on_exit);
++		atexit_registered = 1;
++	}
++}
++
+ int
+ setenv (const char *name, const char *value, int replace)
+ {
+ 	if (!replace)
+ 	{
+ 		if (FindVar(name, GVF_LOCAL_ONLY))
+-		{
+ 			return 0;
+-		}
+ 	}
+ 
++	save_original(name);
+ 	return !SetVar(name, value, -1, GVF_LOCAL_ONLY);
+ }
+ 
+-void
++int
+ unsetenv (const char *name)
+ {
++	save_original(name);
+ 	DeleteVar(name, GVF_LOCAL_ONLY);
++	return 0;
+ }
+ 
+-void
++int
+ putenv (char *str)
+ {
+ 	int i;
+ 
+ 	if (str[0] == '=')
+-	{
+-		return;
+-	}
++		return -1;
+ 
+-	for (i=0; str[i]; i++)
++	for (i = 0; str[i]; i++)
+ 	{
+ 		if (str[i] == '=')
+ 		{
+-			char *name = (char*)AllocVec(i + 1, MEMF_ANY);
++			char *name = (char *)AllocVec(i + 1, MEMF_ANY);
+ 			if (name)
+ 			{
+ 				strncpy(name, str, i);
+ 				name[i] = 0;
+-
+ 				setenv(name, &str[i] + 1, 1);
+ 				FreeVec(name);
+-				return;
++				return 0;
+ 			}
++			return -1;
+ 		}
+ 	}
++	return -1;
+ }
+ 
+ char *
+ getenv (const char *name)
+ {
+ 	struct LocalVar *lvar;
+ 
+ 	if (!(lvar = FindVar(name, GVF_LOCAL_ONLY)))
+-	{
+ 		return NULL;
+-	}
+ 	return lvar->lv_Value;
+ }
+-- 
+2.34.1
+


### PR DESCRIPTION
conditionally use setenv-amigaos only when host clib lacks unsetenv, and add atexit cleanup to restore env vars on exit.
Fixes #30 , but requires testing. 

This PR is for feedback for now, until it is tested.